### PR TITLE
fix: respect engagement toggle in PDF and position stats in threads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [2.0.2] - 2026-06-06
+
+### Fixed
+
+- **PDF Export respect Engagement toggle** (#46): Engagement metrics are now stripped from the PDF export when the *Engagement* toggle is turned off.
+- **Thread Engagement Stats position** (#47): For threads, the engagement stats line in Markdown is now placed right after the first tweet (before the separator) instead of after the last tweet.
+
+---
+
 ## [2.0.1] - 2026-06-06
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "xclipper",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "xclipper",
-      "version": "2.0.1",
+      "version": "2.0.2",
       "devDependencies": {
         "@puppeteer/browsers": "^3.0.4",
         "@types/chrome": "^0.1.43",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xclipper",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "XClipper — free, open-source web clipper for X (Twitter). Download threads, posts, and articles as Markdown or PDF for Obsidian, research, and AI/RAG workflows. Works locally — no API, no accounts, no tracking.",
   "private": true,
   "type": "module",

--- a/src/ast/render-pdf-html.ts
+++ b/src/ast/render-pdf-html.ts
@@ -17,14 +17,17 @@ export interface RenderPdfHtmlOptions {
   // Only 'twitter' is implemented in v1; the option exists so the future
   // 'document' style is additive without API churn.
   style?: 'twitter' | 'document';
+  // When true, engagement metrics (likes, reposts, etc.) are rendered on
+  // tweet cards. Defaults to false — callers must opt in.
+  includeEngagement?: boolean;
 }
 
 // AST → standalone HTML document for PDF rendering. Used by tests and any
 // future preview-page flow. All visual styles are scoped under .xclipper-root so
 // the same content can also be safely injected as a fragment into a live
 // page (see renderPdfFragment + pdf-export.ts).
-export function renderPdfHtml(doc: Document, _opts: RenderPdfHtmlOptions = {}): string {
-  const body = renderBody(doc);
+export function renderPdfHtml(doc: Document, opts: RenderPdfHtmlOptions = {}): string {
+  const body = renderBody(doc, opts);
   const title = doc.metadata.title || tweetTitle(doc.metadata);
   return `<!doctype html>
 <html lang="en"><head><meta charset="utf-8"><title>${escapeHtml(title)}</title>
@@ -34,8 +37,8 @@ export function renderPdfHtml(doc: Document, _opts: RenderPdfHtmlOptions = {}): 
 // Fragment variant for live-DOM injection: returns `<style>…<div class="xclipper-root">…</div>`
 // so the caller can set it as innerHTML of an offscreen container without
 // polluting page styles (all selectors are scoped to .xclipper-root).
-export function renderPdfFragment(doc: Document, _opts: RenderPdfHtmlOptions = {}): string {
-  return `<style>${STYLES}</style><div class="xclipper-root">${renderBody(doc)}</div>`;
+export function renderPdfFragment(doc: Document, opts: RenderPdfHtmlOptions = {}): string {
+  return `<style>${STYLES}</style><div class="xclipper-root">${renderBody(doc, opts)}</div>`;
 }
 
 function tweetTitle(meta: DocumentMetadata): string {
@@ -45,21 +48,21 @@ function tweetTitle(meta: DocumentMetadata): string {
 
 // ─── Top-level body ─────────────────────────────────────────────────
 
-function renderBody(doc: Document): string {
-  if (doc.body.type === 'tweet') return renderTweetCard(doc.body, doc.metadata);
-  if (doc.body.type === 'thread') return renderThread(doc.body, doc.metadata);
+function renderBody(doc: Document, opts: RenderPdfHtmlOptions = {}): string {
+  if (doc.body.type === 'tweet') return renderTweetCard(doc.body, doc.metadata, opts);
+  if (doc.body.type === 'thread') return renderThread(doc.body, doc.metadata, opts);
   return renderArticle(doc.body, doc.metadata);
 }
 
-function renderThread(thread: ThreadNode, meta: DocumentMetadata): string {
+function renderThread(thread: ThreadNode, meta: DocumentMetadata, opts: RenderPdfHtmlOptions = {}): string {
   const cards = thread.tweets.map((t, i) => {
     const isRoot = i === 0;
-    return renderTweetCard(t, isRoot ? meta : undefined);
+    return renderTweetCard(t, isRoot ? meta : undefined, opts);
   }).join('');
   return `<div class="thread">${cards}</div>` + renderSource(meta);
 }
 
-function renderTweetCard(tweet: TweetNode, meta?: DocumentMetadata): string {
+function renderTweetCard(tweet: TweetNode, meta?: DocumentMetadata, opts: RenderPdfHtmlOptions = {}): string {
   const head = renderAuthorHeader(tweet);
   const text = tweet.text.length > 0
     ? `<div class="tweet-body">${renderInlines(tweet.text)}</div>`
@@ -71,7 +74,7 @@ function renderTweetCard(tweet: TweetNode, meta?: DocumentMetadata): string {
   const linkCard = tweet.linkCard ? renderLinkCard(tweet.linkCard) : '';
   const articleCard = tweet.articleCard ? renderArticleCard(tweet.articleCard) : '';
   const quote = tweet.quotedTweet ? renderQuotedTweet(tweet.quotedTweet) : '';
-  const engagement = tweet.engagement
+  const engagement = opts.includeEngagement && tweet.engagement
     ? renderEngagement(tweet.engagement)
     : '';
   const source = meta ? renderSource(meta) : '';

--- a/src/content/content.ts
+++ b/src/content/content.ts
@@ -66,12 +66,14 @@ chrome.runtime.onMessage.addListener((_message, _sender, sendResponse) => {
 
 async function runPdfExport(): Promise<void> {
   await waitForArticle();
-  const response = await extract({ includeMetadata: true });
+  const settings = await loadStoredSettings();
+  const includeEngagement = settings.inlineStats === true;
+  const response = await extract({ includeMetadata: includeEngagement });
   if (!response.success || !response.data || !response.data.body) {
     throw new Error(response.error || 'PDF export: extraction failed');
   }
   const filename = buildFilename(response.data).replace(/\.md$/i, '');
-  await exportPdf(response.data.body, filename);
+  await exportPdf(response.data.body, filename, { includeEngagement });
 }
 
 // ─── Auto-extract bootstrap (#xclipper=download | #xclipper=copy) ───

--- a/src/content/pdf-export.ts
+++ b/src/content/pdf-export.ts
@@ -2,14 +2,18 @@ import type { Document } from '../ast/types';
 import type { PdfPrintResponse } from '../types/messages';
 import { renderPdfFragment } from '../ast/render-pdf-html';
 
+export interface ExportPdfOptions {
+  includeEngagement?: boolean;
+}
+
 // PDF export delegates to background, which opens a print-preview tab in
 // extension origin and triggers window.print(). Chrome's native print
 // engine produces selectable text, clickable links, real Unicode + emoji,
 // and pagination — none of which the prior jsPDF / html2canvas paths
 // could deliver without effectively building a layout engine. See
 // ADR 0001 → "Renderer decisions".
-export async function exportPdf(doc: Document, filenameBase: string): Promise<void> {
-  const html = renderPdfFragment(doc);
+export async function exportPdf(doc: Document, filenameBase: string, opts: ExportPdfOptions = {}): Promise<void> {
+  const html = renderPdfFragment(doc, { includeEngagement: opts.includeEngagement });
   const resp = (await chrome.runtime.sendMessage({
     action: 'PDF_PRINT_REQUEST',
     html,

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "__MSG_extensionName__",
   "short_name": "XClipper",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "__MSG_extensionDescription__",
   "default_locale": "en",
   "permissions": [

--- a/src/shared/post-process.ts
+++ b/src/shared/post-process.ts
@@ -335,11 +335,34 @@ export function postProcess(
   if (opts.inlineStats && data.metadata) {
     const line = buildStatsLine(data.metadata);
     if (line) {
-      const footerRe = /\n+---\n+> Source:/;
-      if (footerRe.test(finalMarkdown)) {
-        finalMarkdown = finalMarkdown.replace(footerRe, `\n\n${line}\n\n---\n> Source:`);
+      // For threads, engagement stats belong to the first tweet — place them
+      // before the first `---` separator (which divides tweet 1 from tweet 2).
+      // The first `---` in the body (after any frontmatter) is the thread
+      // separator; the source footer uses `---` too but sits after all tweets.
+      const isThread = data.type === 'thread';
+      if (isThread) {
+        // Skip past frontmatter (if present) to find the first thread separator.
+        const fmEnd = finalMarkdown.startsWith('---')
+          ? finalMarkdown.indexOf('---', finalMarkdown.indexOf('\n') + 1)
+          : -1;
+        const searchStart = fmEnd >= 0 ? fmEnd + 3 : 0;
+        const sepIdx = finalMarkdown.indexOf('\n---\n', searchStart);
+        if (sepIdx >= 0) {
+          finalMarkdown =
+            finalMarkdown.slice(0, sepIdx) +
+            `\n\n${line}` +
+            finalMarkdown.slice(sepIdx);
+        } else {
+          // Single-tweet thread or no separator found — fall through to default.
+          finalMarkdown = finalMarkdown.replace(/\s*$/, '') + `\n\n${line}\n`;
+        }
       } else {
-        finalMarkdown = finalMarkdown.replace(/\s*$/, '') + `\n\n${line}\n`;
+        const footerRe = /\n+---\n+> Source:/;
+        if (footerRe.test(finalMarkdown)) {
+          finalMarkdown = finalMarkdown.replace(footerRe, `\n\n${line}\n\n---\n> Source:`);
+        } else {
+          finalMarkdown = finalMarkdown.replace(/\s*$/, '') + `\n\n${line}\n`;
+        }
       }
     }
   }

--- a/tests/ast-render-pdf-html.test.ts
+++ b/tests/ast-render-pdf-html.test.ts
@@ -100,4 +100,21 @@ describe('renderPdfHtml', () => {
     expect(html).toContain('class="link-card"');
     expect(html).toContain('getpolyscope.com');
   });
+
+  it('respects includeEngagement option', () => {
+    const doc = loadAst('bcherny-2053982327123132846');
+    // Ensure the AST has some engagement
+    doc.body.type === 'tweet' && (doc.body.engagement = { likes: 42, reposts: 10 });
+    
+    const htmlWithEngagement = renderPdfHtml(doc, { includeEngagement: true });
+    expect(htmlWithEngagement).toContain('class="engagement"');
+    expect(htmlWithEngagement).toContain('❤️ 42');
+    
+    const htmlWithoutEngagement = renderPdfHtml(doc, { includeEngagement: false });
+    expect(htmlWithoutEngagement).not.toContain('class="engagement"');
+    expect(htmlWithoutEngagement).not.toContain('❤️ 42');
+    
+    const htmlDefault = renderPdfHtml(doc);
+    expect(htmlDefault).not.toContain('class="engagement"');
+  });
 });

--- a/tests/post-process.test.ts
+++ b/tests/post-process.test.ts
@@ -313,4 +313,43 @@ describe('postProcess() filename template', () => {
     });
     expect(result.filename).toBe('2026-05-19-example-123.md');
   });
+
+  it('inserts inline stats correctly for single tweets vs threads', () => {
+    const tweetData: ExtractedContent = {
+      type: 'tweet',
+      author: { name: 'Example', handle: '@example' },
+      markdown: '# Example (@example)\n\nThis is a single tweet.\n\n---\n> Source: https://x.com/example/status/123',
+      sourceUrl: 'https://x.com/example/status/123',
+      date: '2026-05-11T00:00:00.000Z',
+      tweetId: '123',
+      metadata: { likes: 10, reposts: 2, replies: 0, bookmarks: 0, views: 100 },
+    };
+
+    const threadData: ExtractedContent = {
+      type: 'thread',
+      author: { name: 'Example', handle: '@example' },
+      markdown: '# Example (@example)\n\nFirst tweet in thread.\n\n---\n\nSecond tweet in thread.\n\n---\n> Source: https://x.com/example/status/123',
+      sourceUrl: 'https://x.com/example/status/123',
+      date: '2026-05-11T00:00:00.000Z',
+      tweetId: '123',
+      metadata: { likes: 10, reposts: 2, replies: 0, bookmarks: 0, views: 100 },
+    };
+
+    // Single tweet: stats before the source footer
+    const singleResult = postProcess(tweetData, {
+      includeMetadata: false,
+      downloadImages: false,
+      inlineStats: true,
+    });
+    expect(singleResult.markdown).toContain('💬 0 · 🔁 2 · ❤️ 10 · 🔖 0 · 👁 100\n\n---\n> Source:');
+
+    // Thread: stats after the first tweet (before the first separator)
+    const threadResult = postProcess(threadData, {
+      includeMetadata: false,
+      downloadImages: false,
+      inlineStats: true,
+    });
+    expect(threadResult.markdown).toContain('First tweet in thread.');
+    expect(threadResult.markdown).toContain('💬 0 · 🔁 2 · ❤️ 10 · 🔖 0 · 👁 100\n---\n\nSecond tweet in thread.');
+  });
 });


### PR DESCRIPTION
This PR resolves two issues:
1. Respects the user's inlineStats (Engagement) setting during PDF exports (fixes #46).
2. Repositioned the inlineStats line in Markdown threads to sit directly after the first tweet instead of the last tweet (fixes #47).

Also bumps the version to 2.0.2.