### PR TITLE
feat: Support link card preview and metadata extraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Added
+
+- **Link Cards**: External link previews in tweets are now captured. Extracts the title, description, and source domain, and embeds the Open Graph preview image (which is intentionally kept as a remote URL to prevent downloading third-party thumbnails locally).
+
 ## [1.4.1] - 2026-05-12
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@
 - **X Articles** — Full support for long-form Articles (formerly Notes) with headings, lists, and code blocks
 - **Tweets & Threads** — Extract tweets, nested threads, and quote tweets into clean Markdown
 - **Quoted Posts** — Preserve quoted-post structure and context in a reusable format, with the original author's name and handle
+- **Link Cards** — Capture external link previews including the title, description, domain, and high-res Open Graph image
 - **Local Image Downloads** — Download embedded X media locally alongside your `.md` file to prevent link rot
 - **YAML Frontmatter** — Rich metadata with author, handle, date, source URL, content type, and engagement stats (likes, reposts, replies, bookmarks, views)
 - **Inline Engagement Stats** — Optional X-style row in the Markdown body: `💬 284 · 🔁 1.5K · ❤️ 8K · 🔖 253 · 👁 100K`

--- a/src/content/tweet.ts
+++ b/src/content/tweet.ts
@@ -270,6 +270,10 @@ function extractSingleTweetFromArticle(
       let title = '';
       let description = '';
 
+      const mediaBlock = cardWrapper.querySelector(
+        '[data-testid="card.layoutSmall.media"], [data-testid="card.layoutLarge.media"]'
+      );
+
       if (detail) {
         // Detail block holds domain / title / description as separate divs.
         const detailDivs = detail.querySelectorAll('div[dir="auto"]');
@@ -284,9 +288,6 @@ function extractSingleTweetFromArticle(
         // Media-only card: title sits as an overlay inside the media block
         // (often dir="ltr"); the domain isn't rendered inside the wrapper, so
         // derive it from the link's hostname.
-        const mediaBlock = cardWrapper.querySelector(
-          '[data-testid="card.layoutSmall.media"], [data-testid="card.layoutLarge.media"]'
-        );
         const overlay = mediaBlock?.querySelector('div[dir="ltr"], div[dir="auto"]');
         title = overlay?.textContent?.trim() || '';
         if (href) {
@@ -298,8 +299,22 @@ function extractSingleTweetFromArticle(
         }
       }
 
+      // OG preview image. Alt is the sentinel `Link card preview` so the
+      // download-images pass in post-process can leave it as a remote URL —
+      // we render it but don't pull it into the local sibling folder.
+      let previewImg = '';
+      const previewImgEl = mediaBlock?.querySelector('img');
+      if (previewImgEl) {
+        let src = (previewImgEl as HTMLImageElement).src || '';
+        if (src.includes('pbs.twimg.com')) {
+          src = src.replace(/&name=\w+/, '&name=large');
+        }
+        if (src) previewImg = `![Link card preview](${src})`;
+      }
+
       if (title) {
         const parts: string[] = [];
+        if (previewImg) parts.push(previewImg);
         if (href) {
           parts.push(`🔗 [**${title}**](${href})`);
         } else {

--- a/src/content/tweet.ts
+++ b/src/content/tweet.ts
@@ -321,7 +321,7 @@ function extractSingleTweetFromArticle(
           parts.push(`🔗 **${title}**`);
         }
         if (description) parts.push(description);
-        if (domain) parts.push(`_${domain}_`);
+        if (domain) parts.push(`_From ${domain}_`);
         embeddedMd = `\n\n> ${parts.join('\n> \n> ')}`;
         embedContainers.push(cardWrapper);
       }

--- a/src/content/tweet.ts
+++ b/src/content/tweet.ts
@@ -265,22 +265,36 @@ function extractSingleTweetFromArticle(
       const detail = cardWrapper.querySelector(
         '[data-testid="card.layoutSmall.detail"], [data-testid="card.layoutLarge.detail"]'
       );
-      const detailDivs = detail
-        ? detail.querySelectorAll('div[dir="auto"]')
-        : cardWrapper.querySelectorAll('div[dir="auto"]');
 
       let domain = '';
       let title = '';
       let description = '';
-      for (const d of detailDivs) {
-        const t = d.textContent?.trim() || '';
-        if (!t) continue;
-        if (!domain) {
-          domain = t;
-        } else if (!title) {
-          title = t;
-        } else if (!description) {
-          description = t;
+
+      if (detail) {
+        // Detail block holds domain / title / description as separate divs.
+        const detailDivs = detail.querySelectorAll('div[dir="auto"]');
+        for (const d of detailDivs) {
+          const t = d.textContent?.trim() || '';
+          if (!t) continue;
+          if (!domain) domain = t;
+          else if (!title) title = t;
+          else if (!description) description = t;
+        }
+      } else {
+        // Media-only card: title sits as an overlay inside the media block
+        // (often dir="ltr"); the domain isn't rendered inside the wrapper, so
+        // derive it from the link's hostname.
+        const mediaBlock = cardWrapper.querySelector(
+          '[data-testid="card.layoutSmall.media"], [data-testid="card.layoutLarge.media"]'
+        );
+        const overlay = mediaBlock?.querySelector('div[dir="ltr"], div[dir="auto"]');
+        title = overlay?.textContent?.trim() || '';
+        if (href) {
+          try {
+            domain = new URL(href).hostname.replace(/^www\./, '');
+          } catch {
+            // leave domain empty if href isn't a parseable URL
+          }
         }
       }
 

--- a/src/shared/post-process.ts
+++ b/src/shared/post-process.ts
@@ -115,6 +115,12 @@ export function postProcess(
         if (!isAllowedImageUrl(imgUrl)) {
           return match;
         }
+        // Link-card OG previews are belong to the destination site, not the
+        // tweet's own media — keep them as remote URLs so we don't accumulate
+        // third-party thumbnails on disk.
+        if (alt === 'Link card preview') {
+          return match;
+        }
 
         try {
           const urlObj = new URL(imgUrl);

--- a/tests/fixtures/marcelpociot-2038915006050300007.md
+++ b/tests/fixtures/marcelpociot-2038915006050300007.md
@@ -1,0 +1,21 @@
+---
+author: "Marcel Pociot"
+handle: "@marcelpociot"
+source: "https://x.com/marcelpociot/status/2038915006050300007"
+date: 2026-03-31T09:43:13.000Z
+type: tweet
+likes: 1285
+reposts: 554
+replies: 65
+bookmarks: 634
+views: 5279861
+---
+# Marcel Pociot (@marcelpociot)
+
+Polyscope - the free agent orchestration tool for developers.  
+  
+Run dozens of AI agents at the same time, blazing fast copy on write clones, a built-in preview browser you can use to visually prompt your agents, mobile access, and much more.
+
+> 🔗 [**The agent-first dev environment**](https://getpolyscope.com/)
+> 
+> _getpolyscope.com_

--- a/tests/fixtures/marcelpociot-2038915006050300007.md
+++ b/tests/fixtures/marcelpociot-2038915006050300007.md
@@ -20,4 +20,4 @@ Run dozens of AI agents at the same time, blazing fast copy on write clones, a b
 > 
 > 🔗 [**The agent-first dev environment**](https://getpolyscope.com/)
 > 
-> _getpolyscope.com_
+> _From getpolyscope.com_

--- a/tests/fixtures/marcelpociot-2038915006050300007.md
+++ b/tests/fixtures/marcelpociot-2038915006050300007.md
@@ -16,6 +16,8 @@ Polyscope - the free agent orchestration tool for developers.
   
 Run dozens of AI agents at the same time, blazing fast copy on write clones, a built-in preview browser you can use to visually prompt your agents, mobile access, and much more.
 
+> ![Link card preview](https://pbs.twimg.com/media/HEut_fPXkAA_Opf?format=jpg&name=large)
+> 
 > 🔗 [**The agent-first dev environment**](https://getpolyscope.com/)
 > 
 > _getpolyscope.com_

--- a/tests/post-process.test.ts
+++ b/tests/post-process.test.ts
@@ -14,6 +14,17 @@ function content(markdown: string): ExtractedContent {
 }
 
 describe('postProcess() image downloads', () => {
+  it('does not download link card preview images even on pbs.twimg.com', () => {
+    const cardUrl = 'https://pbs.twimg.com/media/HEut_fPXkAA_Opf?format=jpg&name=large';
+    const result = postProcess(
+      content(`> ![Link card preview](${cardUrl})`),
+      { includeMetadata: false, downloadImages: true }
+    );
+
+    expect(result.markdown).toContain(`![Link card preview](${cardUrl})`);
+    expect(result.images).toEqual([]);
+  });
+
   it('localizes only allowed X/Twitter media images', () => {
     const allowedUrl = 'https://pbs.twimg.com/media/example?format=jpg&name=large';
     const externalUrl = 'https://example.com/card.jpg';


### PR DESCRIPTION
**Highlights:**
- **Link Card Data Capture:** Reliably extracts external link metadata from tweets, including titles, descriptions, and source domains (even handling media-only cards by deriving the domain from the URL).
- **High-Res Previews:** Automatically captures and embeds the link's Open Graph preview image in its largest format.
- **Smart Image Handling:** Intentionally prevents third-party link card thumbnails from being downloaded locally, retaining them as remote Markdown references to avoid cluttering your local attachments folder.
- **Improved Formatting:** Formats the source domain attribution clearly in the generated blockquote.
- **Documentation & Testing:** Includes new snapshot fixtures, unit tests for the updated image downloading logic, and documentation in both `README.md` and `CHANGELOG.md`.