### PR TITLE
feat: add multi-language support for popup UI (i18n)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - **Copy to Clipboard**: Added a "Copy .md" button to the popup to copy generated markdown directly to your clipboard instead of downloading.
+- **Multi-Language UI**: Popup interface now available in 9 languages — English, Spanish, German, French, Japanese, Portuguese (Brazil), Chinese (Simplified), Arabic, and Persian. The UI automatically matches your browser's language. Content extraction works on any language regardless of UI translation.
 - **Dynamic Theming**: Added light and dark mode support to the popup UI, automatically respecting your system preferences.
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@
 - **YAML Frontmatter** — Rich metadata with author, handle, date, source URL, content type, and engagement stats (likes, reposts, replies, bookmarks, views)
 - **Copy or Download** — Copy Markdown to clipboard or download as a file
 - **Clean Output** — Automatically expand truncated posts and strip engagement buttons, follow prompts, and trackers
+- **Multi-Language UI** — Popup available in English, Spanish, German, French, Japanese, Portuguese (Brazil), Chinese (Simplified), Arabic, and Persian. Content extraction works on any language regardless of UI translation
 - **Light & Dark Mode** — Popup matches your system preferences
 
 ### Great For
@@ -111,6 +112,7 @@ tweet2md/
 │   ├── popup/          # Extension popup UI + trigger
 │   ├── types/          # Shared TypeScript interfaces
 │   ├── icons/          # Extension icons (16, 32, 48, 128px)
+│   ├── _locales/       # i18n translations (en, es, de, fr, ja, pt_BR, zh_CN, ar, fa)
 │   └── manifest.json   # Chrome MV3 manifest
 ├── dist/               # Build output (load this in Chrome)
 ├── build.mjs           # esbuild build script

--- a/build.mjs
+++ b/build.mjs
@@ -57,6 +57,14 @@ async function build() {
     cpSync(iconsDir, distIconsDir, { recursive: true });
   }
 
+  // Copy _locales for i18n
+  const localesDir = resolve(__dirname, 'src/_locales');
+  const distLocalesDir = resolve(__dirname, 'dist/_locales');
+  if (existsSync(localesDir)) {
+    mkdirSync(distLocalesDir, { recursive: true });
+    cpSync(localesDir, distLocalesDir, { recursive: true });
+  }
+
   console.log('✅ Build complete → dist/');
 }
 

--- a/src/_locales/ar/messages.json
+++ b/src/_locales/ar/messages.json
@@ -1,0 +1,74 @@
+{
+  "extensionName": {
+    "message": "tweet2md"
+  },
+  "extensionDescription": {
+    "message": "نسخ أو تنزيل مقالات وسلاسل وتغريدات X (Twitter) بتنسيق Markdown."
+  },
+  "tagline": {
+    "message": "تحويل السلاسل والمقالات إلى Markdown"
+  },
+  "btn_download": {
+    "message": "تنزيل .md"
+  },
+  "btn_copy": {
+    "message": "نسخ .md"
+  },
+  "extracting": {
+    "message": "جاري الاستخراج…"
+  },
+  "opt_save_images_title": {
+    "message": "تنزيل الصور إلى مجلد بجانب ملف Markdown"
+  },
+  "opt_save_images": {
+    "message": "حفظ الصور محليًا"
+  },
+  "opt_metadata_title": {
+    "message": "إضافة الإعجابات وإعادات النشر والمشاهدات كـ YAML frontmatter"
+  },
+  "opt_metadata": {
+    "message": "تضمين البيانات الوصفية"
+  },
+  "footer_hint": {
+    "message": "انتقل إلى تغريدة أو مقال على X.com أولاً"
+  },
+  "error_reload": {
+    "message": "أعد تحميل الصفحة وحاول مرة أخرى."
+  },
+  "error_specific_page": {
+    "message": "افتح صفحة محددة (تحتوي على /status/ في الرابط)."
+  },
+  "error_failed": {
+    "message": "فشل استخراج المحتوى."
+  },
+  "error_unexpected": {
+    "message": "حدث خطأ غير متوقع."
+  },
+  "download_failed": {
+    "message": "فشل التنزيل."
+  },
+  "article_downloaded": {
+    "message": "تم تنزيل المقال!"
+  },
+  "thread_downloaded": {
+    "message": "تم تنزيل السلسلة!"
+  },
+  "tweet_downloaded": {
+    "message": "تم تنزيل التغريدة!"
+  },
+  "downloaded": {
+    "message": "تم التنزيل!"
+  },
+  "article_copied": {
+    "message": "تم نسخ المقال!"
+  },
+  "thread_copied": {
+    "message": "تم نسخ السلسلة!"
+  },
+  "tweet_copied": {
+    "message": "تم نسخ التغريدة!"
+  },
+  "copied": {
+    "message": "تم النسخ!"
+  }
+}

