### PR TITLE
Harden background download handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [1.4.0] - 2026-05-??
+## [1.4.0] - 2026-05-11
 
 ### Added
 
@@ -11,6 +11,12 @@ All notable changes to this project will be documented in this file.
 - **Show Inline Button toggle**: A new popup toggle lets you hide the inline download icon on tweets if it conflicts visually with another extension. Off-state hides existing buttons live, no page reload needed.
 - **Show Engagement Stats Inline toggle**: Optional X-style stats row in the exported Markdown (e.g. `💬 284 · 🔁 1.5K · ❤️ 8K · 🔖 253 · 👁 100K`), independent of YAML frontmatter so you can have either or both.
 - **Grouped Settings**: Popup options are organized into *Export* and *Inline button & context menu* sections so 6 toggles stay scannable.
+
+### Security
+
+- Background download handling now validates the message sender before invoking privileged download APIs — requests are only honored from x.com content scripts or trusted extension pages.
+- Local image downloads are restricted to expected X media hosts (`pbs.twimg.com`, `video.twimg.com`, `abs.twimg.com`, `abs-0.twimg.com`); other external image URLs are left as remote Markdown links rather than downloaded.
+- Strengthened filename / path sanitization to drop `..` segments and absolute paths and to normalize unicode before passing to Chrome's download API.
 
 ### Changed
 
@@ -23,6 +29,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - **Iran Flag (and other glyph) Renders As Full Image**: SVG glyphs served from `abs.twimg.com/responsive-web/client-web/...` weren't recognized as emoji and were being rendered as full-size images in the Markdown. All `.svg` images on X are now treated as glyphs and resolve to their alt-text character.
+- **Tests on Fresh Checkouts**: The test suite now runs cleanly even when no local HTML/MD fixtures have been captured yet, so contributors can clone and `npm test` without setup.
 
 ## [1.3.0] - 2026-05-09
 

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -13,7 +13,7 @@ tweet2md accesses the visible content of supported X.com status pages only after
 ## Data collection
 
 - **No personal data is collected.**
-- The extension accesses website content (text and images on supported X.com/Twitter.com pages) solely to convert it into Markdown and image files at your request.
+- The extension accesses website content (text and images on supported X.com pages) solely to convert it into Markdown and image files at your request.
 - **No browsing history is tracked.**
 - **No analytics or telemetry is sent.**
 - **No data is transmitted to any external server.**
@@ -30,21 +30,25 @@ All data processing happens **entirely within your browser**:
 
 No data leaves your browser at any point during this process. The extension does not store extracted content after the operation completes.
 
+When **Save images locally** is enabled, tweet2md only downloads image assets from expected X media hosts such as `pbs.twimg.com`, `video.twimg.com`, `abs.twimg.com`, and `abs-0.twimg.com`. Other external image URLs are not downloaded by the background worker.
+
 ## Permissions explained
 
 | Permission     | Purpose                                              |
 |----------------|------------------------------------------------------|
 | `activeTab`    | Allows reading the current tab's page content when you click the extension icon |
-| `downloads`    | Allows saving the generated Markdown file and images to your Downloads folder |
+| `downloads`    | Allows saving the generated Markdown file and allowed X media images to your Downloads folder |
 | `storage`      | Allows saving your popup configuration (toggle switches) locally on your device so settings are remembered between sessions |
 | `contextMenus` | Adds the **Save tweet as Markdown** and **Copy tweet as Markdown** items to the browser's right-click menu, scoped to X.com pages. The menu only fires when you click an item; no page content is read otherwise. |
 | `host` (X.com) | A content script is injected on X.com pages to (a) extract the visible post or article content when you trigger an action, and (b) draw the inline download button on tweet action bars. The script reads the DOM locally and never transmits data externally. |
 
 These are the minimum permissions required for the extension to function. No additional permissions are requested.
 
-### About the new entry points (v1.3.0)
+### Entry points and download safety
 
