### PR TITLE
fix: decouple tooltip opacity from disabled toggles (#38)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [2.0.1] - 2026-06-06
+
+### Fixed
+
+- **Tooltip opacity on disabled options** (#38): Decoupled the opacity styles so that tooltips on disabled / greyed-out options (like *Inline button copies instead*) remain fully opaque and readable.
+
+---
+
 ## [2.0.0] - 2026-06-06
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -21,20 +21,20 @@
 ### Key Features
 
 - **Three Ways to Trigger** — Toolbar popup, inline button on every tweet's action bar, or the right-click context menu
+- **Local Image Downloads** — Download embedded X media locally alongside your `.md` file to prevent link rot
+- **PDF Export** — Save tweets, threads, and articles as PDFs via the browser's native print engine. Selectable text, clickable links, embedded images, and full Unicode/emoji support
+- **Add to Obsidian** — One-click handoff to Obsidian via the `obsidian://` URI scheme, with an optional vault name for direct targeting
+- **Obsidian-friendly Frontmatter** — Optional schema with `[[@handle]]` wikilinks for backlinks, synthesized title, `published`/`created` dates, prose description, and a **customizable tags list** (defaults to `clippings, x, {type}`; supports placeholders like `{handle}` and `{date}` with `{`-autocomplete in Settings)
 - **X Articles** — Full support for long-form Articles (formerly Notes) with headings, lists, and code blocks
 - **Tweets & Threads** — Extract tweets, nested threads, and quote tweets into clean Markdown
 - **Single-Tweet Export** — Grab just one tweet without its thread via the right-click menu's **Copy just this tweet (no thread)** item, or by Shift/Alt-clicking the inline button
 - **Quoted Posts** — Preserve quoted-post structure and context in a reusable format, with the original author's name and handle
 - **Link Cards** — Capture external link previews including the title, domain, and high-res Open Graph image
-- **Add to Obsidian** — One-click handoff to Obsidian via the `obsidian://` URI scheme, with an optional vault name for direct targeting
-- **Obsidian-friendly Frontmatter** — Optional schema with `[[@handle]]` wikilinks for backlinks, synthesized title, `published`/`created` dates, prose description, and a **customizable tags list** (defaults to `clippings, x, {type}`; supports placeholders like `{handle}` and `{date}` with `{`-autocomplete in Settings)
-- **Local Image Downloads** — Download embedded X media locally alongside your `.md` file to prevent link rot
 - **Customizable Filename Template** — Configure the exported filename with placeholders (`{date}`, `{datetime}`, `{handle}`, `{author}`, `{id}`, `{slug}`, `{type}`); live preview in Settings. Default keeps the existing behaviour
 - **YAML Frontmatter** — Rich metadata with author, handle, date, source URL, content type, and engagement stats (likes, reposts, replies, bookmarks, views)
 - **Frontmatter Field Picker** — Per-field toggle switches in Settings to include or omit each YAML entry (e.g. drop `views` and `bookmarks` if you don't need them). Saved separately for the default schema and the Obsidian-friendly schema, so flipping the schema toggle preserves both sets
 - **Inline Engagement Stats** — Optional X-style row in the Markdown body: `💬 284 · 🔁 1.5K · ❤️ 8K · 🔖 253 · 👁 100K`
 - **Copy or Download** — Copy Markdown to clipboard or download as a file
-- **PDF Export** — Save tweets, threads, and articles as PDFs via the browser's native print engine. Selectable text, clickable links, embedded images, and full Unicode/emoji support
 - **Clean Output** — Automatically expand truncated posts and strip engagement buttons, follow prompts, and trackers
 - **Multi-Language UI** — Popup available in English, Spanish, German, French, Italian, Russian, Japanese, Portuguese (Brazil), Chinese (Simplified), Hindi, Arabic, and Persian. Content extraction works on any language regardless of UI translation
 - **Light & Dark Mode** — Popup matches your system preferences

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "xclipper",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "xclipper",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "devDependencies": {
         "@puppeteer/browsers": "^3.0.4",
         "@types/chrome": "^0.1.43",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xclipper",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "XClipper — free, open-source web clipper for X (Twitter). Download threads, posts, and articles as Markdown or PDF for Obsidian, research, and AI/RAG workflows. Works locally — no API, no accounts, no tracking.",
   "private": true,
   "type": "module",

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "__MSG_extensionName__",
   "short_name": "XClipper",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "__MSG_extensionDescription__",
   "default_locale": "en",
   "permissions": [

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -712,11 +712,19 @@ details.option-group[open] .option-group-chevron {
 }
 
 .toggle-label.disabled {
-  opacity: 0.4;
   cursor: not-allowed;
 }
 
-.toggle-label.disabled:hover {
+/* Dim only the label's visible children — NOT the container itself.
+ * A parent-level opacity would cascade into the [data-tooltip]::after
+ * pseudo-element, making the tooltip text unreadable (issue #38). */
+.toggle-label.disabled .toggle-text,
+.toggle-label.disabled .toggle-switch {
+  opacity: 0.4;
+}
+
+.toggle-label.disabled:hover .toggle-text,
+.toggle-label.disabled:hover .toggle-switch {
   opacity: 0.4;
 }
 


### PR DESCRIPTION
### Summary
Fixes #38 by preventing the parent container's `opacity: 0.4` from cascading down to the tooltip pseudo-element (`[data-tooltip]::after`).

### Changes
* Decoupled the opacity transition from the `.toggle-label.disabled` container.
* Applied the dimming effect directly to the visible children (`.toggle-text` and `.toggle-switch`) so the tooltip remains fully opaque and readable.