--- a/src/_locales/de/messages.json
+++ b/src/_locales/de/messages.json
@@ -1,0 +1,74 @@
+{
+  "extensionName": {
+    "message": "tweet2md"
+  },
+  "extensionDescription": {
+    "message": "X (Twitter) Artikel, Threads und Tweets als Markdown kopieren oder herunterladen."
+  },
+  "tagline": {
+    "message": "Threads und Artikel in Markdown konvertieren"
+  },
+  "btn_download": {
+    "message": ".md herunterladen"
+  },
+  "btn_copy": {
+    "message": ".md kopieren"
+  },
+  "extracting": {
+    "message": "Wird extrahiert…"
+  },
+  "opt_save_images_title": {
+    "message": "Bilder in einem Ordner neben der Markdown-Datei speichern"
+  },
+  "opt_save_images": {
+    "message": "Bilder lokal speichern"
+  },
+  "opt_metadata_title": {
+    "message": "Likes, Reposts, Aufrufe als YAML-Frontmatter hinzufügen"
+  },
+  "opt_metadata": {
+    "message": "Metadaten einschließen"
+  },
+  "footer_hint": {
+    "message": "Navigiere zuerst zu einem Tweet oder Artikel auf X.com"
+  },
+  "error_reload": {
+    "message": "Lade die Seite neu und versuche es erneut."
+  },
+  "error_specific_page": {
+    "message": "Öffne eine bestimmte Seite (mit /status/ in der URL)."
+  },
+  "error_failed": {
+    "message": "Inhalt konnte nicht extrahiert werden."
+  },
+  "error_unexpected": {
+    "message": "Ein unerwarteter Fehler ist aufgetreten."
+  },
+  "download_failed": {
+    "message": "Fehler beim Herunterladen."
+  },
+  "article_downloaded": {
+    "message": "Artikel heruntergeladen!"
+  },
+  "thread_downloaded": {
+    "message": "Thread heruntergeladen!"
+  },
+  "tweet_downloaded": {
+    "message": "Tweet heruntergeladen!"
+  },
+  "downloaded": {
+    "message": "Heruntergeladen!"
+  },
+  "article_copied": {
+    "message": "Artikel kopiert!"
+  },
+  "thread_copied": {
+    "message": "Thread kopiert!"
+  },
+  "tweet_copied": {
+    "message": "Tweet kopiert!"
+  },
+  "copied": {
+    "message": "Kopiert!"
+  }
+}

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -1,0 +1,74 @@
+{
+  "extensionName": {
+    "message": "tweet2md"
+  },
+  "extensionDescription": {
+    "message": "Copy or Download X (Twitter) Articles, threads, and tweets as Markdown."
+  },
+  "tagline": {
+    "message": "Convert threads & articles to Markdown"
+  },
+  "btn_download": {
+    "message": "Download .md"
+  },
+  "btn_copy": {
+    "message": "Copy .md"
+  },
+  "extracting": {
+    "message": "Extracting…"
+  },
+  "opt_save_images_title": {
+    "message": "Download images to a folder next to the Markdown file"
+  },
+  "opt_save_images": {
+    "message": "Save images locally"
+  },
+  "opt_metadata_title": {
+    "message": "Add likes, reposts, views as YAML frontmatter"
+  },
+  "opt_metadata": {
+    "message": "Include metadata"
+  },
+  "footer_hint": {
+    "message": "Navigate to a tweet or article on X.com first"
+  },
+  "error_reload": {
+    "message": "Reload the page and try again."
+  },
+  "error_specific_page": {
+    "message": "Open a specific tweet or article page (with /status/ in the URL)."
+  },
+  "error_failed": {
+    "message": "Failed to extract content."
+  },
+  "error_unexpected": {
+    "message": "An unexpected error occurred."
+  },
+  "download_failed": {
+    "message": "Download failed."
+  },
+  "article_downloaded": {
+    "message": "Article downloaded!"
+  },
+  "thread_downloaded": {
+    "message": "Thread downloaded!"
+  },
+  "tweet_downloaded": {
+    "message": "Tweet downloaded!"
+  },
+  "downloaded": {
+    "message": "Downloaded!"
+  },
+  "article_copied": {
+    "message": "Article copied!"
+  },
+  "thread_copied": {
+    "message": "Thread copied!"
+  },
+  "tweet_copied": {
+    "message": "Tweet copied!"
+  },
+  "copied": {
+    "message": "Copied!"
+  }
+}