-The inline download button and right-click context menu introduced in v1.3.0 are convenience triggers — they perform the **same local extraction** as the popup. They do not collect, transmit, or store anything beyond what the popup already does. When you activate one of them, tweet2md opens the tweet's permalink in a new tab, runs the extractor, then saves to Downloads or copies to your clipboard, all inside your browser.
+The inline download button and right-click context menu are convenience triggers — they perform the **same local extraction** as the popup. They do not collect, transmit, or store anything beyond what the popup already does. When you activate one of them, tweet2md opens the tweet's permalink in a new tab (or runs in the current one if you're already on it), runs the extractor, then saves to Downloads or copies to your clipboard, all inside your browser.
+
+The background worker validates download messages before using privileged browser APIs. Requests must come from a trusted extension page or a supported X.com content script, and filenames are sanitized before they are passed to Chrome's download API.
 
 ## Third-party services
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 - **X Articles** — Full support for long-form Articles (formerly Notes) with headings, lists, and code blocks
 - **Tweets & Threads** — Extract tweets, nested threads, and quote tweets into clean Markdown
 - **Quoted Posts** — Preserve quoted-post structure and context in a reusable format, with the original author's name and handle
-- **Local Image Downloads** — Download all embedded images locally alongside your `.md` file to prevent link rot
+- **Local Image Downloads** — Download embedded X media locally alongside your `.md` file to prevent link rot
 - **YAML Frontmatter** — Rich metadata with author, handle, date, source URL, content type, and engagement stats (likes, reposts, replies, bookmarks, views)
 - **Inline Engagement Stats** — Optional X-style row in the Markdown body: `💬 284 · 🔁 1.5K · ❤️ 8K · 🔖 253 · 👁 100K`
 - **Copy or Download** — Copy Markdown to clipboard or download as a file
@@ -89,7 +89,7 @@ Pick whichever entry point you prefer — they all run the same extractor and re
 
 Toggles available in the popup:
 
-- **Save images locally** — downloads embedded images alongside the `.md` file in a sibling folder
+- **Save images locally** — downloads embedded X media alongside the `.md` file in a sibling folder
 - **Show engagement stats inline** — renders likes / reposts / replies / bookmarks / views as a row in the Markdown body, X-style
 - **Include metadata** — adds YAML frontmatter (likes, reposts, replies, bookmarks, views, date)
 - **Show inline button on tweets** — toggle the per-tweet download icon on or off (useful if it visually conflicts with another extension)
