### PR TITLE
ci: add GitHub Actions workflow for tests and build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  test-and-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - run: npm ci
+
+      - run: npm test
+
+      - run: npm run build


### PR DESCRIPTION
## Summary
Adds a small CI workflow that runs `npm test` (vitest) and `npm run build` on every PR targeting `main` and every push to `main`.

## Rationale
There's no automated check on PRs today, which means reviewers can't tell at a glance whether a contribution actually compiles or passes the existing test suite. This workflow is the minimum that closes that gap without expanding the project's surface area.

## Design choices
- **Node 20 LTS** — current active LTS, matches what most contributors will have locally.
- **`actions/setup-node@v4`'s built-in `cache: npm`** — no extra cache action needed, picks up `package-lock.json` automatically.
- **`permissions: contents: read`** — least privilege; the job only needs to read the repo.
- **`concurrency` with `cancel-in-progress: true`** — kills redundant runs when a PR is force-pushed, saving CI minutes.
- **Triggers**: `pull_request` to `main` + `push` to `main`. No scheduled runs, no matrix.

## Verified locally
- `npm ci && npm test` → 3 test files, 28 tests pass on `main`
- `npm run build` → `dist/` rebuilt cleanly

## Notes
- No dependencies added, no project source changed, no permissions or manifest changes — the only file is `.github/workflows/ci.yml`.
- Happy to bump Node version, add a matrix, or change triggers if you'd prefer something different.

🤖 Generated with [Claude Code](https://claude.com/claude-code)