--- a/src/_locales/es/messages.json
+++ b/src/_locales/es/messages.json
@@ -1,0 +1,74 @@
+{
+  "extensionName": {
+    "message": "tweet2md"
+  },
+  "extensionDescription": {
+    "message": "Copia o descarga artículos, hilos y tuits de X (Twitter) como Markdown."
+  },
+  "tagline": {
+    "message": "Convierte hilos y artículos a Markdown"
+  },
+  "btn_download": {
+    "message": "Descargar .md"
+  },
+  "btn_copy": {
+    "message": "Copiar .md"
+  },
+  "extracting": {
+    "message": "Extrayendo…"
+  },
+  "opt_save_images_title": {
+    "message": "Descarga las imágenes en una carpeta junto al archivo Markdown"
+  },
+  "opt_save_images": {
+    "message": "Guardar imágenes localmente"
+  },
+  "opt_metadata_title": {
+    "message": "Añade me gusta, reposts y vistas como frontmatter YAML"
+  },
+  "opt_metadata": {
+    "message": "Incluir metadatos"
+  },
+  "footer_hint": {
+    "message": "Navega primero a un tweet o artículo en X.com"
+  },
+  "error_reload": {
+    "message": "Recarga la página y vuelve a intentarlo."
+  },
+  "error_specific_page": {
+    "message": "Abre una página específica (con /status/ en la URL)."
+  },
+  "error_failed": {
+    "message": "Error al extraer el contenido."
+  },
+  "error_unexpected": {
+    "message": "Ocurrió un error inesperado."
+  },
+  "download_failed": {
+    "message": "Error en la descarga."
+  },
+  "article_downloaded": {
+    "message": "¡Artículo descargado!"
+  },
+  "thread_downloaded": {
+    "message": "¡Hilo descargado!"
+  },
+  "tweet_downloaded": {
+    "message": "¡Tweet descargado!"
+  },
+  "downloaded": {
+    "message": "¡Descargado!"
+  },
+  "article_copied": {
+    "message": "¡Artículo copiado!"
+  },
+  "thread_copied": {
+    "message": "¡Hilo copiado!"
+  },
+  "tweet_copied": {
+    "message": "¡Tweet copiado!"
+  },
+  "copied": {
+    "message": "¡Copiado!"
+  }
+}