@@ -104,7 +104,9 @@ Filenames: `@handle-tweetId.md` (tweets/threads) or `@handle-article-slug.md` (a
 - **Tweets/threads**: Turndown.js with custom rules (t.co resolution, emoji inlining, @mention cleanup)
 - **Articles**: Manual Draft.js block parsing for precise heading/list/code-block extraction
 - DOM is cloned and cleaned (engagement bars, follow buttons, navigation stripped) before conversion
-- Downloads via `chrome.downloads` API — nothing leaves your browser
+- Downloads via `chrome.downloads` API after the background worker validates the message sender and sanitizes download paths
+- Local image downloads are limited to expected X media hosts; external image URLs are left as remote Markdown links rather than downloaded
+- Nothing leaves your browser
 
 ## Current Limitations
 
@@ -118,7 +120,7 @@ Filenames: `@handle-tweetId.md` (tweets/threads) or `@handle-article-slug.md` (a
 | Permission     | Why                                                  |
 |----------------|------------------------------------------------------|
 | `activeTab`    | Read the current page's DOM when you click           |
-| `downloads`    | Save the `.md` file and images to Downloads          |
+| `downloads`    | Save the `.md` file and allowed X media images to Downloads |
 | `storage`      | Remember your popup toggle preferences               |
 | `contextMenus` | Add **Save / Copy tweet as Markdown** to the right-click menu (X.com only) |
 | `host` (X.com) | Inject a content script on X.com to extract post / article content and draw the inline download button |
@@ -162,7 +164,7 @@ npm run clean      # Clean build output
 
 ### Tests
 
-`tests/extractor.test.ts` runs the extractor against saved HTML fixtures and compares output against versioned `.md` snapshots (volatile frontmatter fields like `likes` and `date` are normalized). HTML fixtures are gitignored — capture them locally via `copy(document.documentElement.outerHTML)` in DevTools after the page is fully loaded.
+`tests/extractor.test.ts` runs the extractor against saved HTML fixtures and compares output against versioned `.md` snapshots (volatile frontmatter fields like `likes` and `date` are normalized). HTML fixtures are gitignored — capture them locally via `copy(document.documentElement.outerHTML)` in DevTools after the page is fully loaded. If no local fixtures are present, the suite keeps a passing baseline so fresh checkouts can still run tests.
 
 ## License
 

--- a/src/background/background.ts
+++ b/src/background/background.ts
@@ -1,4 +1,10 @@
 import type { DownloadRequest } from '../types/messages';
+import {
+  isAllowedImageUrl,
+  isTrustedDownloadSender,
+  isTrustedXContentSender,
+  sanitizeFilePath,
+} from './security';
 
 // ─── Context menu: Save / Copy tweet as Markdown ────────────────────
 
@@ -89,22 +95,32 @@ chrome.contextMenus.onClicked.addListener((info, tab) => {
   chrome.tabs.create({ url: appendMarker(target, action) });
 });
 
-chrome.runtime.onMessage.addListener((msg, _sender, _sendResponse) => {
-  if (msg && msg.action === 'TWEET2MD_CTX_URL') {
-    lastContextUrl = typeof msg.url === 'string' ? msg.url : null;
-  }
+chrome.runtime.onMessage.addListener((msg, sender, _sendResponse) => {
+  if (!msg || msg.action !== 'TWEET2MD_CTX_URL') return false;
+  if (!isTrustedXContentSender(sender)) return false;
+
+  lastContextUrl = typeof msg.url === 'string' ? msg.url : null;
   return false;
 });
 
 // ─── Download handler ───────────────────────────────────────────────
 
 chrome.runtime.onMessage.addListener(
-  (message: DownloadRequest, _sender, sendResponse) => {
-    if (message.action !== 'DOWNLOAD_MD') return false;
+  (message: DownloadRequest, sender, sendResponse) => {
+    if (!message || message.action !== 'DOWNLOAD_MD') return false;
+
+    if (!isTrustedDownloadSender(sender, chrome.runtime.id)) {
+      sendResponse({ success: false, error: 'Untrusted sender' });
+      return false;
+    }
 
     // First download any required images
     if (message.images && message.images.length > 0) {
       for (const img of message.images) {
+        if (!img || typeof img.url !== 'string' || !isAllowedImageUrl(img.url)) {
+          continue;
+        }
+
         chrome.downloads.download({
           url: img.url,
           filename: sanitizeFilePath(img.filename),
@@ -138,16 +154,3 @@ chrome.runtime.onMessage.addListener(
     return true; // keep channel open for async sendResponse
   }
 );
-
-/**
- * Remove characters that are invalid in filenames/paths.
- * Allows '/' to organize images into a folder next to markdown.
- */
-function sanitizeFilePath(name: string): string {
-  return name
-    .replace(/[<>:"\\|?*\x00-\x1f]/g, '_') // removed '/' from invalid chars
-    .replace(/\s+/g, '-')
-    .replace(/-{2,}/g, '-')
-    // don't drop leading/trailing slash handling because we want folder structure
-    .slice(0, 200); // Keep path length reasonable
-}

--- a/src/background/security.ts
+++ b/src/background/security.ts
@@ -1,9 +1,4 @@
-const ALLOWED_IMAGE_HOSTS = new Set([
-  'pbs.twimg.com',
-  'video.twimg.com',
-  'abs.twimg.com',
-  'abs-0.twimg.com',
-]);
+export { isAllowedImageUrl } from '../shared/media';
 
 const DEFAULT_DOWNLOAD_FILENAME = 'tweet2md.md';
 const MAX_PATH_SEGMENT_LENGTH = 80;
@@ -55,11 +50,6 @@ export function isTrustedDownloadSender(
   extensionId: string
 ): boolean {
   return isTrustedXContentSender(sender) || isExtensionPageSender(sender, extensionId);
-}
-
-export function isAllowedImageUrl(raw: string): boolean {
-  const url = parseUrl(raw);
-  return !!url && url.protocol === 'https:' && ALLOWED_IMAGE_HOSTS.has(url.hostname);
 }
 
 function sanitizePathSegment(segment: string): string {

--- a/src/background/security.ts
+++ b/src/background/security.ts
@@ -1,0 +1,108 @@
+const ALLOWED_IMAGE_HOSTS = new Set([
+  'pbs.twimg.com',
+  'video.twimg.com',
+  'abs.twimg.com',
+  'abs-0.twimg.com',
+]);
+
+const DEFAULT_DOWNLOAD_FILENAME = 'tweet2md.md';
+const MAX_PATH_SEGMENT_LENGTH = 80;
+const MAX_DOWNLOAD_PATH_LENGTH = 200;
+
+function parseUrl(raw: string | undefined): URL | null {
+  if (!raw) return null;
+  try {
+    return new URL(raw);
+  } catch {
+    return null;
+  }
+}
+
+function isHttpsXUrl(raw: string | undefined): boolean {
+  const url = parseUrl(raw);
+  return url?.protocol === 'https:' && url.hostname === 'x.com';
+}
+
+function isExtensionPageSender(
+  sender: chrome.runtime.MessageSender,
+  extensionId: string
+): boolean {
+  if (!extensionId || sender.id !== extensionId) return false;
+
+  const candidates = [sender.url, sender.origin];
+
+  return candidates.some((candidate) => {
+    const url = parseUrl(candidate);
+    return url?.protocol === 'chrome-extension:' && url.hostname === extensionId;
+  });
+}
+
+export function isTrustedXContentSender(
+  sender: chrome.runtime.MessageSender
+): boolean {
+  if (isHttpsXUrl(sender.url)) return true;
+
+  const senderUrl = parseUrl(sender.url);
+  if (!senderUrl || senderUrl.protocol === 'about:') {
+    if (isHttpsXUrl(sender.origin)) return true;
+  }
+
+  return !sender.url && !sender.origin && isHttpsXUrl(sender.tab?.url);
+}
+
+export function isTrustedDownloadSender(
+  sender: chrome.runtime.MessageSender,
+  extensionId: string
+): boolean {
+  return isTrustedXContentSender(sender) || isExtensionPageSender(sender, extensionId);
+}
+
+export function isAllowedImageUrl(raw: string): boolean {
+  const url = parseUrl(raw);
+  return !!url && url.protocol === 'https:' && ALLOWED_IMAGE_HOSTS.has(url.hostname);
+}
+
+function sanitizePathSegment(segment: string): string {
+  return segment
+    .replace(/[<>:"|?*\x00-\x1f]/g, '_')
+    .replace(/\s+/g, '-')
+    .replace(/-{2,}/g, '-')
+    .slice(0, MAX_PATH_SEGMENT_LENGTH);
+}
+
+function truncatePathPreservingExtension(path: string): string {
+  if (path.length <= MAX_DOWNLOAD_PATH_LENGTH) return path;
+
+  const lastSlash = path.lastIndexOf('/');
+  const finalSegment = lastSlash >= 0 ? path.slice(lastSlash + 1) : path;
+  const lastDot = finalSegment.lastIndexOf('.');
+  const hasExtension = lastDot > 0 && lastDot < finalSegment.length - 1;
+
+  if (hasExtension) {
+    const extension = finalSegment.slice(lastDot);
+    if (extension.length < MAX_DOWNLOAD_PATH_LENGTH) {
+      return path
+        .slice(0, MAX_DOWNLOAD_PATH_LENGTH - extension.length)
+        .replace(/\/+$/g, '') + extension;
+    }
+  }
+
+  return path.slice(0, MAX_DOWNLOAD_PATH_LENGTH).replace(/\/+$/g, '');
+}
+
+export function sanitizeFilePath(name: string): string {
+  const sanitized = String(name ?? '')
+    .normalize('NFKC')
+    .replace(/\\/g, '/')
+    .replace(/\/+/g, '/')
+    .split('/')
+    .filter((part) => part && part !== '.' && part !== '..')
+    .map(sanitizePathSegment)
+    .filter(Boolean)
+    .join('/')
+    .replace(/^\/+/, '');
+
+  if (!sanitized) return DEFAULT_DOWNLOAD_FILENAME;
+
+  return truncatePathPreservingExtension(sanitized) || DEFAULT_DOWNLOAD_FILENAME;
+}

--- a/src/shared/media.ts
+++ b/src/shared/media.ts
@@ -1,0 +1,15 @@
+const ALLOWED_IMAGE_HOSTS = new Set([
+  'pbs.twimg.com',
+  'video.twimg.com',
+  'abs.twimg.com',
+  'abs-0.twimg.com',
+]);
+
+export function isAllowedImageUrl(raw: string): boolean {
+  try {
+    const url = new URL(raw);
+    return url.protocol === 'https:' && ALLOWED_IMAGE_HOSTS.has(url.hostname);
+  } catch {
+    return false;
+  }
+}

--- a/src/shared/post-process.ts
+++ b/src/shared/post-process.ts
@@ -1,4 +1,5 @@
 import type { ExtractedContent, TweetMetadata } from '../types/messages';
+import { isAllowedImageUrl } from './media';
 
 export interface PostProcessOptions {
   includeMetadata: boolean;
@@ -111,6 +112,10 @@ export function postProcess(
     finalMarkdown = finalMarkdown.replace(
       /!\[(.*?)\]\((https:\/\/[^)]+)\)/g,
       (match, alt, imgUrl) => {
+        if (!isAllowedImageUrl(imgUrl)) {
+          return match;
+        }
+
         try {
           const urlObj = new URL(imgUrl);
           let fname = urlObj.pathname.split('/').pop() || 'image';

--- a/tests/background-security.test.ts
+++ b/tests/background-security.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, it } from 'vitest';
+import {
+  isAllowedImageUrl,
+  isTrustedDownloadSender,
+  isTrustedXContentSender,
+  sanitizeFilePath,
+} from '../src/background/security';
+
+const EXTENSION_ID = 'abcdefghijklmnopabcdefghijklmnop';
+
+function sender(fields: Partial<chrome.runtime.MessageSender>): chrome.runtime.MessageSender {
+  return fields as chrome.runtime.MessageSender;
+}
+
+describe('isTrustedXContentSender()', () => {
+  it('accepts HTTPS x.com content-script senders', () => {
+    expect(
+      isTrustedXContentSender(
+        sender({
+          id: EXTENSION_ID,
+          url: 'https://x.com/example/status/123',
+          origin: 'https://x.com',
+          tab: { url: 'https://x.com/example/status/123' } as chrome.tabs.Tab,
+        })
+      )
+    ).toBe(true);
+  });
+
+  it('rejects non-HTTPS x.com senders', () => {
+    expect(
+      isTrustedXContentSender(
+        sender({
+          id: EXTENSION_ID,
+          url: 'http://x.com/example/status/123',
+          origin: 'http://x.com',
+        })
+      )
+    ).toBe(false);
+  });
+
+  it('rejects twitter.com for this x.com-scoped PR', () => {
+    expect(
+      isTrustedXContentSender(
+        sender({
+          id: EXTENSION_ID,
+          url: 'https://twitter.com/example/status/123',
+          origin: 'https://twitter.com',
+        })
+      )
+    ).toBe(false);
+  });
+
+  it('rejects unrelated and malformed sender URLs', () => {
+    expect(
+      isTrustedXContentSender(
+        sender({
+          id: EXTENSION_ID,
+          url: 'https://example.com/page',
+          origin: 'https://example.com',
+        })
+      )
+    ).toBe(false);
+
+    expect(
+      isTrustedXContentSender(
+        sender({
+          id: EXTENSION_ID,
+          url: 'not a url',
+        })
+      )
+    ).toBe(false);
+  });
+
+  it('uses sender origin when the sender URL is ambiguous', () => {
+    expect(
+      isTrustedXContentSender(
+        sender({
+          id: EXTENSION_ID,
+          url: 'about:blank',
+          origin: 'https://x.com',
+        })
+      )
+    ).toBe(true);
+  });
+});
+
+describe('isTrustedDownloadSender()', () => {
+  it('accepts trusted X content-script senders', () => {
+    expect(
+      isTrustedDownloadSender(
+        sender({
+          id: EXTENSION_ID,
+          url: 'https://x.com/example/status/123',
+          origin: 'https://x.com',
+        }),
+        EXTENSION_ID
+      )
+    ).toBe(true);
+  });
+
+  it('accepts trusted extension-page senders', () => {
+    expect(
+      isTrustedDownloadSender(
+        sender({
+          id: EXTENSION_ID,
+          url: `chrome-extension://${EXTENSION_ID}/popup.html`,
+          origin: `chrome-extension://${EXTENSION_ID}`,
+        }),
+        EXTENSION_ID
+      )
+    ).toBe(true);
+  });
+
+  it('rejects same-extension content-script senders on unrelated pages', () => {
+    expect(
+      isTrustedDownloadSender(
+        sender({
+          id: EXTENSION_ID,
+          url: 'https://example.com/page',
+          origin: 'https://example.com',
+          tab: { url: 'https://example.com/page' } as chrome.tabs.Tab,
+        }),
+        EXTENSION_ID
+      )
+    ).toBe(false);
+  });
+
+  it('rejects other extension IDs and missing sender identity', () => {
+    expect(
+      isTrustedDownloadSender(
+        sender({
+          id: 'otherextensionidotherextensionid',
+          url: 'chrome-extension://otherextensionidotherextensionid/popup.html',
+          origin: 'chrome-extension://otherextensionidotherextensionid',
+        }),
+        EXTENSION_ID
+      )
+    ).toBe(false);
+
+    expect(isTrustedDownloadSender(sender({}), EXTENSION_ID)).toBe(false);
+  });
+});
+
+describe('isAllowedImageUrl()', () => {
+  it.each([
+    'https://pbs.twimg.com/media/example.jpg',
+    'https://video.twimg.com/ext_tw_video/123/pu/vid/720x720/video.mp4',
+    'https://abs.twimg.com/hashflags/example.png',
+    'https://abs-0.twimg.com/emoji/v2/svg/1f600.svg',
+  ])('accepts allowed media URL %s', (url) => {
+    expect(isAllowedImageUrl(url)).toBe(true);
+  });
+
+  it.each([
+    'http://pbs.twimg.com/media/example.jpg',
+    'https://example.com/image.jpg',
+    'https://pbs.twimg.com.example.com/image.jpg',
+    'not a url',
+  ])('rejects disallowed media URL %s', (url) => {
+    expect(isAllowedImageUrl(url)).toBe(false);
+  });
+});
+
+describe('sanitizeFilePath()', () => {
+  it.each([
+    ['../../evil.md', 'evil.md'],
+    ['/absolute/path.md', 'absolute/path.md'],
+    ['folder/../../evil.md', 'folder/evil.md'],
+    ['folder//image.jpg', 'folder/image.jpg'],
+    ['tweet title with spaces.md', 'tweet-title-with-spaces.md'],
+    ['bad\u0000name.md', 'bad_name.md'],
+    ['../..', 'tweet2md.md'],
+  ])('sanitizes %s to %s', (input, expected) => {
+    expect(sanitizeFilePath(input)).toBe(expected);
+  });
+
+  it('limits individual path segments to 80 characters', () => {
+    const result = sanitizeFilePath(`${'a'.repeat(120)}.jpg`);
+    expect(result).toHaveLength(80);
+  });
+
+  it('limits the total path to 200 characters and preserves the final extension when feasible', () => {
+    const input = Array.from(
+      { length: 8 },
+      (_, i) => `folder-${i}-${'a'.repeat(30)}`
+    ).join('/') + '/final.md';
+    const result = sanitizeFilePath(input);
+    expect(result.length).toBeLessThanOrEqual(200);
+    expect(result.endsWith('.md')).toBe(true);
+  });
+});

--- a/tests/extractor.test.ts
+++ b/tests/extractor.test.ts
@@ -98,6 +98,12 @@ function findHtmlForId(id: string): string | null {
 const mdFixtures = readdirSync(FIXTURES).filter((f) => f.endsWith('.md'));
 
 describe('extract() snapshot tests', () => {
+  if (mdFixtures.length === 0) {
+    it('has no markdown fixtures to compare', () => {
+      expect(mdFixtures).toEqual([]);
+    });
+  }
+
   for (const mdName of mdFixtures) {
     const mdPath = join(FIXTURES, mdName);
     const expectedRaw = readFileSync(mdPath, 'utf-8');

--- a/tests/fixtures/.gitkeep
+++ b/tests/fixtures/.gitkeep
@@ -1,0 +1,1 @@
+# Keep the fixture directory present for extractor test discovery.

--- a/tests/post-process.test.ts
+++ b/tests/post-process.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { postProcess } from '../src/shared/post-process';
+import type { ExtractedContent } from '../src/types/messages';
+
+function content(markdown: string): ExtractedContent {
+  return {
+    type: 'tweet',
+    author: { name: 'Example', handle: '@example' },
+    markdown,
+    sourceUrl: 'https://x.com/example/status/123',
+    date: '2026-05-11T00:00:00.000Z',
+    tweetId: '123',
+  };
+}
+
+describe('postProcess() image downloads', () => {
+  it('localizes only allowed X/Twitter media images', () => {
+    const allowedUrl = 'https://pbs.twimg.com/media/example?format=jpg&name=large';
+    const externalUrl = 'https://example.com/card.jpg';
+    const result = postProcess(
+      content(`![Allowed](${allowedUrl})\n![External](${externalUrl})`),
+      { includeMetadata: false, downloadImages: true }
+    );
+
+    expect(result.markdown).toContain('![Allowed](example-123/example.jpg)');
+    expect(result.markdown).toContain(`![External](${externalUrl})`);
+    expect(result.images).toEqual([
+      { url: allowedUrl, filename: 'example-123/example.jpg' },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- Add testable background security helpers for sender trust, image URL allowlisting, and deterministic download path sanitization.
- Apply sender validation before context URL updates and privileged download handling.
- Preserve external image URLs as remote Markdown links while localizing only allowed X/Twitter media.
- Document the hardened download behavior in README, PRIVACY, and CHANGELOG.
- Keep fresh checkouts testable when extractor fixtures are absent.

## Test Plan
- [x] npm test
- [x] npm run build
- [x] Manual Chrome smoke test: loaded unpacked extension, exported via toolbar popup and inline tweet download icon, verified Markdown and local media output at /Users/quinn/Downloads/adamghowiba-2051361283396784273.md.