### PR TITLE
Bounded, locale-tolerant thread extraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+### Changed
+
+- **Thread extraction reliability**: Replaced fixed post-scroll sleeps with a bounded, article-aware collection loop and added diagnostics for incomplete thread exports.
+- **Locale-tolerant promoted-tweet detection**: The thread collector's "Promoted" label fallback now recognizes the modern bare `Ad` label and localized variants (`広告`, `プロモーション`, `Werbung`, `Patrocinado`, `Anuncio`, `广告`, and more), so ads no longer slip through on non-English X.com sessions.
+- **`thread_degraded` frontmatter flag**: Single-post collections that hit `max_steps`/`max_duration` are still labeled `type: thread` so diagnostics survive, but now carry an explicit `thread_degraded: true` field so the disambiguation is obvious to readers.
+
 ## [1.4.0] - 2026-05-11
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Filenames: `@handle-tweetId.md` (tweets/threads) or `@handle-article-slug.md` (a
 ## How it works
 
 - Content script auto-injects on `x.com/*/status/*` pages
-- **Tweets/threads**: Turndown.js with custom rules (t.co resolution, emoji inlining, @mention cleanup)
+- **Tweets/threads**: Turndown.js with custom rules plus bounded DOM collection for virtualized thread timelines
 - **Articles**: Manual Draft.js block parsing for precise heading/list/code-block extraction
 - DOM is cloned and cleaned (engagement bars, follow buttons, navigation stripped) before conversion
 - Downloads via `chrome.downloads` API after the background worker validates the message sender and sanitizes download paths
@@ -113,6 +113,7 @@ Filenames: `@handle-tweetId.md` (tweets/threads) or `@handle-article-slug.md` (a
 - Focused on x.com content extraction
 - Videos and GIFs are not exported as playable media files
 - Requires a page reload if the extension was installed or updated after opening the tab
+- Thread extraction is DOM-based and bounded. Very long or unusually rendered threads may export partially; when that happens, metadata and an HTML comment include the stop reason and collected count. A degraded single-post extraction may be labeled `type: thread` so those diagnostics are preserved.
 - Some content may stop working if x.com changes its page structure significantly
 
 ## Permissions

--- a/src/content/content.ts
+++ b/src/content/content.ts
@@ -2,7 +2,11 @@ import type { DownloadRequest, ExtractResponse } from '../types/messages';
 import { postProcess, resolveDownloadImages } from '../shared/post-process';
 import { delay, isArticlePage } from './dom';
 import { extractArticle } from './article';
-import { extractTweetAsync, extractEngagementMetadata } from './tweet';
+import {
+  extractTweetAsync,
+  extractEngagementMetadata,
+  findTweetArticleByStatusId,
+} from './tweet';
 import { waitForArticle } from './wait';
 
 // ─── Main Extraction Entry Point ────────────────────────────────────
@@ -21,10 +25,13 @@ export async function extract(options?: {
     const isArticle = isArticlePage();
     const data = isArticle ? extractArticle() : await extractTweetAsync();
 
-    if (options?.includeMetadata) {
-      const firstArticle = document.querySelector('article[role="article"]');
-      if (firstArticle) {
-        data.metadata = extractEngagementMetadata(firstArticle);
+    if (options?.includeMetadata && !data.metadata) {
+      const metadataArticle = isArticle
+        ? document.querySelector('article[role="article"]')
+        : findTweetArticleByStatusId(data.tweetId) ||
+          document.querySelector('article[role="article"]');
+      if (metadataArticle) {
+        data.metadata = extractEngagementMetadata(metadataArticle);
       }
     }
 

--- a/src/content/thread-collector.ts
+++ b/src/content/thread-collector.ts
@@ -1,0 +1,432 @@
+import type { AuthorInfo, ThreadExtractionInfo, ThreadStopReason } from '../types/messages';
+
+export type { ThreadStopReason };
+
+export interface ThreadTweetParts {
+  text: string;
+  media: string[];
+}
+
+export interface CollectedThreadTweet extends ThreadTweetParts {
+  id: string;
+}
+
+export interface ThreadCollectionResult {
+  author?: AuthorInfo;
+  tweets: CollectedThreadTweet[];
+  info: ThreadExtractionInfo;
+}
+
+export interface ThreadCollectorOptions {
+  maxSteps: number;
+  maxDurationMs: number;
+  settleMs: number;
+  mutationTimeoutMs: number;
+  maxWaitMs: number;
+  bottomThresholdPx: number;
+}
+
+export const DEFAULT_THREAD_COLLECTOR_OPTIONS: ThreadCollectorOptions = {
+  maxSteps: 60,
+  maxDurationMs: 25_000,
+  settleMs: 500,
+  mutationTimeoutMs: 1_250,
+  maxWaitMs: 2_000,
+  bottomThresholdPx: 50,
+};
+
+export interface ThreadCollectorEnv<TArticle = Element> {
+  targetStatusId?: string;
+  targetAuthor?: AuthorInfo;
+  queryArticles(): TArticle[];
+  scrollToTop(): void;
+  scrollBy(amount: number): void;
+  isAtBottom(thresholdPx: number): boolean;
+  now(): number;
+  waitForRelevantArticlesToSettle(
+    deadlineAt: number,
+    opts: ThreadCollectorOptions
+  ): Promise<void>;
+  getScrollStep(): number;
+  getAuthor(article: TArticle): AuthorInfo;
+  getStatusId(article: TArticle): string;
+  isPromotedArticle(article: TArticle): boolean;
+  extractTweet(article: TArticle): ThreadTweetParts;
+}
+
+export interface BrowserThreadCollectorDeps {
+  targetStatusId?: string;
+  targetAuthor?: AuthorInfo;
+  getAuthor(article: Element): AuthorInfo;
+  getStatusId(article: Element): string;
+  extractTweet(article: Element): ThreadTweetParts;
+}
+
+function mergeOptions(
+  overrides: Partial<ThreadCollectorOptions> = {}
+): ThreadCollectorOptions {
+  return { ...DEFAULT_THREAD_COLLECTOR_OPTIONS, ...overrides };
+}
+
+function sameHandle(a: string, b: string): boolean {
+  return a.toLowerCase() === b.toLowerCase();
+}
+
+function buildInfo(
+  complete: boolean,
+  stopReason: ThreadStopReason,
+  collectedCount: number,
+  failedCount: number,
+  steps: number,
+  durationMs: number
+): ThreadExtractionInfo {
+  return { complete, stopReason, collectedCount, failedCount, steps, durationMs };
+}
+
+function isTargetStatus<TArticle>(
+  env: ThreadCollectorEnv<TArticle>,
+  article: TArticle,
+  statusId?: string
+): boolean {
+  if (!env.targetStatusId) return false;
+  return (statusId || env.getStatusId(article)) === env.targetStatusId;
+}
+
+function shouldSkipPromoted<TArticle>(
+  env: ThreadCollectorEnv<TArticle>,
+  article: TArticle,
+  statusId?: string
+): boolean {
+  return !isTargetStatus(env, article, statusId) && env.isPromotedArticle(article);
+}
+
+function seedTargetArticle<TArticle>(
+  env: ThreadCollectorEnv<TArticle>,
+  collected: Map<string, CollectedThreadTweet>,
+  observedSameAuthorIds: Set<string>,
+  failedSameAuthorIds: Set<string>
+): AuthorInfo | null {
+  const articles = env.queryArticles();
+  const targetArticle = env.targetStatusId
+    ? articles.find(
+        (article) =>
+          env.getStatusId(article) === env.targetStatusId
+      )
+    : undefined;
+  const fallbackArticle =
+    targetArticle ||
+    (env.targetAuthor?.handle && env.targetAuthor.handle !== 'unknown'
+      ? articles.find(
+          (article) =>
+            !shouldSkipPromoted(env, article) &&
+            sameHandle(env.getAuthor(article).handle, env.targetAuthor!.handle)
+        )
+      : undefined);
+
+  if (!fallbackArticle) return null;
+
+  const statusId = env.getStatusId(fallbackArticle);
+  if (!statusId) return env.getAuthor(fallbackArticle);
+
+  observedSameAuthorIds.add(statusId);
+  try {
+    const parts = env.extractTweet(fallbackArticle);
+    collected.set(statusId, { id: statusId, ...parts });
+  } catch {
+    failedSameAuthorIds.add(statusId);
+  }
+  return env.getAuthor(fallbackArticle);
+}
+
+// Locale-stable structural marker is the primary signal. The label set covers
+// the X.com display languages the extension itself ships locales for, plus
+// "Ad" — the current English label X.com renders for many promoted formats.
+const PROMOTED_LABELS = new Set(
+  [
+    'promoted',
+    'ad',
+    'promoted tweet',
+    '広告',
+    'プロモーション',
+    'プロモツイート',
+    'werbung',
+    'anuncio',
+    'patrocinado',
+    'promu',
+    '广告',
+    'إعلان',
+    'تبلیغ',
+  ].map((label) => label.toLowerCase())
+);
+
+export function isPromotedArticle(article: Element): boolean {
+  if (
+    article.querySelector('[data-testid="placementTracking"], [data-testid="promotedIndicator"]')
+  ) {
+    return true;
+  }
+
+  // Scan label nodes outside the tweet body and any embedded quote/link
+  // card. Real promoted tweets still contain a tweetText element — the ad
+  // label lives in a sibling header span — so we can't bail on tweetText
+  // presence. We exclude nodes inside tweetText (avoid matching ad-related
+  // words in normal copy) and inside role="link" (avoid matching a
+  // quoted-tweet's own "Promoted" label as the outer article's).
+  return Array.from(article.querySelectorAll('span, div')).some((el) => {
+    if (el.closest('[data-testid="tweetText"]')) return false;
+    if (el.closest('[role="link"]')) return false;
+    const text = (el.textContent || '').replace(/\s+/g, ' ').trim().toLowerCase();
+    return PROMOTED_LABELS.has(text);
+  });
+}
+
+export function hasRelevantArticleMutation(records: MutationRecord[]): boolean {
+  return records.some((record) =>
+    Array.from(record.addedNodes).some((node) => {
+      if (node.nodeType !== Node.ELEMENT_NODE) return false;
+      const el = node as Element;
+      return (
+        el.matches?.('article[role="article"]') ||
+        !!el.querySelector?.('article[role="article"]')
+      );
+    })
+  );
+}
+
+export async function collectThreadTweets<TArticle>(
+  env: ThreadCollectorEnv<TArticle>,
+  overrides: Partial<ThreadCollectorOptions> = {}
+): Promise<ThreadCollectionResult> {
+  const opts = mergeOptions(overrides);
+  const startedAt = env.now();
+  const deadlineAt = startedAt + opts.maxDurationMs;
+  const collected = new Map<string, CollectedThreadTweet>();
+  const observedSameAuthorIds = new Set<string>();
+  const failedSameAuthorIds = new Set<string>();
+
+  let pendingBoundary = false;
+  let threadAuthor: AuthorInfo | null = null;
+  let quietCycles = 0;
+  let steps = 0;
+  let stopReason: ThreadStopReason = 'max_steps';
+
+  threadAuthor = seedTargetArticle(
+    env,
+    collected,
+    observedSameAuthorIds,
+    failedSameAuthorIds
+  );
+  env.scrollToTop();
+
+  while (steps < opts.maxSteps) {
+    steps += 1;
+
+    if (env.now() >= deadlineAt) {
+      stopReason = 'max_duration';
+      break;
+    }
+
+    await env.waitForRelevantArticlesToSettle(deadlineAt, opts);
+
+    if (env.now() >= deadlineAt) {
+      stopReason = 'max_duration';
+      break;
+    }
+
+    const articles = env.queryArticles();
+    if (steps === 1 && articles.length === 0 && collected.size === 0) {
+      stopReason = 'no_new_posts';
+      break;
+    }
+
+    if (!threadAuthor && env.targetStatusId) {
+      const targetArticle = articles.find(
+        (article) =>
+          env.getStatusId(article) === env.targetStatusId
+      );
+      if (targetArticle) {
+        threadAuthor = env.getAuthor(targetArticle);
+      }
+    }
+    if (!threadAuthor && env.targetAuthor?.handle && env.targetAuthor.handle !== 'unknown') {
+      threadAuthor = env.targetAuthor;
+    }
+
+    const hadPendingBoundaryAtCycleStart = pendingBoundary;
+    let observedSameAuthorProgress = false;
+    let sawNonPromotedArticle = false;
+    const sawArticle = articles.length > 0;
+
+    for (const article of articles) {
+      const statusId = env.getStatusId(article);
+      if (shouldSkipPromoted(env, article, statusId)) continue;
+      sawNonPromotedArticle = true;
+      if (!statusId) continue;
+      const articleAuthor = env.getAuthor(article);
+      if (!threadAuthor && env.targetStatusId) continue;
+      if (!threadAuthor) threadAuthor = articleAuthor;
+
+      if (sameHandle(articleAuthor.handle, threadAuthor.handle)) {
+        if (!observedSameAuthorIds.has(statusId)) {
+          observedSameAuthorIds.add(statusId);
+          observedSameAuthorProgress = true;
+          pendingBoundary = false;
+
+          try {
+            const parts = env.extractTweet(article);
+            collected.set(statusId, { id: statusId, ...parts });
+          } catch {
+            failedSameAuthorIds.add(statusId);
+          }
+        }
+        continue;
+      }
+
+      if (observedSameAuthorIds.size > 0 && !pendingBoundary) {
+        pendingBoundary = true;
+      }
+    }
+
+    if (hadPendingBoundaryAtCycleStart && pendingBoundary && !observedSameAuthorProgress) {
+      stopReason = 'reply_boundary';
+      break;
+    }
+
+    if (!pendingBoundary && env.isAtBottom(opts.bottomThresholdPx)) {
+      stopReason = 'bottom';
+      break;
+    }
+
+    const quietEligible =
+      !pendingBoundary &&
+      !observedSameAuthorProgress &&
+      (sawNonPromotedArticle || (observedSameAuthorIds.size > 0 && !sawArticle));
+    const adOnly = sawArticle && !sawNonPromotedArticle;
+
+    // Ad-only cycles are treated as absent and preserve quiet-cycle state.
+    if (quietEligible) {
+      quietCycles += 1;
+      if (quietCycles >= 2) {
+        stopReason = 'no_new_posts';
+        break;
+      }
+    } else if (!adOnly) {
+      quietCycles = 0;
+    }
+
+    if (steps >= opts.maxSteps) {
+      stopReason = 'max_steps';
+      break;
+    }
+
+    env.scrollBy(env.getScrollStep());
+  }
+
+  const scanComplete =
+    stopReason === 'reply_boundary' ||
+    stopReason === 'bottom' ||
+    stopReason === 'no_new_posts';
+  const complete = scanComplete && failedSameAuthorIds.size === 0;
+  // Date.now() can move backwards under NTP/system-clock adjustments, so
+  // clamp to keep thread_duration_ms a non-negative integer for downstream
+  // YAML and HTML-comment consumers.
+  const durationMs = Math.max(0, Math.round(env.now() - startedAt));
+
+  return {
+    author: threadAuthor || undefined,
+    tweets: Array.from(collected.values()),
+    info: buildInfo(
+      complete,
+      stopReason,
+      collected.size,
+      failedSameAuthorIds.size,
+      steps,
+      durationMs
+    ),
+  };
+}
+
+function getWaitMs(deadlineAt: number, opts: ThreadCollectorOptions): number {
+  const remaining = Math.max(0, deadlineAt - Date.now());
+  return Math.min(opts.maxWaitMs, remaining);
+}
+
+export function findTimelineRoot(): Element {
+  const firstArticle = document.querySelector('article[role="article"]');
+  const timeline =
+    firstArticle?.closest('[aria-label][role="region"]') ||
+    firstArticle?.closest('main') ||
+    document.querySelector('main');
+  // Cold starts can have no article yet; body is noisy, but mutation filtering
+  // ignores non-article churn until the first article subtree is added.
+  return timeline || document.body;
+}
+
+export function createBrowserThreadCollectorEnv(
+  deps: BrowserThreadCollectorDeps
+): ThreadCollectorEnv<Element> {
+  return {
+    targetStatusId: deps.targetStatusId,
+    targetAuthor: deps.targetAuthor,
+    queryArticles: () => Array.from(document.querySelectorAll('article[role="article"]')),
+    scrollToTop: () => window.scrollTo({ top: 0, behavior: 'instant' }),
+    scrollBy: (amount) => window.scrollBy({ top: amount, behavior: 'instant' }),
+    isAtBottom: (thresholdPx) =>
+      window.scrollY + window.innerHeight >= document.documentElement.scrollHeight - thresholdPx,
+    now: () => Date.now(),
+    waitForRelevantArticlesToSettle: (deadlineAt, opts) =>
+      waitForRelevantArticlesToSettle(findTimelineRoot(), deadlineAt, opts),
+    getScrollStep: () => Math.max(window.innerHeight * 0.6, 400),
+    getAuthor: deps.getAuthor,
+    getStatusId: deps.getStatusId,
+    isPromotedArticle,
+    extractTweet: deps.extractTweet,
+  };
+}
+
+export function waitForRelevantArticlesToSettle(
+  root: Element,
+  deadlineAt: number,
+  opts: ThreadCollectorOptions
+): Promise<void> {
+  const maxWaitMs = getWaitMs(deadlineAt, opts);
+  if (maxWaitMs <= 0) return Promise.resolve();
+
+  return new Promise((resolve) => {
+    let settledTimer: ReturnType<typeof setTimeout> | null = null;
+    let fallbackTimer: ReturnType<typeof setTimeout> | null = null;
+    let maxTimer: ReturnType<typeof setTimeout> | null = null;
+    let done = false;
+    let observer: MutationObserver;
+
+    const cleanup = () => {
+      if (done) return;
+      done = true;
+      observer.takeRecords();
+      observer.disconnect();
+      if (settledTimer) clearTimeout(settledTimer);
+      if (fallbackTimer) clearTimeout(fallbackTimer);
+      if (maxTimer) clearTimeout(maxTimer);
+      resolve();
+    };
+
+    const markRelevant = () => {
+      if (fallbackTimer) {
+        clearTimeout(fallbackTimer);
+        fallbackTimer = null;
+      }
+      if (settledTimer) clearTimeout(settledTimer);
+      settledTimer = setTimeout(cleanup, opts.settleMs);
+    };
+
+    observer = new MutationObserver((records) => {
+      if (hasRelevantArticleMutation(records)) {
+        markRelevant();
+      }
+    });
+
+    observer.observe(root, { childList: true, subtree: true });
+    fallbackTimer = setTimeout(cleanup, opts.mutationTimeoutMs);
+    maxTimer = setTimeout(cleanup, maxWaitMs);
+  });
+}

--- a/src/content/tweet.ts
+++ b/src/content/tweet.ts
@@ -2,7 +2,6 @@ import type { ExtractedContent, TweetMetadata } from '../types/messages';
 import { turndown, cleanupMarkdown } from './markdown';
 import {
   SELECTORS,
-  delay,
   extractAuthor,
   extractAuthorFromArticle,
   extractDate,
@@ -10,6 +9,10 @@ import {
   getTweetStatusId,
   cleanContentClone,
 } from './dom';
+import {
+  collectThreadTweets,
+  createBrowserThreadCollectorEnv,
+} from './thread-collector';
 
 /**
  * Extract engagement metadata from a tweet's role="group" aria-label.
@@ -26,22 +29,44 @@ export function extractEngagementMetadata(
 
   const meta: TweetMetadata = {};
 
-  const repliesMatch = label.match(/([\d,]+)\s*repl/i);
-  if (repliesMatch) meta.replies = parseInt(repliesMatch[1].replace(/,/g, ''), 10);
+  const replies = extractCount(label, 'repl');
+  if (replies !== undefined) meta.replies = replies;
 
-  const repostsMatch = label.match(/([\d,]+)\s*repost/i);
-  if (repostsMatch) meta.reposts = parseInt(repostsMatch[1].replace(/,/g, ''), 10);
+  const reposts = extractCount(label, 'repost');
+  if (reposts !== undefined) meta.reposts = reposts;
 
-  const likesMatch = label.match(/([\d,]+)\s*like/i);
-  if (likesMatch) meta.likes = parseInt(likesMatch[1].replace(/,/g, ''), 10);
+  const likes = extractCount(label, 'like');
+  if (likes !== undefined) meta.likes = likes;
 
-  const bookmarksMatch = label.match(/([\d,]+)\s*bookmark/i);
-  if (bookmarksMatch) meta.bookmarks = parseInt(bookmarksMatch[1].replace(/,/g, ''), 10);
+  const bookmarks = extractCount(label, 'bookmark');
+  if (bookmarks !== undefined) meta.bookmarks = bookmarks;
 
-  const viewsMatch = label.match(/([\d,]+)\s*view/i);
-  if (viewsMatch) meta.views = parseInt(viewsMatch[1].replace(/,/g, ''), 10);
+  const views = extractCount(label, 'view');
+  if (views !== undefined) meta.views = views;
 
   return Object.keys(meta).length > 0 ? meta : undefined;
+}
+
+function extractCount(label: string, metricPrefix: string): number | undefined {
+  const match = label.match(new RegExp(`([\\d,.]+\\s*[kmb]?)\\s*${metricPrefix}`, 'i'));
+  if (!match) return undefined;
+
+  const normalized = match[1].replace(/,/g, '').replace(/\s+/g, '').toLowerCase();
+  const countMatch = normalized.match(/^(\d+(?:\.\d+)?)([kmb])?$/);
+  if (!countMatch) return undefined;
+
+  const value = Number(countMatch[1]);
+  const suffix = countMatch[2];
+  const multiplier = suffix === 'm' ? 1_000_000 : suffix === 'k' ? 1_000 : 1;
+  return Math.round(value * multiplier);
+}
+
+export function findTweetArticleByStatusId(statusId: string): Element | null {
+  return (
+    Array.from(document.querySelectorAll('article[role="article"]')).find(
+      (article) => getTweetStatusId(article) === statusId
+    ) || null
+  );
 }
 
 function extractTextFromElement(textEl: Element): string {
@@ -197,11 +222,22 @@ function extractSingleTweetFromArticle(
 
   // Media
   const media: string[] = [];
+  const videos = Array.from(article.querySelectorAll('video'));
+  const videoPosters = new Set(
+    videos
+      .map((video) => video.getAttribute('poster'))
+      .filter((poster): poster is string => !!poster)
+  );
 
   const photos = article.querySelectorAll(`${SELECTORS.tweetPhoto} img`);
   photos.forEach((img) => {
     let src = (img as HTMLImageElement).src;
-    if (src && !src.includes('emoji') && !src.includes('profile_images')) {
+    if (
+      src &&
+      !videoPosters.has(src) &&
+      !src.includes('emoji') &&
+      !src.includes('profile_images')
+    ) {
       if (src.includes('pbs.twimg.com')) {
         src = src.replace(/&name=\w+/, '&name=large');
       }
@@ -209,7 +245,6 @@ function extractSingleTweetFromArticle(
     }
   });
 
-  const videos = article.querySelectorAll('video');
   videos.forEach((video) => {
     const poster = video.getAttribute('poster');
     if (poster) {
@@ -223,77 +258,44 @@ function extractSingleTweetFromArticle(
 /**
  * Scroll-aware thread extraction.
  *
- * X.com uses a virtualized list — only tweets near the viewport exist in the
- * DOM at any given moment. To capture a full thread we:
- *   1. Scroll to the very top of the page.
- *   2. Collect all visible thread-author tweets (stopping on a different-author
- *      tweet, which signals the start of the reply section).
- *   3. Scroll down a step and repeat, deduplicating by status ID.
- *   4. Stop once no new thread tweets appear after a scroll (thread complete)
- *      OR we hit a different-author tweet.
+ * X.com uses a virtualized list, so thread collection is bounded and waits for
+ * article mutations to settle after scrolls instead of relying on fixed sleeps.
  */
 export async function extractTweetAsync(): Promise<ExtractedContent> {
   const date = extractDate();
   const tweetId = extractTweetId();
   const sourceUrl = window.location.href;
+  const targetArticle = findTweetArticleByStatusId(tweetId);
+  const metadata = targetArticle ? extractEngagementMetadata(targetArticle) : undefined;
+
+  const collection = await collectThreadTweets(
+    createBrowserThreadCollectorEnv({
+      targetStatusId: tweetId,
+      targetAuthor: extractAuthor(),
+      getAuthor: extractAuthorFromArticle,
+      getStatusId: getTweetStatusId,
+      extractTweet: extractSingleTweetFromArticle,
+    })
+  );
 
   window.scrollTo({ top: 0, behavior: 'instant' });
-  await delay(600);
 
-  let allArticles = document.querySelectorAll('article[role="article"]');
-  if (allArticles.length === 0) {
-    const author = extractAuthor();
+  const threadTweets = collection.tweets;
+  const threadAuthor = collection.author || extractAuthor();
+
+  if (threadTweets.length === 0) {
     return {
       type: 'tweet',
-      author,
-      markdown: `# ${author.name} (${author.handle})\n\n*Could not extract tweet content.*\n\n---\n\n> Source: ${sourceUrl}\n> Date: ${date}`,
+      author: threadAuthor,
+      markdown: `# ${threadAuthor.name} (${threadAuthor.handle})\n\n*Could not extract tweet content.*\n\n---\n\n> Source: ${sourceUrl}\n> Date: ${date}`,
       sourceUrl,
       date,
       tweetId,
+      metadata,
     };
   }
 
-  const threadAuthor = extractAuthorFromArticle(allArticles[0]);
-
-  const collected = new Map<string, { text: string; media: string[] }>();
-  let threadDone = false;
-
-  const SCROLL_STEP = Math.max(window.innerHeight * 0.6, 400);
-  const MAX_STEPS = 60;
-
-  for (let step = 0; step < MAX_STEPS && !threadDone; step++) {
-    allArticles = document.querySelectorAll('article[role="article"]');
-    const sizeBefore = collected.size;
-
-    for (const article of allArticles) {
-      const articleAuthor = extractAuthorFromArticle(article);
-      if (
-        articleAuthor.handle.toLowerCase() !==
-        threadAuthor.handle.toLowerCase()
-      ) {
-        threadDone = true;
-        break;
-      }
-      const sid = getTweetStatusId(article);
-      if (!collected.has(sid)) {
-        collected.set(sid, extractSingleTweetFromArticle(article));
-      }
-    }
-
-    if (threadDone) break;
-
-    const atBottom =
-      window.scrollY + window.innerHeight >= document.documentElement.scrollHeight - 50;
-    if (atBottom && collected.size === sizeBefore) break;
-
-    window.scrollBy({ top: SCROLL_STEP, behavior: 'instant' });
-    await delay(400);
-  }
-
-  window.scrollTo({ top: 0, behavior: 'instant' });
-
-  const threadTweets = Array.from(collected.values());
-  const isThread = threadTweets.length > 1;
+  const isThread = threadTweets.length > 1 || !collection.info.complete;
   const parts: string[] = [
     `# ${threadAuthor.name} (${threadAuthor.handle})`,
     '',
@@ -320,5 +322,7 @@ export async function extractTweetAsync(): Promise<ExtractedContent> {
     sourceUrl,
     date,
     tweetId,
+    metadata,
+    thread: isThread ? collection.info : undefined,
   };
 }

--- a/src/shared/post-process.ts
+++ b/src/shared/post-process.ts
@@ -64,6 +64,14 @@ function stripSourceFooter(md: string): string {
   return md.replace(/\n+---\n+> Source:.*\n> Date:.*$/s, '');
 }
 
+function insertBeforeSourceFooter(md: string, block: string): string {
+  const footerRe = /\n+---\n+> Source:/;
+  if (footerRe.test(md)) {
+    return md.replace(footerRe, `\n\n${block}\n\n---\n> Source:`);
+  }
+  return md.replace(/\s*$/, '') + `\n\n${block}\n`;
+}
+
 export function postProcess(
   data: ExtractedContent,
   opts: PostProcessOptions
@@ -81,6 +89,19 @@ export function postProcess(
     lines.push(`source: "${data.sourceUrl}"`);
     lines.push(`date: ${data.date}`);
     lines.push(`type: ${data.type}`);
+    if (data.thread) {
+      lines.push(`thread_complete: ${data.thread.complete}`);
+      lines.push(`thread_stop_reason: "${data.thread.stopReason}"`);
+      lines.push(`thread_collected_count: ${data.thread.collectedCount}`);
+      lines.push(`thread_failed_count: ${data.thread.failedCount}`);
+      lines.push(`thread_steps: ${data.thread.steps}`);
+      lines.push(`thread_duration_ms: ${data.thread.durationMs}`);
+      // Single-post collections labeled type: thread to preserve diagnostics.
+      // The flag makes that disambiguation obvious to readers of the frontmatter.
+      if (!data.thread.complete && data.thread.collectedCount <= 1) {
+        lines.push(`thread_degraded: true`);
+      }
+    }
     if (m) {
       if (m.likes !== undefined) lines.push(`likes: ${m.likes}`);
       if (m.reposts !== undefined) lines.push(`reposts: ${m.reposts}`);
@@ -95,13 +116,20 @@ export function postProcess(
   if (opts.inlineStats && data.metadata) {
     const line = buildStatsLine(data.metadata);
     if (line) {
-      const footerRe = /\n+---\n+> Source:/;
-      if (footerRe.test(finalMarkdown)) {
-        finalMarkdown = finalMarkdown.replace(footerRe, `\n\n${line}\n\n---\n> Source:`);
-      } else {
-        finalMarkdown = finalMarkdown.replace(/\s*$/, '') + `\n\n${line}\n`;
-      }
+      finalMarkdown = insertBeforeSourceFooter(finalMarkdown, line);
     }
+  }
+
+  if (data.thread && !data.thread.complete) {
+    const comment =
+      `<!-- tweet2md: thread extraction may be incomplete; ` +
+      `tweet_id=${data.tweetId}; ` +
+      `stop_reason=${data.thread.stopReason}; ` +
+      `collected=${data.thread.collectedCount}; ` +
+      `failed=${data.thread.failedCount}; ` +
+      `steps=${data.thread.steps}; ` +
+      `duration_ms=${data.thread.durationMs} -->`;
+    finalMarkdown = insertBeforeSourceFooter(finalMarkdown, comment);
   }
 
   const imagesToDownload: { url: string; filename: string }[] = [];

--- a/src/types/messages.ts
+++ b/src/types/messages.ts
@@ -11,6 +11,22 @@ export interface TweetMetadata {
   views?: number;
 }
 
+export type ThreadStopReason =
+  | 'reply_boundary'
+  | 'bottom'
+  | 'no_new_posts'
+  | 'max_steps'
+  | 'max_duration';
+
+export interface ThreadExtractionInfo {
+  complete: boolean;
+  stopReason: ThreadStopReason;
+  collectedCount: number;
+  failedCount: number;
+  steps: number;
+  durationMs: number;
+}
+
 export interface ExtractedContent {
   type: 'tweet' | 'thread' | 'article';
   author: AuthorInfo;
@@ -20,6 +36,7 @@ export interface ExtractedContent {
   date: string;
   tweetId: string;
   metadata?: TweetMetadata;
+  thread?: ThreadExtractionInfo;
 }
 
 export interface ExtractRequest {

--- a/tests/post-process.test.ts
+++ b/tests/post-process.test.ts
@@ -29,3 +29,149 @@ describe('postProcess() image downloads', () => {
     ]);
   });
 });
+
+function threadContent(overrides: Partial<ExtractedContent> = {}): ExtractedContent {
+  return {
+    type: 'thread',
+    author: { name: 'Example', handle: '@example' },
+    markdown: '# Example (@example)\n\nfirst\n\n---\n\n> Source: https://x.com/example/status/123\n> Date: 2026-05-11T00:00:00.000Z',
+    sourceUrl: 'https://x.com/example/status/123',
+    date: '2026-05-11T00:00:00.000Z',
+    tweetId: '123',
+    thread: {
+      complete: true,
+      stopReason: 'reply_boundary',
+      collectedCount: 3,
+      failedCount: 0,
+      steps: 4,
+      durationMs: 2200,
+    },
+    ...overrides,
+  };
+}
+
+describe('postProcess() thread diagnostics', () => {
+  it('emits thread diagnostics in YAML metadata for complete threads', () => {
+    const result = postProcess(threadContent(), {
+      includeMetadata: true,
+      downloadImages: false,
+    });
+
+    expect(result.markdown).toContain('type: thread');
+    expect(result.markdown).toContain('thread_complete: true');
+    expect(result.markdown).toContain('thread_stop_reason: "reply_boundary"');
+    expect(result.markdown).toContain('thread_collected_count: 3');
+    expect(result.markdown).toContain('thread_failed_count: 0');
+    expect(result.markdown).toContain('thread_steps: 4');
+    expect(result.markdown).toContain('thread_duration_ms: 2200');
+    expect(result.markdown).not.toContain('tweet2md: thread extraction may be incomplete');
+  });
+
+  it('adds a quiet comment for incomplete threads', () => {
+    const result = postProcess(
+      threadContent({
+        thread: {
+          complete: false,
+          stopReason: 'max_steps',
+          collectedCount: 12,
+          failedCount: 1,
+          steps: 60,
+          durationMs: 24750,
+        },
+      }),
+      { includeMetadata: true, downloadImages: false }
+    );
+
+    expect(result.markdown).toContain('thread_complete: false');
+    expect(result.markdown).toContain('thread_stop_reason: "max_steps"');
+    expect(result.markdown).toContain(
+      '<!-- tweet2md: thread extraction may be incomplete; tweet_id=123; stop_reason=max_steps; collected=12; failed=1; steps=60; duration_ms=24750 -->'
+    );
+  });
+
+  it('adds the incomplete comment even when YAML metadata is disabled', () => {
+    const result = postProcess(
+      threadContent({
+        thread: {
+          complete: false,
+          stopReason: 'max_duration',
+          collectedCount: 2,
+          failedCount: 0,
+          steps: 8,
+          durationMs: 25000,
+        },
+      }),
+      { includeMetadata: false, downloadImages: false }
+    );
+
+    expect(result.markdown).not.toContain('thread_complete:');
+    expect(result.markdown).toContain('tweet2md: thread extraction may be incomplete');
+  });
+
+  it('flags a degraded single-post collection in frontmatter', () => {
+    const result = postProcess(
+      threadContent({
+        thread: {
+          complete: false,
+          stopReason: 'max_duration',
+          collectedCount: 1,
+          failedCount: 0,
+          steps: 4,
+          durationMs: 25000,
+        },
+      }),
+      { includeMetadata: true, downloadImages: false }
+    );
+
+    expect(result.markdown).toContain('thread_complete: false');
+    expect(result.markdown).toContain('thread_degraded: true');
+    expect(result.markdown).toContain('tweet2md: thread extraction may be incomplete');
+  });
+
+  it('omits thread_degraded for multi-post incomplete collections', () => {
+    const result = postProcess(
+      threadContent({
+        thread: {
+          complete: false,
+          stopReason: 'max_steps',
+          collectedCount: 12,
+          failedCount: 0,
+          steps: 60,
+          durationMs: 24000,
+        },
+      }),
+      { includeMetadata: true, downloadImages: false }
+    );
+
+    expect(result.markdown).not.toContain('thread_degraded');
+  });
+
+  it('preserves inline stats and the incomplete-thread comment together', () => {
+    const result = postProcess(
+      threadContent({
+        metadata: { likes: 1234, replies: 5, reposts: 10, views: 50_000 },
+        thread: {
+          complete: false,
+          stopReason: 'max_steps',
+          collectedCount: 8,
+          failedCount: 1,
+          steps: 60,
+          durationMs: 24500,
+        },
+      }),
+      { includeMetadata: false, downloadImages: false, inlineStats: true }
+    );
+
+    expect(result.markdown).toContain('💬 5');
+    expect(result.markdown).toContain('❤️ 1.2K');
+    expect(result.markdown).toContain('tweet2md: thread extraction may be incomplete');
+    // Both blocks must land before the source footer, not after.
+    const sourceIdx = result.markdown.indexOf('> Source:');
+    const statsIdx = result.markdown.indexOf('💬');
+    const commentIdx = result.markdown.indexOf('tweet2md:');
+    expect(statsIdx).toBeGreaterThan(-1);
+    expect(commentIdx).toBeGreaterThan(-1);
+    expect(statsIdx).toBeLessThan(sourceIdx);
+    expect(commentIdx).toBeLessThan(sourceIdx);
+  });
+});

--- a/tests/thread-collector.test.ts
+++ b/tests/thread-collector.test.ts
@@ -1,0 +1,518 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  collectThreadTweets,
+  DEFAULT_THREAD_COLLECTOR_OPTIONS,
+  hasRelevantArticleMutation,
+  isPromotedArticle,
+  type ThreadCollectorEnv,
+  waitForRelevantArticlesToSettle,
+} from '../src/content/thread-collector';
+
+function element(html: string): Element {
+  const root = document.createElement('div');
+  root.innerHTML = html.trim();
+  return root.firstElementChild as Element;
+}
+
+function childListRecord(addedNodes: Node[]): MutationRecord {
+  return {
+    type: 'childList',
+    target: document.body,
+    addedNodes: addedNodes as unknown as NodeList,
+    removedNodes: [] as unknown as NodeList,
+    previousSibling: null,
+    nextSibling: null,
+    attributeName: null,
+    attributeNamespace: null,
+    oldValue: null,
+  } as MutationRecord;
+}
+
+interface FakeArticle {
+  id: string;
+  handle: string;
+  promoted?: boolean;
+  fail?: boolean;
+}
+
+function fakeEnv(
+  cycles: FakeArticle[][],
+  opts: {
+    bottomAtCycle?: number;
+    nowStepMs?: number;
+    targetStatusId?: string;
+    targetAuthor?: { name: string; handle: string };
+    scrollToTopCycle?: number;
+  } = {}
+): ThreadCollectorEnv<FakeArticle> & { scrolls: number[] } {
+  let cycle = 0;
+  let now = 0;
+  const scrolls: number[] = [];
+  const nowStepMs = opts.nowStepMs ?? 100;
+
+  return {
+    scrolls,
+    targetStatusId: opts.targetStatusId,
+    targetAuthor: opts.targetAuthor,
+    queryArticles: () => cycles[Math.min(cycle, cycles.length - 1)] || [],
+    scrollToTop: () => {
+      if (opts.scrollToTopCycle !== undefined) {
+        cycle = opts.scrollToTopCycle;
+      }
+    },
+    scrollBy: (amount) => {
+      scrolls.push(amount);
+      cycle += 1;
+    },
+    isAtBottom: () => opts.bottomAtCycle !== undefined && cycle >= opts.bottomAtCycle,
+    now: () => now,
+    waitForRelevantArticlesToSettle: async () => {
+      now += nowStepMs;
+    },
+    getScrollStep: () => 400,
+    getAuthor: (article) => ({ name: article.handle.slice(1), handle: article.handle }),
+    getStatusId: (article) => article.id,
+    isPromotedArticle: (article) => article.promoted === true,
+    extractTweet: (article) => {
+      if (article.fail) throw new Error(`failed ${article.id}`);
+      return { text: `tweet ${article.id}`, media: [] };
+    },
+  };
+}
+
+describe('thread collector helpers', () => {
+  it('detects relevant article mutations only from added article elements', () => {
+    const article = element('<article role="article"><div>tweet</div></article>');
+    const wrapper = element('<div><article role="article"><div>tweet</div></article></div>');
+    const counter = document.createTextNode('5 likes');
+
+    expect(hasRelevantArticleMutation([childListRecord([article])])).toBe(true);
+    expect(hasRelevantArticleMutation([childListRecord([wrapper])])).toBe(true);
+    expect(hasRelevantArticleMutation([childListRecord([counter])])).toBe(false);
+  });
+
+  it('treats promoted articles as state-neutral skips', () => {
+    const promotedByMarker = element(
+      '<article role="article"><div data-testid="placementTracking"></div><span>Promoted</span></article>'
+    );
+    const promotedByLabel = element(
+      '<article role="article"><div><span>Promoted</span></div></article>'
+    );
+    const normal = element('<article role="article"><div data-testid="tweetText">hello</div></article>');
+    const normalWithNestedPromotedText = element(
+      '<article role="article"><div data-testid="tweetText">hello</div><div role="link"><span>Promoted</span></div></article>'
+    );
+
+    expect(isPromotedArticle(promotedByMarker)).toBe(true);
+    expect(isPromotedArticle(promotedByLabel)).toBe(true);
+    expect(isPromotedArticle(normal)).toBe(false);
+    expect(isPromotedArticle(normalWithNestedPromotedText)).toBe(false);
+  });
+
+  it('matches the modern bare "Ad" label and localized variants', () => {
+    const adLabel = element('<article role="article"><div><span>Ad</span></div></article>');
+    const werbung = element('<article role="article"><div><span>Werbung</span></div></article>');
+    const patrocinado = element('<article role="article"><div><span>Patrocinado</span></div></article>');
+    const japanese = element('<article role="article"><div><span>広告</span></div></article>');
+    const chineseSimplified = element('<article role="article"><div><span>广告</span></div></article>');
+    const unrelatedForeign = element('<article role="article"><div><span>Hola</span></div></article>');
+    const tweetContainingAdWord = element(
+      '<article role="article"><div data-testid="tweetText">had a bad ad day</div></article>'
+    );
+
+    expect(isPromotedArticle(adLabel)).toBe(true);
+    expect(isPromotedArticle(werbung)).toBe(true);
+    expect(isPromotedArticle(patrocinado)).toBe(true);
+    expect(isPromotedArticle(japanese)).toBe(true);
+    expect(isPromotedArticle(chineseSimplified)).toBe(true);
+    expect(isPromotedArticle(unrelatedForeign)).toBe(false);
+    expect(isPromotedArticle(tweetContainingAdWord)).toBe(false);
+  });
+
+  it('matches a promoted tweet that has both a body and an ad label', () => {
+    // Real-world shape: an ad without `placementTracking` but with the
+    // visible "Ad" / "Promoted" label sitting in the header next to the
+    // username, alongside a tweetText body containing the ad copy.
+    const promotedWithBody = element(
+      '<article role="article">' +
+        '<div><span>Brand</span><span>Ad</span></div>' +
+        '<div data-testid="tweetText">Buy our product</div>' +
+      '</article>'
+    );
+    const promotedWithBodyLocalized = element(
+      '<article role="article">' +
+        '<div><span>Marke</span><span>Werbung</span></div>' +
+        '<div data-testid="tweetText">Kauf unser Produkt</div>' +
+      '</article>'
+    );
+
+    expect(isPromotedArticle(promotedWithBody)).toBe(true);
+    expect(isPromotedArticle(promotedWithBodyLocalized)).toBe(true);
+  });
+});
+
+// If fake timers become flaky with a future JSDOM/Vitest upgrade, keep the
+// assertions but switch these wait-helper tests to real timers with small
+// deadlines. MutationObserver delivery is microtask-based in JSDOM.
+describe('waitForRelevantArticlesToSettle()', () => {
+  it('resolves at mutationTimeoutMs when no relevant article mutation arrives', async () => {
+    vi.useFakeTimers();
+    const root = document.createElement('div');
+    document.body.appendChild(root);
+
+    try {
+      const promise = waitForRelevantArticlesToSettle(
+        root,
+        Date.now() + 10_000,
+        {
+          ...DEFAULT_THREAD_COLLECTOR_OPTIONS,
+          settleMs: 500,
+          mutationTimeoutMs: 100,
+          maxWaitMs: 2_000,
+        }
+      );
+
+      root.appendChild(document.createElement('span'));
+      await vi.advanceTimersByTimeAsync(99);
+
+      let resolved = false;
+      promise.then(() => {
+        resolved = true;
+      });
+      await Promise.resolve();
+      expect(resolved).toBe(false);
+
+      await vi.advanceTimersByTimeAsync(1);
+      await expect(promise).resolves.toBeUndefined();
+    } finally {
+      root.remove();
+      vi.useRealTimers();
+    }
+  });
+
+  it('resolves at maxWaitMs even if relevant article mutations keep arriving', async () => {
+    vi.useFakeTimers();
+    const root = document.createElement('div');
+    document.body.appendChild(root);
+
+    try {
+      const promise = waitForRelevantArticlesToSettle(
+        root,
+        Date.now() + 10_000,
+        {
+          ...DEFAULT_THREAD_COLLECTOR_OPTIONS,
+          settleMs: 500,
+          mutationTimeoutMs: 1_000,
+          maxWaitMs: 200,
+        }
+      );
+
+      root.appendChild(element('<article role="article"><div>one</div></article>'));
+      await vi.advanceTimersByTimeAsync(75);
+      root.appendChild(element('<article role="article"><div>two</div></article>'));
+      await vi.advanceTimersByTimeAsync(75);
+      root.appendChild(element('<article role="article"><div>three</div></article>'));
+      await vi.advanceTimersByTimeAsync(200);
+
+      await expect(promise).resolves.toBeUndefined();
+    } finally {
+      root.remove();
+      vi.useRealTimers();
+    }
+  });
+});
+
+describe('collectThreadTweets()', () => {
+  it('dedupes same-author tweets and completes at a confirmed reply boundary', async () => {
+    const env = fakeEnv([
+      [{ id: '1', handle: '@example' }],
+      [{ id: '1', handle: '@example' }, { id: '2', handle: '@example' }],
+      [{ id: '2', handle: '@example' }, { id: 'reply', handle: '@other' }],
+      [{ id: 'reply', handle: '@other' }],
+    ]);
+
+    const result = await collectThreadTweets(env);
+
+    expect(result.author?.handle).toBe('@example');
+    expect(result.tweets.map((t) => t.id)).toEqual(['1', '2']);
+    expect(result.info).toMatchObject({
+      complete: true,
+      stopReason: 'reply_boundary',
+      collectedCount: 2,
+      failedCount: 0,
+    });
+  });
+
+  it('anchors the thread author to the target status when a reply appears first', async () => {
+    const env = fakeEnv(
+      [
+        [
+          { id: 'reply', handle: '@reply' },
+          { id: 'root', handle: '@example' },
+        ],
+        [{ id: 'reply', handle: '@reply' }],
+      ],
+      { targetStatusId: 'root' }
+    );
+
+    const result = await collectThreadTweets(env);
+
+    expect(result.author?.handle).toBe('@example');
+    expect(result.tweets.map((t) => t.id)).toEqual(['root']);
+    expect(result.info.stopReason).toBe('reply_boundary');
+  });
+
+  it('does not skip the target status even when it matches promoted heuristics', async () => {
+    const env = fakeEnv(
+      [
+        [
+          { id: 'root', handle: '@example', promoted: true },
+          { id: 'reply', handle: '@reply' },
+        ],
+        [{ id: 'reply', handle: '@reply' }],
+      ],
+      { targetStatusId: 'root' }
+    );
+
+    const result = await collectThreadTweets(env);
+
+    expect(result.author?.handle).toBe('@example');
+    expect(result.tweets.map((t) => t.id)).toEqual(['root']);
+    expect(result.info.stopReason).toBe('reply_boundary');
+  });
+
+  it('falls back to the focused page author when the target status id is unavailable', async () => {
+    const env = fakeEnv(
+      [
+        [
+          { id: 'reply', handle: '@reply' },
+          { id: 'root-dom-fallback-id', handle: '@example' },
+        ],
+        [{ id: 'reply', handle: '@reply' }],
+      ],
+      {
+        targetStatusId: 'root-from-url',
+        targetAuthor: { name: 'Example', handle: '@example' },
+      }
+    );
+
+    const result = await collectThreadTweets(env);
+
+    expect(result.author?.handle).toBe('@example');
+    expect(result.tweets.map((t) => t.id)).toEqual(['root-dom-fallback-id']);
+    expect(result.info.stopReason).toBe('reply_boundary');
+  });
+
+  it('keeps a pre-scroll target tweet when scrolling temporarily unmounts articles', async () => {
+    const env = fakeEnv(
+      [
+        [{ id: 'root', handle: '@example' }],
+        [],
+        [],
+      ],
+      {
+        targetStatusId: 'root',
+        scrollToTopCycle: 1,
+      }
+    );
+
+    const result = await collectThreadTweets(env, { maxSteps: 4 });
+
+    expect(result.author?.handle).toBe('@example');
+    expect(result.tweets.map((t) => t.id)).toEqual(['root']);
+    expect(result.info.stopReason).toBe('no_new_posts');
+    expect(result.info.complete).toBe(true);
+  });
+
+  it('does not re-extract the target when it reappears after a transient unmount', async () => {
+    const baseEnv = fakeEnv(
+      [
+        [{ id: 'root', handle: '@example' }],
+        [],
+        [{ id: 'root', handle: '@example' }],
+        [{ id: 'root', handle: '@example' }],
+      ],
+      {
+        targetStatusId: 'root',
+        scrollToTopCycle: 1,
+      }
+    );
+    const extractCalls: string[] = [];
+    const env: typeof baseEnv = {
+      ...baseEnv,
+      extractTweet: (article) => {
+        extractCalls.push(article.id);
+        return baseEnv.extractTweet(article);
+      },
+    };
+
+    const result = await collectThreadTweets(env, { maxSteps: 5 });
+
+    expect(result.tweets.map((t) => t.id)).toEqual(['root']);
+    expect(extractCalls).toEqual(['root']);
+    expect(result.info.stopReason).toBe('no_new_posts');
+    expect(result.info.complete).toBe(true);
+  });
+
+  it('clears a pending boundary when a later same-author tweet appears', async () => {
+    const env = fakeEnv([
+      [{ id: '1', handle: '@example' }],
+      [{ id: 'other', handle: '@other' }],
+      [{ id: '2', handle: '@example' }],
+      [{ id: 'other2', handle: '@other' }],
+      [{ id: 'other2', handle: '@other' }],
+    ]);
+
+    const result = await collectThreadTweets(env);
+
+    expect(result.tweets.map((t) => t.id)).toEqual(['1', '2']);
+    expect(result.info.stopReason).toBe('reply_boundary');
+    expect(result.info.complete).toBe(true);
+  });
+
+  it('clears a pending boundary for a same-author tweet even when extraction fails', async () => {
+    const env = fakeEnv([
+      [{ id: '1', handle: '@example' }],
+      [{ id: 'other', handle: '@other' }],
+      [{ id: '2', handle: '@example', fail: true }],
+      [{ id: 'other2', handle: '@other' }],
+      [{ id: 'other2', handle: '@other' }],
+    ]);
+
+    const result = await collectThreadTweets(env);
+
+    expect(result.tweets.map((t) => t.id)).toEqual(['1']);
+    expect(result.info.failedCount).toBe(1);
+    expect(result.info.stopReason).toBe('reply_boundary');
+    expect(result.info.complete).toBe(false);
+  });
+
+  it('treats promoted articles as absent from progress and boundary state', async () => {
+    const env = fakeEnv([
+      [{ id: '1', handle: '@example' }],
+      [{ id: 'ad', handle: '@brand', promoted: true }],
+      [{ id: 'ad2', handle: '@brand', promoted: true }],
+      [{ id: '2', handle: '@example' }],
+      [{ id: 'other', handle: '@other' }],
+      [{ id: 'other', handle: '@other' }],
+    ]);
+
+    const result = await collectThreadTweets(env);
+
+    expect(result.tweets.map((t) => t.id)).toEqual(['1', '2']);
+    expect(result.info.stopReason).toBe('reply_boundary');
+  });
+
+  it('does not reset quiet-cycle state for ad-only scans', async () => {
+    const env = fakeEnv([
+      [{ id: '1', handle: '@example' }],
+      [],
+      [{ id: 'ad', handle: '@brand', promoted: true }],
+      [],
+    ]);
+
+    const result = await collectThreadTweets(env, { maxSteps: 5 });
+
+    expect(result.tweets.map((t) => t.id)).toEqual(['1']);
+    expect(result.info.stopReason).toBe('no_new_posts');
+    expect(result.info.complete).toBe(true);
+  });
+
+  it('distinguishes bottom from no_new_posts', async () => {
+    const bottomEnv = fakeEnv(
+      [
+        [{ id: '1', handle: '@example' }],
+        [{ id: '1', handle: '@example' }],
+      ],
+      { bottomAtCycle: 1 }
+    );
+
+    const bottom = await collectThreadTweets(bottomEnv);
+    expect(bottom.info.stopReason).toBe('bottom');
+
+    const quietEnv = fakeEnv([
+      [{ id: '1', handle: '@example' }],
+      [{ id: '1', handle: '@example' }],
+      [{ id: '1', handle: '@example' }],
+    ]);
+
+    const quiet = await collectThreadTweets(quietEnv, { maxSteps: 4 });
+    expect(quiet.info.stopReason).toBe('no_new_posts');
+  });
+
+  it('counts empty scans after a collected tweet toward no_new_posts', async () => {
+    const env = fakeEnv([
+      [{ id: '1', handle: '@example' }],
+      [],
+      [],
+    ]);
+
+    const result = await collectThreadTweets(env, { maxSteps: 5 });
+
+    expect(result.tweets.map((t) => t.id)).toEqual(['1']);
+    expect(result.info.stopReason).toBe('no_new_posts');
+    expect(result.info.complete).toBe(true);
+  });
+
+  it('clamps durationMs to non-negative when the clock moves backwards', async () => {
+    const env = fakeEnv(
+      [
+        [{ id: '1', handle: '@example' }],
+        [{ id: '1', handle: '@example' }],
+      ],
+      { nowStepMs: -500 }
+    );
+
+    const result = await collectThreadTweets(env, { maxSteps: 3 });
+
+    expect(result.info.durationMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it('marks max_steps and max_duration incomplete', async () => {
+    const stepsEnv = fakeEnv([
+      [{ id: '1', handle: '@example' }],
+      [{ id: '2', handle: '@example' }],
+      [{ id: '3', handle: '@example' }],
+    ]);
+
+    const steps = await collectThreadTweets(stepsEnv, { maxSteps: 2 });
+    expect(steps.info.stopReason).toBe('max_steps');
+    expect(steps.info.complete).toBe(false);
+
+    const durationEnv = fakeEnv(
+      [
+        [{ id: '1', handle: '@example' }],
+        [{ id: '2', handle: '@example' }],
+      ],
+      { nowStepMs: 30_000 }
+    );
+
+    const duration = await collectThreadTweets(durationEnv, { maxDurationMs: 1 });
+    expect(duration.info.stopReason).toBe('max_duration');
+    expect(duration.info.complete).toBe(false);
+  });
+
+  it('keeps incomplete diagnostics for a one-post collection', async () => {
+    const env = fakeEnv([
+      [{ id: '1', handle: '@example' }],
+      [{ id: '2', handle: '@example' }],
+    ]);
+
+    const result = await collectThreadTweets(env, { maxSteps: 1 });
+
+    expect(result.tweets.map((t) => t.id)).toEqual(['1']);
+    expect(result.info.stopReason).toBe('max_steps');
+    expect(result.info.complete).toBe(false);
+  });
+
+  it('stops after the first settled scan when no articles render', async () => {
+    const env = fakeEnv([[], [], []], { nowStepMs: 100 });
+
+    const result = await collectThreadTweets(env, { maxDurationMs: 25_000 });
+
+    expect(result.tweets).toEqual([]);
+    expect(result.info.stopReason).toBe('no_new_posts');
+    expect(result.info.steps).toBe(1);
+    expect(env.scrolls).toEqual([]);
+  });
+});

--- a/tests/tweet-media.test.ts
+++ b/tests/tweet-media.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { extractTweetAsync } from '../src/content/tweet';
+
+function setStatusUrl(path: string): void {
+  window.history.pushState(null, '', path);
+}
+
+function setBody(html: string): void {
+  document.body.innerHTML = html;
+}
+
+afterEach(() => {
+  document.body.innerHTML = '';
+  vi.restoreAllMocks();
+  vi.useRealTimers();
+});
+
+describe('tweet media extraction', () => {
+  it('does not emit a video poster thumbnail as both an image and a video', async () => {
+    vi.useFakeTimers();
+    vi.spyOn(window, 'scrollTo').mockImplementation(() => {});
+    vi.spyOn(window, 'scrollBy').mockImplementation(() => {});
+    setStatusUrl('/example/status/123');
+
+    const poster = 'https://pbs.twimg.com/amplify_video_thumb/123/img/poster.jpg';
+    setBody(`
+      <main>
+        <article role="article">
+          <div data-testid="User-Name">
+            <a href="/example">Example</a>
+            <a href="/example">@example</a>
+          </div>
+          <a href="/example/status/123"><time datetime="2026-05-11T12:00:00.000Z"></time></a>
+          <div data-testid="tweetText">hello video</div>
+          <div data-testid="tweetPhoto">
+            <img src="https://pbs.twimg.com/media/photo?format=jpg&name=small" />
+          </div>
+          <div data-testid="tweetPhoto">
+            <img src="${poster}" />
+            <video poster="${poster}"></video>
+          </div>
+        </article>
+      </main>
+    `);
+
+    const extraction = extractTweetAsync();
+    await vi.advanceTimersByTimeAsync(1_250);
+    const result = await extraction;
+
+    expect(result.markdown).toContain(
+      '![Image](https://pbs.twimg.com/media/photo?format=jpg&name=large)'
+    );
+    expect(result.markdown).not.toContain(`![Image](${poster})`);
+    expect(result.markdown).toContain(`[🎥 Video](${poster})`);
+  });
+});

--- a/tests/tweet-metadata.test.ts
+++ b/tests/tweet-metadata.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { extract } from '../src/content/content';
+import { extractEngagementMetadata } from '../src/content/tweet';
+
+function setStatusUrl(path: string): void {
+  window.history.pushState(null, '', path);
+}
+
+function setBody(html: string): void {
+  document.body.innerHTML = html;
+}
+
+afterEach(() => {
+  document.body.innerHTML = '';
+  vi.restoreAllMocks();
+  vi.useRealTimers();
+});
+
+describe('tweet metadata extraction', () => {
+  it('parses abbreviated X engagement counts', () => {
+    setBody(`
+      <article role="article">
+        <div role="group" aria-label="24 replies, 32 reposts, 797 likes, 1.5K bookmarks, 122.4K views"></div>
+      </article>
+    `);
+
+    expect(extractEngagementMetadata(document.body)).toEqual({
+      replies: 24,
+      reposts: 32,
+      likes: 797,
+      bookmarks: 1500,
+      views: 122400,
+    });
+  });
+
+  it('uses the target status article for metadata when another article is mounted first', async () => {
+    vi.useFakeTimers();
+    vi.spyOn(window, 'scrollTo').mockImplementation(() => {});
+    vi.spyOn(window, 'scrollBy').mockImplementation(() => {});
+    setStatusUrl('/david__booth/status/2051021016361836837');
+
+    setBody(`
+      <main>
+        <article role="article">
+          <div data-testid="User-Name">
+            <a href="/reply">Reply Person</a>
+            <a href="/reply">@reply</a>
+          </div>
+          <a href="/reply/status/999"><time datetime="2026-05-11T12:00:00.000Z"></time></a>
+          <div data-testid="tweetText">mounted before the target</div>
+          <div role="group" aria-label="1 reply, 14 likes, 11 bookmarks, 9,231 views"></div>
+        </article>
+        <article role="article">
+          <div data-testid="User-Name">
+            <a href="/david__booth">David Booth</a>
+            <a href="/david__booth">@david__booth</a>
+          </div>
+          <a href="/david__booth/status/2051021016361836837"><time datetime="2026-05-03T19:28:11.000Z"></time></a>
+          <div data-testid="tweetText">root thread tweet</div>
+          <div role="group" aria-label="24 replies, 32 reposts, 797 likes, 1.5K bookmarks, 122.4K views"></div>
+        </article>
+      </main>
+    `);
+
+    const extraction = extract({ includeMetadata: true });
+    await vi.advanceTimersByTimeAsync(3_000);
+    const response = await extraction;
+
+    expect(response.success).toBe(true);
+    if (!response.success || !response.data) return;
+
+    expect(response.data.metadata).toEqual({
+      replies: 24,
+      reposts: 32,
+      likes: 797,
+      bookmarks: 1500,
+      views: 122400,
+    });
+  });
+});


### PR DESCRIPTION
> **Note on branch name:** This branch is named `codex/background-download-hardening` for historical reasons in my fork — the diff is entirely about thread-extraction reliability and contains no background-download changes. (Tried renaming it; GitHub auto-closes cross-fork PRs when the source branch is renamed, so I reverted.)

## Summary
- Replaces fixed post-scroll sleeps with a bounded, article-aware collector for X.com thread timelines.
- Adds completion diagnostics to thread exports so partial captures identify the stop reason, collected count, failed count, step count, and duration.
- Local-first: no X API calls, no new permissions, no new dependencies.

## Context
The old extractor stopped on the first different-author article and relied on blind delays after scrolling. That is fragile on X.com because timelines are virtualized, ads and reply stubs can appear between same-author posts, and DOM rendering can lag behind scroll position. This PR introduces a small collector module that waits only for relevant article mutations, confirms reply boundaries with a follow-up pass, skips promoted articles as state-neutral, and returns bounded diagnostics when it cannot prove completion.

The design intentionally stays best-effort and browser-local. It does not attempt perfect conversation reconstruction or use network/API data; it improves the existing DOM extractor while preserving the extension privacy model.

## Notes for reviewers
- Single-tweet exports still avoid the thread metadata path unless extraction is degraded; degraded one-post captures may be labeled `type: thread` so diagnostics are preserved. A `thread_degraded: true` field is added to the YAML frontmatter in that specific case so the disambiguation is obvious to readers.
- Deleted, broken, or indefinitely loading status pages with no article elements exit after the first bounded settled scan instead of waiting for the full wall-clock budget.
- The promoted-tweet skip heuristic uses `data-testid="placementTracking"` as the primary structural signal, with a locale-tolerant label fallback (`Ad`, `Promoted`, `広告`, `Werbung`, `Patrocinado`, `广告`, and more) for ad formats that lack the data-testid. The fallback scans label nodes outside `tweetText` and outside embedded `role="link"` subtrees, so it correctly identifies real ads (which still contain tweetText) without false-positive-ing on tweets that quote a promoted post or mention ad-related words.

## Test plan
- `npm test` — 6 files, 59 tests passed
- `npm run build` — clean, `dist/` rebuilt

## Manual smoke suggested
- Load `dist/` unpacked in Chrome.
- Export a single tweet through the toolbar popup and confirm it completes quickly.
- Export a same-author multi-post thread through the inline icon with metadata enabled and confirm thread diagnostic fields are present.