--- a/src/_locales/fa/messages.json
+++ b/src/_locales/fa/messages.json
@@ -1,0 +1,74 @@
+{
+  "extensionName": {
+    "message": "tweet2md"
+  },
+  "extensionDescription": {
+    "message": "کپی یا دانلود مقالات، رشته‌ها و توییت‌های X (Twitter) به صورت Markdown."
+  },
+  "tagline": {
+    "message": "تبدیل رشته‌ها و مقالات به Markdown"
+  },
+  "btn_download": {
+    "message": "دانلود .md"
+  },
+  "btn_copy": {
+    "message": "کپی .md"
+  },
+  "extracting": {
+    "message": "در حال استخراج…"
+  },
+  "opt_save_images_title": {
+    "message": "دانلود تصاویر در پوشه‌ای در کنار فایل Markdown"
+  },
+  "opt_save_images": {
+    "message": "ذخیره محلی تصاویر"
+  },
+  "opt_metadata_title": {
+    "message": "افزودن متادیتا به عنوان YAML frontmatter"
+  },
+  "opt_metadata": {
+    "message": "شامل متادیتا"
+  },
+  "footer_hint": {
+    "message": "ابتدا به یک توییت در X.com بروید"
+  },
+  "error_reload": {
+    "message": "صفحه را دوباره بارگذاری کنید و دوباره امتحان کنید."
+  },
+  "error_specific_page": {
+    "message": "یک صفحه خاص (با /status/ در URL) را باز کنید."
+  },
+  "error_failed": {
+    "message": "استخراج محتوا با شکست مواجه شد."
+  },
+  "error_unexpected": {
+    "message": "یک خطای غیرمنتظره رخ داد."
+  },
+  "download_failed": {
+    "message": "دانلود ناموفق بود."
+  },
+  "article_downloaded": {
+    "message": "مقاله دانلود شد!"
+  },
+  "thread_downloaded": {
+    "message": "رشته دانلود شد!"
+  },
+  "tweet_downloaded": {
+    "message": "توییت دانلود شد!"
+  },
+  "downloaded": {
+    "message": "دانلود شد!"
+  },
+  "article_copied": {
+    "message": "مقاله کپی شد!"
+  },
+  "thread_copied": {
+    "message": "رشته کپی شد!"
+  },
+  "tweet_copied": {
+    "message": "توییت کپی شد!"
+  },
+  "copied": {
+    "message": "کپی شد!"
+  }
+}

--- a/src/_locales/fr/messages.json
+++ b/src/_locales/fr/messages.json
@@ -1,0 +1,74 @@
+{
+  "extensionName": {
+    "message": "tweet2md"
+  },
+  "extensionDescription": {
+    "message": "Copiez ou téléchargez des articles, fils de discussion et tweets X (Twitter) en Markdown."
+  },
+  "tagline": {
+    "message": "Convertir les fils et articles en Markdown"
+  },
+  "btn_download": {
+    "message": "Télécharger .md"
+  },
+  "btn_copy": {
+    "message": "Copier .md"
+  },
+  "extracting": {
+    "message": "Extraction…"
+  },
+  "opt_save_images_title": {
+    "message": "Télécharger les images dans un dossier à côté du fichier Markdown"
+  },
+  "opt_save_images": {
+    "message": "Enregistrer les images localement"
+  },
+  "opt_metadata_title": {
+    "message": "Ajouter les j'aime, reposts, vues en tant que YAML frontmatter"
+  },
+  "opt_metadata": {
+    "message": "Inclure les métadonnées"
+  },
+  "footer_hint": {
+    "message": "Accédez d'abord à un tweet ou un article sur X.com"
+  },
+  "error_reload": {
+    "message": "Rechargez la page et réessayez."
+  },
+  "error_specific_page": {
+    "message": "Ouvrez une page spécifique (avec /status/ dans l'URL)."
+  },
+  "error_failed": {
+    "message": "Échec de l'extraction du contenu."
+  },
+  "error_unexpected": {
+    "message": "Une erreur inattendue s'est produite."
+  },
+  "download_failed": {
+    "message": "Échec du téléchargement."
+  },
+  "article_downloaded": {
+    "message": "Article téléchargé !"
+  },
+  "thread_downloaded": {
+    "message": "Fil téléchargé !"
+  },
+  "tweet_downloaded": {
+    "message": "Tweet téléchargé !"
+  },
+  "downloaded": {
+    "message": "Téléchargé !"
+  },
+  "article_copied": {
+    "message": "Article copié !"
+  },
+  "thread_copied": {
+    "message": "Fil copié !"
+  },
+  "tweet_copied": {
+    "message": "Tweet copié !"
+  },
+  "copied": {
+    "message": "Copié !"
+  }
+}

--- a/src/_locales/ja/messages.json
+++ b/src/_locales/ja/messages.json
@@ -1,0 +1,74 @@
+{
+  "extensionName": {
+    "message": "tweet2md"
+  },
+  "extensionDescription": {
+    "message": "X (Twitter) の記事、スレッド、ツイートを Markdown としてコピーまたはダウンロード。"
+  },
+  "tagline": {
+    "message": "スレッドや記事をMarkdownに変換"
+  },
+  "btn_download": {
+    "message": ".mdをダウンロード"
+  },
+  "btn_copy": {
+    "message": ".mdをコピー"
+  },
+  "extracting": {
+    "message": "抽出中…"
+  },
+  "opt_save_images_title": {
+    "message": "Markdownファイルと同じフォルダに画像をダウンロードする"
+  },
+  "opt_save_images": {
+    "message": "画像をローカルに保存"
+  },
+  "opt_metadata_title": {
+    "message": "いいね、リポスト、閲覧数をYAMLフロントマターとして追加"
+  },
+  "opt_metadata": {
+    "message": "メタデータを含める"
+  },
+  "footer_hint": {
+    "message": "まずX.comのツイートまたは記事に移動してください"
+  },
+  "error_reload": {
+    "message": "ページを再読み込みして、やり直してください。"
+  },
+  "error_specific_page": {
+    "message": "特定のページ（URLに/status/を含む）を開いてください。"
+  },
+  "error_failed": {
+    "message": "コンテンツの抽出に失敗しました。"
+  },
+  "error_unexpected": {
+    "message": "予期しないエラーが発生しました。"
+  },
+  "download_failed": {
+    "message": "ダウンロードに失敗しました。"
+  },
+  "article_downloaded": {
+    "message": "記事をダウンロードしました！"
+  },
+  "thread_downloaded": {
+    "message": "スレッドをダウンロードしました！"
+  },
+  "tweet_downloaded": {
+    "message": "ツイートをダウンロードしました！"
+  },
+  "downloaded": {
+    "message": "ダウンロード完了！"
+  },
+  "article_copied": {
+    "message": "記事をコピーしました！"
+  },
+  "thread_copied": {
+    "message": "スレッドをコピーしました！"
+  },
+  "tweet_copied": {
+    "message": "ツイートをコピーしました！"
+  },
+  "copied": {
+    "message": "コピー完了！"
+  }
+}

--- a/src/_locales/pt_BR/messages.json
+++ b/src/_locales/pt_BR/messages.json
@@ -1,0 +1,74 @@
+{
+  "extensionName": {
+    "message": "tweet2md"
+  },
+  "extensionDescription": {
+    "message": "Copie ou baixe artigos, threads e tweets do X (Twitter) como Markdown."
+  },
+  "tagline": {
+    "message": "Converta threads e artigos para Markdown"
+  },
+  "btn_download": {
+    "message": "Baixar arquivo .md"
+  },
+  "btn_copy": {
+    "message": "Copiar .md"
+  },
+  "extracting": {
+    "message": "Extraindo…"
+  },
+  "opt_save_images_title": {
+    "message": "Baixar imagens para uma pasta ao lado do arquivo Markdown"
+  },
+  "opt_save_images": {
+    "message": "Salvar imagens localmente"
+  },
+  "opt_metadata_title": {
+    "message": "Adicionar curtidas, reposts, visualizações como YAML frontmatter"
+  },
+  "opt_metadata": {
+    "message": "Incluir metadados"
+  },
+  "footer_hint": {
+    "message": "Navegue primeiro para um tweet ou artigo no X.com"
+  },
+  "error_reload": {
+    "message": "Recarregue a página e tente novamente."
+  },
+  "error_specific_page": {
+    "message": "Abra uma página específica (com /status/ na URL)."
+  },
+  "error_failed": {
+    "message": "Falha ao extrair o conteúdo."
+  },
+  "error_unexpected": {
+    "message": "Ocorreu um erro inesperado."
+  },
+  "download_failed": {
+    "message": "Falha no download."
+  },
+  "article_downloaded": {
+    "message": "Artigo baixado!"
+  },
+  "thread_downloaded": {
+    "message": "Thread baixada!"
+  },
+  "tweet_downloaded": {
+    "message": "Tweet baixado!"
+  },
+  "downloaded": {
+    "message": "Baixado!"
+  },
+  "article_copied": {
+    "message": "Artigo copiado!"
+  },
+  "thread_copied": {
+    "message": "Thread copiada!"
+  },
+  "tweet_copied": {
+    "message": "Tweet copiado!"
+  },
+  "copied": {
+    "message": "Copiado!"
+  }
+}

--- a/src/_locales/zh_CN/messages.json
+++ b/src/_locales/zh_CN/messages.json
@@ -1,0 +1,74 @@
+{
+  "extensionName": {
+    "message": "tweet2md"
+  },
+  "extensionDescription": {
+    "message": "作为 Markdown 复制或下载 X (Twitter) 上的文章、贴文和推文。"
+  },
+  "tagline": {
+    "message": "将推文和文章转换为 Markdown"
+  },
+  "btn_download": {
+    "message": "下载 .md"
+  },
+  "btn_copy": {
+    "message": "复制 .md"
+  },
+  "extracting": {
+    "message": "提取中…"
+  },
+  "opt_save_images_title": {
+    "message": "将图片下载到 Markdown 文件旁的文件夹中"
+  },
+  "opt_save_images": {
+    "message": "将图片保存到本地"
+  },
+  "opt_metadata_title": {
+    "message": "将点赞、转发、浏览量作为 YAML frontmatter 添加"
+  },
+  "opt_metadata": {
+    "message": "包含元数据"
+  },
+  "footer_hint": {
+    "message": "请先导航到 X.com 上的推文或文章页面"
+  },
+  "error_reload": {
+    "message": "请重新加载页面然后再试。"
+  },
+  "error_specific_page": {
+    "message": "请打开特定的页面（URL中包含 /status/）。"
+  },
+  "error_failed": {
+    "message": "提取内容失败。"
+  },
+  "error_unexpected": {
+    "message": "发生了意外错误。"
+  },
+  "download_failed": {
+    "message": "下载失败。"
+  },
+  "article_downloaded": {
+    "message": "文章已下载！"
+  },
+  "thread_downloaded": {
+    "message": "线程已下载！"
+  },
+  "tweet_downloaded": {
+    "message": "推文已下载！"
+  },
+  "downloaded": {
+    "message": "已下载！"
+  },
+  "article_copied": {
+    "message": "文章已复制！"
+  },
+  "thread_copied": {
+    "message": "线程已复制！"
+  },
+  "tweet_copied": {
+    "message": "推文已复制！"
+  },
+  "copied": {
+    "message": "已复制！"
+  }
+}

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,8 @@
   "manifest_version": 3,
   "name": "tweet2md",
   "version": "1.2.0",
-  "description": "Copy or Download X (Twitter) Articles, threads, and tweets as Markdown.",
+  "description": "__MSG_extensionDescription__",
+  "default_locale": "en",
   "permissions": ["activeTab", "downloads", "storage"],
   "action": {
     "default_popup": "popup.html",

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -15,7 +15,7 @@
         <img src="icons/icon-48.png" alt="tweet2md" class="logo-icon" />
         <h1 class="logo-text">tweet<span class="accent">2md</span></h1>
       </div>
-      <p class="tagline">Convert threads &amp; articles to Markdown</p>
+      <p class="tagline" data-i18n="tagline">Convert threads &amp; articles to Markdown</p>
     </header>
 
     <main class="popup-main">
@@ -27,7 +27,7 @@
             <polyline points="7 10 12 15 17 10" />
             <line x1="12" y1="15" x2="12" y2="3" />
           </svg>
-          <span class="btn-label">Download .md</span>
+          <span class="btn-label" data-i18n="btn_download">Download .md</span>
         </button>
         <button id="btn-copy" class="btn-secondary btn-action" type="button">
           <svg class="btn-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
@@ -35,12 +35,12 @@
             <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
             <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
           </svg>
-          <span class="btn-label">Copy .md</span>
+          <span class="btn-label" data-i18n="btn_copy">Copy .md</span>
         </button>
       </div>
 
       <div class="options">
-        <label class="toggle-label" title="Download images to a folder next to the markdown file">
+        <label class="toggle-label" title="Download images to a folder next to the markdown file" data-i18n-title="opt_save_images_title">
           <span class="toggle-text">
             <svg class="toggle-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
               stroke-linecap="round" stroke-linejoin="round">
@@ -48,18 +48,18 @@
               <circle cx="8.5" cy="8.5" r="1.5" />
               <polyline points="21 15 16 10 5 21" />
             </svg>
-            Save images locally
+            <span data-i18n="opt_save_images">Save images locally</span>
           </span>
           <input type="checkbox" id="chk-download-images" class="toggle-input" />
           <span class="toggle-switch"></span>
         </label>
-        <label class="toggle-label" title="Add likes, reposts, views as YAML frontmatter">
+        <label class="toggle-label" title="Add likes, reposts, views as YAML frontmatter" data-i18n-title="opt_metadata_title">
           <span class="toggle-text">
             <svg class="toggle-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
               stroke-linecap="round" stroke-linejoin="round">
               <polyline points="22 12 18 12 15 21 9 3 6 12 2 12" />
             </svg>
-            Include metadata
+            <span data-i18n="opt_metadata">Include metadata</span>
           </span>
           <input type="checkbox" id="chk-include-metadata" class="toggle-input" />
           <span class="toggle-switch"></span>
@@ -70,7 +70,7 @@
     </main>
 
     <footer class="popup-footer">
-      <span class="hint">Navigate to a tweet or article on X.com first</span>
+      <span class="hint" data-i18n="footer_hint">Navigate to a tweet or article on X.com first</span>
     </footer>
   </div>
 

--- a/src/popup/popup.ts
+++ b/src/popup/popup.ts
@@ -10,6 +10,21 @@ const chkMetadata = document.getElementById(
   'chk-include-metadata'
 ) as HTMLInputElement;
 
+// ─── Initialize i18n ──────────────────────────────────────────────────
+
+document.querySelectorAll('[data-i18n]').forEach((el) => {
+  const key = el.getAttribute('data-i18n');
+  if (key) {
+    el.textContent = chrome.i18n.getMessage(key) || el.textContent;
+  }
+});
+document.querySelectorAll('[data-i18n-title]').forEach((el) => {
+  const key = el.getAttribute('data-i18n-title');
+  if (key) {
+    el.setAttribute('title', chrome.i18n.getMessage(key) || el.getAttribute('title')!);
+  }
+});
+
 // ─── Settings Persistence ───────────────────────────────────────────
 
 const SETTINGS_KEY = 'tweet2md_settings';
@@ -82,12 +97,12 @@ function setLoading(loading: boolean, target?: 'download' | 'copy'): void {
   if (target === 'download' || !target) {
     btnDownload.classList.toggle('loading', loading);
     const dlLabel = btnDownload.querySelector('.btn-label');
-    if (dlLabel) dlLabel.textContent = loading ? 'Extracting…' : 'Download .md';
+    if (dlLabel) dlLabel.textContent = loading ? (chrome.i18n.getMessage('extracting') || 'Extracting…') : (chrome.i18n.getMessage('btn_download') || 'Download .md');
   }
   if (target === 'copy' || !target) {
     btnCopy.classList.toggle('loading', loading);
     const cpLabel = btnCopy.querySelector('.btn-label');
-    if (cpLabel) cpLabel.textContent = loading ? 'Extracting…' : 'Copy .md';
+    if (cpLabel) cpLabel.textContent = loading ? (chrome.i18n.getMessage('extracting') || 'Extracting…') : (chrome.i18n.getMessage('btn_copy') || 'Copy .md');
   }
 
   // When stopping, always reset both to default state
@@ -96,8 +111,8 @@ function setLoading(loading: boolean, target?: 'download' | 'copy'): void {
     btnCopy.classList.remove('loading');
     const dlLabel = btnDownload.querySelector('.btn-label');
     const cpLabel = btnCopy.querySelector('.btn-label');
-    if (dlLabel) dlLabel.textContent = 'Download .md';
-    if (cpLabel) cpLabel.textContent = 'Copy .md';
+    if (dlLabel) dlLabel.textContent = chrome.i18n.getMessage('btn_download') || 'Download .md';
+    if (cpLabel) cpLabel.textContent = chrome.i18n.getMessage('btn_copy') || 'Copy .md';
   }
 }
 
@@ -147,12 +162,12 @@ async function extractMarkdown(): Promise<ExtractionResult> {
 
   const url = tab.url || '';
   if (!url.includes('x.com/')) {
-    throw new Error('Navigate to a tweet or article on X.com first.');
+    throw new Error(chrome.i18n.getMessage('footer_hint') || 'Navigate to a tweet or article on X.com first.');
   }
 
   if (!url.includes('/status/')) {
     throw new Error(
-      'Open a specific tweet or article page (with /status/ in the URL).'
+      chrome.i18n.getMessage('error_specific_page') || 'Open a specific tweet or article page (with /status/ in the URL).'
     );
   }
 
@@ -165,7 +180,7 @@ async function extractMarkdown(): Promise<ExtractionResult> {
   });
 
   if (!response.success || !response.data) {
-    throw new Error(response.error || 'Failed to extract content.');
+    throw new Error(response.error || chrome.i18n.getMessage('error_failed') || 'Failed to extract content.');
   }
 
   const baseFilename = buildFilename(response.data);
@@ -238,10 +253,10 @@ async function extractMarkdown(): Promise<ExtractionResult> {
 
 function handleExtractionError(err: unknown): void {
   const message =
-    err instanceof Error ? err.message : 'An unexpected error occurred.';
+    err instanceof Error ? err.message : (chrome.i18n.getMessage('error_unexpected') || 'An unexpected error occurred.');
 
   if (message.includes('Receiving end does not exist')) {
-    showStatus('Reload the page and try again.', 'error');
+    showStatus(chrome.i18n.getMessage('error_reload') || 'Reload the page and try again.', 'error');
   } else {
     showStatus(message, 'error');
   }
@@ -266,14 +281,14 @@ btnDownload.addEventListener('click', async () => {
 
     chrome.runtime.sendMessage(downloadMsg, (downloadResponse) => {
       if (chrome.runtime.lastError || !downloadResponse?.success) {
-        showStatus(downloadResponse?.error || 'Download failed.', 'error');
+        showStatus(downloadResponse?.error || chrome.i18n.getMessage('download_failed') || 'Download failed.', 'error');
       } else {
         const typeLabels: Record<string, string> = {
-          article: 'Article downloaded!',
-          thread: 'Thread downloaded!',
-          tweet: 'Tweet downloaded!',
+          article: chrome.i18n.getMessage('article_downloaded') || 'Article downloaded!',
+          thread: chrome.i18n.getMessage('thread_downloaded') || 'Thread downloaded!',
+          tweet: chrome.i18n.getMessage('tweet_downloaded') || 'Tweet downloaded!',
         };
-        const label = typeLabels[result.type] || 'Downloaded!';
+        const label = typeLabels[result.type] || chrome.i18n.getMessage('downloaded') || 'Downloaded!';
         showStatus(`✓ ${label}`, 'success');
       }
       setLoading(false);
@@ -295,11 +310,11 @@ btnCopy.addEventListener('click', async () => {
     await navigator.clipboard.writeText(result.markdown);
 
     const typeLabels: Record<string, string> = {
-      article: 'Article copied!',
-      thread: 'Thread copied!',
-      tweet: 'Tweet copied!',
+      article: chrome.i18n.getMessage('article_copied') || 'Article copied!',
+      thread: chrome.i18n.getMessage('thread_copied') || 'Thread copied!',
+      tweet: chrome.i18n.getMessage('tweet_copied') || 'Tweet copied!',
     };
-    const label = typeLabels[result.type] || 'Copied!';
+    const label = typeLabels[result.type] || chrome.i18n.getMessage('copied') || 'Copied!';
     showStatus(`✓ ${label}`, 'success');
     setLoading(false);
   } catch (err) {


### PR DESCRIPTION
- **Full UI Internationalization:** Transitioned the extension popup UI from hardcoded strings to dynamically loaded translations using Chrome's native i18n APIs.
- **Newly Supported Languages:** Added fully localized `messages.json` files for 9 languages: English, Spanish, German, French, Japanese, Portuguese (Brazil), Chinese (Simplified), Arabic, and Persian.
- **Build System Integration:** Updated the esbuild pipeline (`build.mjs`) to ensure the `_locales` directory and its contents are seamlessly bundled into the distribution directory.
- **Documentation Refreshed:** Updated `README.md` to display the new folder structure and supported languages, and added the feature notes to the `CHANGELOG.md`.