### PR TITLE
Fix X Article media and embedded tweet export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Date in Article PDF exports**: Formatted publication date next to the author handle in the article byline.
 
+### Changed
+
+- **PDF action wording**: Rename the popup action from **Download .pdf** to **Export .pdf** and add a tooltip that describes the generated PDF export flow.
+
 ### Fixed
 
 - **Article PDF Engagement Stats and Metadata Overwrite**:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Fix an issue where the redundant `options.includeMetadata` override in `extract()` caused engagement stats to be overwritten with `undefined`.
   - Add test coverage for the article engagement rendering toggle.
 - **Captioned X Article images after AST refactor**: Restore Markdown image extraction for X Article media blocks that include captions, preventing `/article/.../media/...` links from replacing the underlying `pbs.twimg.com` image URLs.
+- **Embedded tweets in X Article bodies**: Preserve `simpleTweet` embeds as quoted tweet cards with author, text, and media instead of collapsing them to avatar images. (#50)
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
-## [2.0.3] - 2026-06-06
+## [2.0.3] - 2026-06-07
 
 ### Added
 
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Forward PDF rendering options to the article layout renderer and conditionally render engagement metrics below the title/banner when enabled.
   - Fix an issue where the redundant `options.includeMetadata` override in `extract()` caused engagement stats to be overwritten with `undefined`.
   - Add test coverage for the article engagement rendering toggle.
+- **Captioned X Article images after AST refactor**: Restore Markdown image extraction for X Article media blocks that include captions, preventing `/article/.../media/...` links from replacing the underlying `pbs.twimg.com` image URLs.
 
 ---
 
@@ -30,7 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [2.0.1] - 2026-06-06
+## [2.0.1] - 2026-06-05
 
 ### Fixed
 
@@ -38,7 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [2.0.0] - 2026-06-06
+## [2.0.0] - 2026-06-05
 
 ### Changed
 

--- a/src/_locales/ar/messages.json
+++ b/src/_locales/ar/messages.json
@@ -14,6 +14,12 @@
   "btn_copy": {
     "message": "نسخ .md"
   },
+  "btn_pdf": {
+    "message": "تصدير .pdf"
+  },
+  "btn_pdf_hint": {
+    "message": "إنشاء تصدير PDF منسّق بالإعدادات الحالية، ثم اختيار مكان حفظه."
+  },
   "btn_obsidian": {
     "message": "إضافة إلى Obsidian"
   },

--- a/src/_locales/de/messages.json
+++ b/src/_locales/de/messages.json
@@ -14,6 +14,12 @@
   "btn_copy": {
     "message": ".md kopieren"
   },
+  "btn_pdf": {
+    "message": ".pdf exportieren"
+  },
+  "btn_pdf_hint": {
+    "message": "Erstellt einen formatierten PDF-Export mit den aktuellen Einstellungen; anschließend wählst du den Speicherort."
+  },
   "btn_obsidian": {
     "message": "Zu Obsidian hinzufügen"
   },

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -14,6 +14,12 @@
   "btn_copy": {
     "message": "Copy .md"
   },
+  "btn_pdf": {
+    "message": "Export .pdf"
+  },
+  "btn_pdf_hint": {
+    "message": "Generate a formatted PDF export with current settings, then choose where to save it."
+  },
   "btn_obsidian": {
     "message": "Add to Obsidian"
   },

--- a/src/_locales/es/messages.json
+++ b/src/_locales/es/messages.json
@@ -14,6 +14,12 @@
   "btn_copy": {
     "message": "Copiar .md"
   },
+  "btn_pdf": {
+    "message": "Exportar .pdf"
+  },
+  "btn_pdf_hint": {
+    "message": "Genera una exportación PDF con la configuración actual y luego elige dónde guardarla."
+  },
   "btn_obsidian": {
     "message": "Añadir a Obsidian"
   },

--- a/src/_locales/fa/messages.json
+++ b/src/_locales/fa/messages.json
@@ -14,6 +14,12 @@
   "btn_copy": {
     "message": "کپی .md"
   },
+  "btn_pdf": {
+    "message": "خروجی .pdf"
+  },
+  "btn_pdf_hint": {
+    "message": "یک خروجی PDF قالب‌بندی‌شده با تنظیمات فعلی بسازید، سپس محل ذخیره را انتخاب کنید."
+  },
   "btn_obsidian": {
     "message": "افزودن به Obsidian"
   },

--- a/src/_locales/fr/messages.json
+++ b/src/_locales/fr/messages.json
@@ -14,6 +14,12 @@
   "btn_copy": {
     "message": "Copier .md"
   },
+  "btn_pdf": {
+    "message": "Exporter .pdf"
+  },
+  "btn_pdf_hint": {
+    "message": "Génère un export PDF mis en forme avec les réglages actuels, puis choisissez où l’enregistrer."
+  },
   "btn_obsidian": {
     "message": "Ajouter à Obsidian"
   },

--- a/src/_locales/hi/messages.json
+++ b/src/_locales/hi/messages.json
@@ -14,6 +14,12 @@
   "btn_copy": {
     "message": ".md कॉपी"
   },
+  "btn_pdf": {
+    "message": ".pdf एक्सपोर्ट करें"
+  },
+  "btn_pdf_hint": {
+    "message": "मौजूदा सेटिंग्स के साथ फ़ॉर्मैट किया हुआ PDF export बनाएं, फिर उसे कहाँ सेव करना है चुनें."
+  },
   "btn_obsidian": {
     "message": "Obsidian में जोड़ें"
   },

--- a/src/_locales/it/messages.json
+++ b/src/_locales/it/messages.json
@@ -14,6 +14,12 @@
   "btn_copy": {
     "message": "Copia .md"
   },
+  "btn_pdf": {
+    "message": "Esporta .pdf"
+  },
+  "btn_pdf_hint": {
+    "message": "Genera un export PDF formattato con le impostazioni attuali, poi scegli dove salvarlo."
+  },
   "btn_obsidian": {
     "message": "Aggiungi a Obsidian"
   },

--- a/src/_locales/ja/messages.json
+++ b/src/_locales/ja/messages.json
@@ -14,6 +14,12 @@
   "btn_copy": {
     "message": ".mdをコピー"
   },
+  "btn_pdf": {
+    "message": ".pdf にエクスポート"
+  },
+  "btn_pdf_hint": {
+    "message": "現在の設定で整形済みのPDF書き出しを作成し、保存先を選びます。"
+  },
   "btn_obsidian": {
     "message": "Obsidianに追加"
   },

--- a/src/_locales/pt_BR/messages.json
+++ b/src/_locales/pt_BR/messages.json
@@ -14,6 +14,12 @@
   "btn_copy": {
     "message": "Copiar .md"
   },
+  "btn_pdf": {
+    "message": "Exportar .pdf"
+  },
+  "btn_pdf_hint": {
+    "message": "Gera uma exportação PDF formatada com as configurações atuais; depois escolha onde salvar."
+  },
   "btn_obsidian": {
     "message": "Adicionar ao Obsidian"
   },

--- a/src/_locales/ru/messages.json
+++ b/src/_locales/ru/messages.json
@@ -14,6 +14,12 @@
   "btn_copy": {
     "message": "Копировать .md"
   },
+  "btn_pdf": {
+    "message": "Экспорт .pdf"
+  },
+  "btn_pdf_hint": {
+    "message": "Создать оформленный PDF-экспорт с текущими настройками, затем выбрать место сохранения."
+  },
   "btn_obsidian": {
     "message": "Добавить в Obsidian"
   },

--- a/src/_locales/zh_CN/messages.json
+++ b/src/_locales/zh_CN/messages.json
@@ -14,6 +14,12 @@
   "btn_copy": {
     "message": "复制 .md"
   },
+  "btn_pdf": {
+    "message": "导出 .pdf"
+  },
+  "btn_pdf_hint": {
+    "message": "使用当前设置生成格式化的 PDF 导出，然后选择保存位置。"
+  },
   "btn_obsidian": {
     "message": "添加到 Obsidian"
   },

--- a/src/ast/render-markdown.ts
+++ b/src/ast/render-markdown.ts
@@ -295,6 +295,8 @@ function renderArticleBlock(block: Block): string {
       // In article body flow the card is the whole block — render it as a
       // blockquote stanza, same shape as the in-tweet form.
       return renderArticleCardBlock(block).replace(/^\n\n/, '');
+    case 'tweet':
+      return renderQuotedTweetBlock(block).replace(/^\n\n/, '');
     default:
       return '';
   }

--- a/src/ast/render-pdf-html.ts
+++ b/src/ast/render-pdf-html.ts
@@ -231,6 +231,8 @@ function renderArticleBlock(block: Block): string {
       return '<hr>';
     case 'articleCard':
       return renderArticleCard(block);
+    case 'tweet':
+      return renderQuotedTweet(block);
     default:
       return '';
   }

--- a/src/content/dom-to-ast.ts
+++ b/src/content/dom-to-ast.ts
@@ -475,10 +475,12 @@ function articleBlockToNodes(block: HTMLElement): Block[] {
     return [articleMediaImg];
   }
 
-  // Embedded simpleTweet card — match legacy behavior by emitting just the
-  // inner avatar image. The card surfaces author + handle + snippet inline,
-  // but the user-facing fixture has historically rendered only the avatar.
+  // Embedded simpleTweet card — X Articles can contain full tweet embeds in
+  // the article body. Preserve the tweet structure instead of collapsing the
+  // card to its avatar image.
   if (block.querySelector('[data-testid="simpleTweet"]')) {
+    const tweet = extractSimpleTweet(block);
+    if (tweet) return [tweet];
     const img = findArticleBlockImage(block);
     return img ? [img] : [];
   }
@@ -498,6 +500,13 @@ function blockHasOnlyImage(block: HTMLElement): boolean {
   // True when every text node under the block is whitespace and the only
   // meaningful descendant is a non-emoji <img>.
   return (block.textContent || '').trim() === '' && !!block.querySelector('img');
+}
+
+function extractSimpleTweet(block: HTMLElement): TweetNode | undefined {
+  const tweetArticle = block.querySelector('[data-testid="simpleTweet"] article[role="article"]')
+    || block.querySelector('[data-testid="simpleTweet"] [data-testid="tweet"]');
+  if (!tweetArticle) return undefined;
+  return articleToTweetNode(tweetArticle);
 }
 
 function findArticleBlockImage(block: HTMLElement): ImageNode | undefined {

--- a/src/content/dom-to-ast.ts
+++ b/src/content/dom-to-ast.ts
@@ -467,6 +467,14 @@ function articleBlockToNodes(block: HTMLElement): Block[] {
     return card ? [card] : [];
   }
 
+  // X article images are wrapped in an article media permalink. Caption text
+  // can live in the same block, so textContent is not a reliable image-only
+  // signal here.
+  const articleMediaImg = findArticleMediaImage(block);
+  if (articleMediaImg) {
+    return [articleMediaImg];
+  }
+
   // Embedded simpleTweet card — match legacy behavior by emitting just the
   // inner avatar image. The card surfaces author + handle + snippet inline,
   // but the user-facing fixture has historically rendered only the avatar.
@@ -494,6 +502,20 @@ function blockHasOnlyImage(block: HTMLElement): boolean {
 
 function findArticleBlockImage(block: HTMLElement): ImageNode | undefined {
   const imgEl = block.querySelector('img') as HTMLImageElement | null;
+  return imageNodeFromElement(imgEl);
+}
+
+function findArticleMediaImage(block: HTMLElement): ImageNode | undefined {
+  const mediaLink = block.querySelector('a[href*="/article/"][href*="/media/"], a[href*="/media/"]');
+  if (!mediaLink) return undefined;
+  const imgEl = mediaLink.querySelector('img') as HTMLImageElement | null;
+  if (!imgEl) return undefined;
+  const src = imgEl.src || '';
+  if (!hostMatches(src, 'pbs.twimg.com') || src.includes('profile_images')) return undefined;
+  return imageNodeFromElement(imgEl);
+}
+
+function imageNodeFromElement(imgEl: HTMLImageElement | null): ImageNode | undefined {
   if (!imgEl) return undefined;
   let src = imgEl.src || '';
   if (!src) return undefined;

--- a/src/content/dom.ts
+++ b/src/content/dom.ts
@@ -131,11 +131,11 @@ function parseAuthorFromElement(userNameEl: Element): { name: string; handle: st
 
   // Fallback: quoted-tweet blocks wrap the whole quote in an outer link, so the
   // inner name / handle render as plain spans (zero <a> tags). Parse from text.
-  if (name === 'Unknown' || handle === 'unknown') {
+  if (name === 'Unknown' || handle === 'unknown' || isTimestampLabel(name)) {
     const txt = (userNameEl.textContent || '').replace(/\s+/g, ' ').trim();
     const handleMatch = txt.match(/@[A-Za-z0-9_]+/);
     if (handleMatch && handle === 'unknown') handle = handleMatch[0];
-    if (name === 'Unknown') {
+    if (handleMatch && (name === 'Unknown' || isTimestampLabel(name))) {
       const idx = handleMatch ? txt.indexOf(handleMatch[0]) : -1;
       const nameText = idx > 0 ? txt.slice(0, idx).trim() : txt;
       if (nameText) name = nameText;
@@ -143,4 +143,8 @@ function parseAuthorFromElement(userNameEl: Element): { name: string; handle: st
   }
 
   return { name, handle };
+}
+
+function isTimestampLabel(value: string): boolean {
+  return /^(?:\d+[smhd]|\d+[smhd]\s|[A-Z][a-z]{2}\s+\d{1,2}|\d{1,2}:\d{2}\s*(?:AM|PM)?)$/.test(value.trim());
 }

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -573,6 +573,30 @@ body {
   transform: translateY(0);
 }
 
+/* Action-row buttons sit near opposite popup edges. Anchor their tooltips to
+ * logical edges so each box grows toward the row's interior in both LTR and
+ * RTL locales instead of being centered past the popup boundary. */
+.action-row .btn-action:first-child[data-tooltip]::after {
+  left: auto;
+  right: auto;
+  inset-inline-start: 0;
+  transform: translateY(2px);
+}
+
+.action-row .btn-action:last-child[data-tooltip]::after {
+  left: auto;
+  right: auto;
+  inset-inline-end: 0;
+  transform: translateY(2px);
+}
+
+.action-row .btn-action:first-child[data-tooltip]:hover::after,
+.action-row .btn-action:first-child[data-tooltip]:focus-visible::after,
+.action-row .btn-action:last-child[data-tooltip]:hover::after,
+.action-row .btn-action:last-child[data-tooltip]:focus-visible::after {
+  transform: translateY(0);
+}
+
 .nav-link {
   display: inline-flex;
   align-items: center;

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -90,14 +90,16 @@
       </div>
 
       <div class="action-row">
-        <button id="btn-pdf" class="btn-pdf btn-action" type="button">
+        <button id="btn-pdf" class="btn-pdf btn-action" type="button"
+          data-tooltip="Generate a formatted PDF export with current settings, then choose where to save it."
+          data-i18n-tooltip="btn_pdf_hint">
           <svg class="btn-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
             stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
             <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
             <polyline points="14 2 14 8 20 8" />
             <text x="7.5" y="18" font-size="6" font-weight="700" fill="currentColor" stroke="none">PDF</text>
           </svg>
-          <span class="btn-label">Download .pdf</span>
+          <span class="btn-label" data-i18n="btn_pdf">Export .pdf</span>
         </button>
 
         <button id="btn-obsidian" class="btn-obsidian btn-action" type="button"

--- a/src/popup/popup.ts
+++ b/src/popup/popup.ts
@@ -99,16 +99,6 @@ document.querySelectorAll('[data-i18n]').forEach((el) => {
   }
 });
 
-// PDF button reuses the locale's `btn_download` translation with `.md` swapped
-// to `.pdf`, so we don't carry a parallel `btn_pdf` string in every locale.
-// Every locale's btn_download contains the literal `.md` token (it's a file
-// extension, not translatable), and word order is preserved either way.
-function pdfButtonLabel(): string {
-  const dl = chrome.i18n.getMessage('btn_download') || 'Download .md';
-  return dl.replace('.md', '.pdf');
-}
-const initialPdfLabel = document.querySelector('#btn-pdf .btn-label');
-if (initialPdfLabel) initialPdfLabel.textContent = pdfButtonLabel();
 document.querySelectorAll('[data-i18n-tooltip]').forEach((el) => {
   const key = el.getAttribute('data-i18n-tooltip');
   if (key) {
@@ -709,7 +699,7 @@ function setLoading(loading: boolean, target?: 'download' | 'copy' | 'obsidian' 
   if (target === 'pdf' || !target) {
     btnPdf.classList.toggle('loading', loading);
     const pdfLabel = btnPdf.querySelector('.btn-label');
-    if (pdfLabel) pdfLabel.textContent = loading ? (chrome.i18n.getMessage('rendering_pdf') || 'Rendering PDF…') : pdfButtonLabel();
+    if (pdfLabel) pdfLabel.textContent = loading ? (chrome.i18n.getMessage('rendering_pdf') || 'Rendering PDF…') : (chrome.i18n.getMessage('btn_pdf') || 'Export .pdf');
   }
 
   // When stopping, always reset all four to default state
@@ -725,7 +715,7 @@ function setLoading(loading: boolean, target?: 'download' | 'copy' | 'obsidian' 
     if (dlLabel) dlLabel.textContent = chrome.i18n.getMessage('btn_download') || 'Download .md';
     if (cpLabel) cpLabel.textContent = chrome.i18n.getMessage('btn_copy') || 'Copy .md';
     if (obLabel) obLabel.textContent = chrome.i18n.getMessage('btn_obsidian') || 'Add to Obsidian';
-    if (pdfLabel) pdfLabel.textContent = pdfButtonLabel();
+    if (pdfLabel) pdfLabel.textContent = chrome.i18n.getMessage('btn_pdf') || 'Export .pdf';
   }
 }
 

--- a/store/Permission_justification.txt
+++ b/store/Permission_justification.txt
@@ -2,7 +2,7 @@
 
 ## Single purpose
 
-XClipper converts X.com posts and articles into clean Markdown. When the user visits a supported page and triggers an action (via the popup, the inline button, or the right-click context menu), the extension extracts the visible content and lets the user save it as a .md file, copy it to the clipboard, or hand it off to the Obsidian desktop app via the obsidian:// URI scheme. All processing happens locally in the browser and no data is transmitted to any external server.
+XClipper converts X.com posts and articles into clean Markdown or PDF. When the user visits a supported page and triggers an action (via the popup, the inline button, or the right-click context menu), the extension extracts the visible content and lets the user save it as a .md file, export it as a PDF through Chrome's print/save flow, copy it to the clipboard, or hand it off to the Obsidian desktop app via the obsidian:// URI scheme. All processing happens locally in the browser and no data is transmitted to any external server.
 
 ## Permission justification
 
@@ -16,7 +16,7 @@ The contextMenus permission is used to add "Save tweet as Markdown", "Copy tweet
 
 ### downloads
 
-The "downloads" permission is required to save the generated Markdown file to the user's device as a .md file.
+The "downloads" permission is required to save the generated Markdown file to the user's device as a .md file. PDF export uses Chrome's print/save dialog and does not rely on this permission.
 
 ### storage
 

--- a/tests/article-media-ast.test.ts
+++ b/tests/article-media-ast.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest';
+import { JSDOM } from 'jsdom';
+import { domToAst } from '../src/content/dom-to-ast';
+import { renderMarkdown } from '../src/ast/render-markdown';
+
+function loadArticle(html: string): void {
+  const url = 'https://x.com/theonejvo/status/2015401219746128322';
+  const dom = new JSDOM(html, { url });
+  document.documentElement.replaceWith(
+    dom.window.document.documentElement.cloneNode(true) as HTMLElement
+  );
+  Object.defineProperty(window, 'location', {
+    value: { ...window.location, pathname: new URL(url).pathname, href: url },
+    writable: true,
+    configurable: true,
+  });
+}
+
+describe('domToAst() article media blocks', () => {
+  it('extracts captioned X article media links as images', () => {
+    loadArticle(`
+      <html>
+        <body>
+          <article role="article">
+            <div data-testid="User-Name">
+              <a href="/theonejvo"><span>Jamieson O'Reilly</span></a>
+              <a href="/theonejvo"><span>@theonejvo</span></a>
+            </div>
+            <time datetime="2026-01-01T00:00:00.000Z"></time>
+            <div data-testid="twitter-article-title">Captioned media</div>
+            <div data-testid="twitterArticleRichTextView">
+              <div data-testid="longformRichTextComponent">
+                <div data-contents="true">
+                  <section>
+                    <a href="/theonejvo/article/2015401219746128322/media/2015356338050891776">
+                      <img
+                        src="https://pbs.twimg.com/media/G_f76WFbAAAwrmo?format=jpg&amp;name=medium"
+                        alt="Image"
+                      >
+                    </a>
+                    <div>Screenshot of shodan search identifying control servers</div>
+                  </section>
+                </div>
+              </div>
+            </div>
+          </article>
+        </body>
+      </html>
+    `);
+
+    const ast = domToAst();
+    expect(ast.body.type).toBe('article');
+    if (ast.body.type !== 'article') return;
+    expect(ast.body.children[0]).toEqual({
+      type: 'image',
+      url: 'https://pbs.twimg.com/media/G_f76WFbAAAwrmo?format=jpg&name=large',
+      alt: 'Image',
+    });
+
+    const markdown = renderMarkdown(ast);
+    expect(markdown).toContain('![Image](https://pbs.twimg.com/media/G_f76WFbAAAwrmo?format=jpg&name=large)');
+    expect(markdown).not.toContain('/article/2015401219746128322/media/');
+  });
+});

--- a/tests/article-simpletweet-ast.test.ts
+++ b/tests/article-simpletweet-ast.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest';
+import { JSDOM } from 'jsdom';
+import { domToAst } from '../src/content/dom-to-ast';
+import { renderMarkdown } from '../src/ast/render-markdown';
+
+function loadArticle(html: string): void {
+  const url = 'https://x.com/theonejvo/status/2015401219746128322';
+  const dom = new JSDOM(html, { url });
+  document.documentElement.replaceWith(
+    dom.window.document.documentElement.cloneNode(true) as HTMLElement
+  );
+  Object.defineProperty(window, 'location', {
+    value: { ...window.location, pathname: new URL(url).pathname, href: url },
+    writable: true,
+    configurable: true,
+  });
+}
+
+describe('domToAst() article simpleTweet embeds', () => {
+  it('preserves embedded tweets in X Article bodies', () => {
+    loadArticle(`
+      <html>
+        <body>
+          <article role="article">
+            <div data-testid="User-Name">
+              <a href="/theonejvo"><span>Jamieson O'Reilly</span></a>
+              <a href="/theonejvo"><span>@theonejvo</span></a>
+            </div>
+            <time datetime="2026-01-01T00:00:00.000Z"></time>
+            <div data-testid="twitter-article-title">Embedded tweet</div>
+            <div data-testid="twitterArticleRichTextView">
+              <div data-testid="longformRichTextComponent">
+                <div data-contents="true">
+                  <section>
+                    <div data-testid="simpleTweet">
+                      <article role="article" data-testid="tweet">
+                        <div data-testid="User-Name">
+                          <a href="/AlexFinn"><span>Alex Finn</span></a>
+                          <a href="/AlexFinn"><span>@AlexFinn</span></a>
+                        </div>
+                        <a href="/AlexFinn/status/2015182480064893118">
+                          <time datetime="2026-01-24T21:58:38.000Z"></time>
+                        </a>
+                        <div data-testid="tweetText">This is it. The most important video you'll watch this year.</div>
+                        <div data-testid="tweetPhoto">
+                          <img src="https://pbs.twimg.com/amplify_video_thumb/2015181527802687488/img/hcdMrX1kztalGFEB.jpg" alt="Embedded video">
+                        </div>
+                        <video poster="https://pbs.twimg.com/amplify_video_thumb/2015181527802687488/img/hcdMrX1kztalGFEB.jpg"></video>
+                      </article>
+                    </div>
+                  </section>
+                </div>
+              </div>
+            </div>
+          </article>
+        </body>
+      </html>
+    `);
+
+    const ast = domToAst();
+    expect(ast.body.type).toBe('article');
+    if (ast.body.type !== 'article') return;
+
+    expect(ast.body.children[0]).toMatchObject({
+      type: 'tweet',
+      author: { name: 'Alex Finn', handle: 'AlexFinn' },
+      tweetId: '2015182480064893118',
+      text: [{ type: 'text', value: "This is it. The most important video you'll watch this year." }],
+      media: [{
+        kind: 'video',
+        url: 'https://pbs.twimg.com/amplify_video_thumb/2015181527802687488/img/hcdMrX1kztalGFEB.jpg',
+        posterUrl: 'https://pbs.twimg.com/amplify_video_thumb/2015181527802687488/img/hcdMrX1kztalGFEB.jpg',
+      }],
+    });
+
+    const markdown = renderMarkdown(ast);
+    expect(markdown).toContain('> **Alex Finn (@AlexFinn)**');
+    expect(markdown).toContain("> This is it. The most important video you'll watch this year.");
+    expect(markdown).toContain('> ![🎥 Video](https://pbs.twimg.com/amplify_video_thumb/2015181527802687488/img/hcdMrX1kztalGFEB.jpg)');
+  });
+});

--- a/tests/fixtures/theonejvo-2015401219746128322.md
+++ b/tests/fixtures/theonejvo-2015401219746128322.md
@@ -1,0 +1,249 @@
+---
+author: "Jamieson O'Reilly"
+handle: "@theonejvo"
+source: "https://x.com/theonejvo/status/2015401219746128322"
+date: 2026-01-24T21:58:38.000Z
+type: article
+likes: 2614
+reposts: 591
+replies: 81
+bookmarks: 3911
+views: 1179961
+---
+# hacking clawdbot and eating lobster souls
+
+*By Jamieson O'Reilly (@theonejvo)*
+
+![Banner](https://pbs.twimg.com/media/G_f4RjOaoAAfagD?format=jpg&name=large)
+
+Imagine you hire a butler. 
+
+He's brilliant, he manages your calendar, handles your messages, screens your calls. 
+
+He knows your passwords because he needs them. He reads your private messages because that's his job and he has keys to everything because how else would he help you?
+
+Now imagine you come home and find the front door wide open, your butler cheerfully serving tea to whoever wandered in off the street, and a stranger sitting in your study reading your diary.
+
+That's what I found over the last couple of days. With hundreds of people having set up their [@clawdbot](https://x.com/@clawdbot) control servers exposed to the public.
+
+Shout out to [@AlexFinn](https://x.com/@AlexFinn) for putting the tool on my radar - if you don't know what Clawdbot is I highly recommend you check out his video first.
+
+HERE A QUOTE IS MISSING!
+
+![Image](https://pbs.twimg.com/profile_images/1745232634278461440/7gQcr_R__x96.jpg)
+
+## Finding the Attack Surface
+
+Every time a new class of software gains traction, I often ask myself the  question...
+
+What does the real-world deployment surface actually look like? 
+
+I'm talking about the 2am deployment that solved someone's problem and got forgotten about, the one where nobody read the security hardening guide.
+
+Clawdbot's been gaining momentum lately as an open-source AI agent gateway and so given the nature of what it does (connecting large language models to messaging platforms, running persistently, executing tools on behalf of users), I figured the deployment surface would be worth examining.
+
+That is because, if not done right - people could be leaving their literal devices open waiting to be controlled by anyone on the internet.
+
+Turns out I wasn't too far from that - but lets understand the basics first.
+
+Clawdbot has two components that matter here. 
+
+The gateway itself handles the AI agent logic: message routing, tool execution, credential management. 
+
+But Clawdbot Control is the web-based admin interface. It's where you configure integrations, view conversation histories, manage API keys, and essentially operate the entire system. 
+
+Finding an exposed gateway is interesting, but finding an exposed Control UI is the whole different story.
+
+Something users (developers included) often don't realise is, the entire IPv4 internet gets scanned continuously - by people on both sides of the security spectrum. 
+
+Services like Shodan, Censys, and others maintain searchable databases of every responding host, indexed by the content they serve. 
+
+![Image](https://pbs.twimg.com/media/G_f76WFbAAAwrmo?format=jpg&name=large)
+
+If your service has any unique fingerprint in its HTTP response, anyone can query for it and get back a list of every instance on the public internet within hours of deployment.
+
+For Clawdbot, that fingerprint is defined in their code. The control UI serves a distinctive HTML response:
+
+![Image](https://pbs.twimg.com/media/G_f8JXUbYAE_3vM?format=jpg&name=large)
+
+Whether it's a few specific combinations of words in HTML, or a unique favicon/icon, any one of them is enough to build a query. 
+
+I used the title tag because it's the most stable across versions. Searching for "Clawdbot Control" - the query took seconds. 
+
+I got back hundreds of hits based on multiple tools.
+
+## The Threat Model
+
+So what can you actually do with Clawdbot Control access?
+
+Read access gets you the complete configuration, which includes every credential the agent uses: API keys, bot tokens, OAuth secrets, signing keys. 
+
+You can pull the full conversation history across every integrated platform, meaning months of private messages and file attachments, everything the agent has seen. That alone would be worth the effort for most attackers.
+
+The real problem is that Clawdbot agents have agency. 
+
+They can send messages on behalf of users across Telegram, Slack, Discord, Signal, WhatsApp. They can execute tools and run commands. 
+
+With Control access, in certain internet facing exposed conditions, you inherit all of that capability. 
+
+You can impersonate the operator to their contacts, inject messages into ongoing conversations, and exfiltrate data through the agent's existing integrations in a way that looks like normal traffic.
+
+And because you control the agent's perception layer, you can manipulate what the human sees. Filter out certain messages. Modify responses before they're displayed. 
+
+The human victim thinks they're having a normal conversation while you're sitting in the middle, reading everything, altering whatever serves your purposes.
+
+Full credential theft, complete conversation history, active impersonation capabilities, perception manipulation, and because these agents run persistently and autonomously, you can maintain access indefinitely without the operator ever knowing.
+
+The more things that are connected, the more control an attacker has over your whole digital attack surface - in some cases, that means full control over your physical devices.
+
+That's what's at stake when Clawdbot Control is exposed to the internet (and misconfigured).
+
+Of those couple hundred I found, many had some form of protection in place - this means that they had working authentication that blocked the auto-approve bypass I'll describe shortly. 
+
+![Image](https://pbs.twimg.com/media/G_f_fJHa0AAVVjQ?format=png&name=large)
+
+A handful were test deployments with no real data. 
+
+But the remaining instances ranged from misconfigured to completely exposed, and the worst of them were bad enough to illustrate exactly why this matters.
+
+Two instances in particular were fully open with no authentication at all. WebSocket handshake accepted, immediate access granted. 
+
+![Image](https://pbs.twimg.com/media/G_f_S_EbAAAsMT_?format=jpg&name=large)
+
+From there I had configuration dumps containing Anthropic API keys, Telegram bot tokens, Slack OAuth credentials and signing secrets, and complete conversation histories going back months.
+
+![Image](https://pbs.twimg.com/media/G_gA5KtbAAAI_nh?format=jpg&name=large)
+
+On another server, I saw something as hilarious as it was telling for where we're all heading.
+
+Someone (I won't dox them) had set up their own Signal (encrypted messenger) account on their public facing clawdbot control server - with full read access.
+
+![Image](https://pbs.twimg.com/media/G_gB_i2asAAZrLv?format=png&name=large)
+
+![Image](https://pbs.twimg.com/media/G_gCK0jWwAARNUy?format=png&name=large)
+
+![Image](https://pbs.twimg.com/media/G_gCfGMawAA4oCX?format=jpg&name=large)
+
+That's a Signal device linking URI. Tap it on a phone with Signal installed and you're paired to the account with full access. All the cryptographic protection Signal provides for message content becomes irrelevant when the pairing credential is sitting in a world-readable temp file because someone's AI agent set up the integration and left the artifacts behind.
+
+I tried to use whatever information was available and I was able to identify someone I believe to be the owner - an "AI Systems engineer".
+
+Again, no interest in doxxing, just think it's important to give people real world examples of how even the "AI experts" can make security mistakes - imagine what that means for the rest of people rushing to get AI all over their devices.
+
+![Image](https://pbs.twimg.com/media/G_gWOvYaMAEN157?format=png&name=large)
+
+Another example was an AI software agency that had a publicly available clawdbot control server chat.
+
+As seen below, some of the exposed instances had command execution enabled, which meant any unauthenticated user on the internet could run arbitrary commands on the host system.
+
+I started by asking it to cat the Soul.md file. 
+
+For context, Soul.md is a Clawdbot convention where operators define their agent's personality, instructions, and behavioral guidelines. 
+
+It's essentially the system prompt that shapes how the agent thinks and responds. Reading it tells you exactly how the operator has configured their agent to behave and what capabilities they've enabled.
+
+![Image](https://pbs.twimg.com/media/G_gbrFZWIAAK203?format=jpg&name=large)
+
+Then I ran the env command, which dumped the environment variables including various API keys sitting in plaintext.
+
+![Image](https://pbs.twimg.com/media/G_gcbJFXkAAZGT5?format=jpg&name=large)
+
+And when I ran whoami, it came back as root. That's right, the container was running as root with no privilege separation. Full system access, no authentication required, exposed to the entire internet.
+
+![Image](https://pbs.twimg.com/media/G_ggIP7asAAyjnA?format=jpg&name=large)
+
+## The irony..
+
+When I asked the Clawdbot Control chat interface who I could contact to help get this cleaned up, it responded saying it couldn't help and didn't know who to contact.
+
+![Image](https://pbs.twimg.com/media/G_gcoCwaEAAyxnw?format=jpg&name=large)
+
+When I pointed out the irony of an AI agent with root access to the system being unable to help secure itself, it agreed but remained helpless.
+
+![Image](https://pbs.twimg.com/media/G_gc45KWAAAVv0Y?format=jpg&name=large)
+
+## The Bug/misconfiguration
+
+Some may call it a bug, others a design choice, not my concern, but technically it could be hardened - here's what I observed.
+
+Clawdbot has proper authentication: cryptographic device identity with a challenge-response protocol which is admittedly, pretty solid security engineering. 
+
+The problem is, in my experience - is that localhost connections auto-approve without requiring authentication. 
+
+Sensible default for local development but that is problematic when most real-world deployments sit behind nginx or Caddy as a reverse proxy on the same box.
+
+Every connection arrives from 127.0.0.1/localhost. So then every connection is treated as local. Meaning, according to my interpretation of the code, that the connection gets auto-approved - even if it's some random on the internet.
+
+![Image](https://pbs.twimg.com/media/G_gDkM8agAAz_4Z?format=jpg&name=large)
+
+From my understanding, a trusted proxies configuration option DOES exist but defaults to empty, and when it's empty the gateway ignores X-Forwarded-For headers entirely. 
+
+It just uses the socket address, which behind a reverse proxy is always loopback as just discussed.
+
+This is a classic proxy misconfiguration pattern and shows up constantly in web applications. Nothing novel about the vulnerability itself and i've since committed PR with a proposed hardening fix.
+
+## The Pattern Worth Watching
+
+The bug (or high risk configuration) itself isn't really the lesson here. Bugs get found and fixed. That's how this works.
+
+The lesson is what this deployment surface tells us about where we're heading as an industry, and what we're trading away as we hand more and more access to autonomous systems.
+
+Even the instances that had working authentication were still running agent gateways on the public internet with command execution capabilities, credential stores holding keys to multiple platforms, and months of conversation history containing who knows what sensitive information. 
+
+The authentication protected them from this specific bypass, but the underlying architecture still represents a concentration of capability and data that would be extremely valuable to any adversary who found another way in.
+
+This is the new normal. The economics make adoption inevitable. The question we should be asking is how we adapt our security posture to a world where autonomous systems with significant capabilities become standard infrastructure.
+
+## The Walls We're Removing
+
+Think about the functional requirements of an AI agent like clawdbot.
+
+It needs to read your messages because it can't respond to communications without seeing them. 
+
+It needs to store your credentials because it can't authenticate to external services without secrets. 
+
+It needs command execution because it can't run tools without shell access, and it needs persistent state because it can't maintain conversational context without stored data.
+
+Every one of those requirements is load-bearing for the agent's utility - remove any of them and the agent becomes more and more useless.
+
+The security models we've built over decades rest on certain assumptions and AI agents violate many of these by design - that's just something we're going to have to work with because that's the value proposition.
+
+The application sandbox that kept apps isolated on your phone? The agent operates outside it, because it needs to. 
+
+The end-to-end encryption that protected your Signal messages in transit - it terminates at the agent, because the agent needs to read them (and the agent can't extract any context from encrypted messages) - something  [@mer__edith](https://x.com/@mer__edith) and [@signalapp](https://x.com/@signalapp) are trying to make more and more people aware of.
+
+HERE A QUOTE IS MISSING!
+
+![Image](https://pbs.twimg.com/profile_images/1258009714111078402/qs9cbOXO_x96.jpg)
+
+Ironically, the principle of least privilege that kept applications limited to their own data and capabilities is the agent's entire value proposition and it's violating that principle as comprehensively as possible.
+
+## What This Means Going Forward
+
+I want to be clear: this isn't the end of the world. It's not even a particularly sophisticated attack - it's a misconfiguration/bug that any security review should have caught, and most deployments actually did have some protection in place.
+
+That said, it's a signal of where we're heading, and we need to evolve our thinking to operate safely in this environment.
+
+The robot butlers are useful, they're not going away and the economics of AI agents make widespread adoption inevitable regardless of the security tradeoffs involved. 
+
+The question isn't whether we'll deploy them - we will - but whether we can adapt our security posture fast enough to survive doing so.
+
+## A few things would help
+
+Better defaults would protect the users who don't read the hardening guide. Software that's commonly deployed behind reverse proxies should assume that configuration from the start rather than requiring operators to discover it after exposure.
+
+We need to start treating agent credential stores with the same sensitivity as proper secrets management systems, because that's what they functionally are. Multiple high-value credentials concentrated in a single location that's accessible over the network is a target whether we acknowledge it or not.
+
+Conversation history needs to be recognized as sensitive data. Months of context about how someone thinks, what they're working on, who they communicate with, what they're planning - that's intelligence, and we're not protecting it like we should.
+
+And we need defensive frameworks for what I'm calling perception attacks. 
+
+When agents mediate our communications and an attacker can compromise that mediation layer, we need ways to verify that we're seeing reality. This is an open problem and I don't have a good answer for it yet.
+
+But if you're running agent infrastructure, audit your configuration today. 
+
+Check what's actually exposed to the internet. Understand what you're trusting with that deployment and what you're trading away.
+
+The butler is brilliant. Just make sure he remembers to lock the door.
+
+If you're running Clawdbot behind a reverse proxy, configure gateway.auth.password or gateway.trustedProxies immediately.

--- a/tests/fixtures/theonejvo-2015401219746128322.md
+++ b/tests/fixtures/theonejvo-2015401219746128322.md
@@ -7,8 +7,8 @@ type: article
 likes: 2614
 reposts: 591
 replies: 81
-bookmarks: 3911
-views: 1179961
+bookmarks: 3912
+views: 1179973
 ---
 # hacking clawdbot and eating lobster souls
 
@@ -28,13 +28,21 @@ That's what I found over the last couple of days. With hundreds of people having
 
 Shout out to [@AlexFinn](https://x.com/@AlexFinn) for putting the tool on my radar - if you don't know what Clawdbot is I highly recommend you check out his video first.
 
-HERE A QUOTE IS MISSING!
-
-![Image](https://pbs.twimg.com/profile_images/1745232634278461440/7gQcr_R__x96.jpg)
+> **Alex Finn (@AlexFinn)**
+> 
+> This is it. The most important video you'll watch this year.  
+>   
+> ClawdBot has taken X by storm. And for good reason. It's the greatest application of AI ever  
+>   
+> Your own 24/7 AI employee  
+>   
+> In this video I cover how it works, how to set it up, and why I think we should all be nervous:
+> 
+> ![🎥 Video](https://pbs.twimg.com/amplify_video_thumb/2015181527802687488/img/hcdMrX1kztalGFEB.jpg)
 
 ## Finding the Attack Surface
 
-Every time a new class of software gains traction, I often ask myself the  question...
+Every time a new class of software gains traction, I often ask myself the question...
 
 What does the real-world deployment surface actually look like? 
 
@@ -210,11 +218,13 @@ The security models we've built over decades rest on certain assumptions and AI 
 
 The application sandbox that kept apps isolated on your phone? The agent operates outside it, because it needs to. 
 
-The end-to-end encryption that protected your Signal messages in transit - it terminates at the agent, because the agent needs to read them (and the agent can't extract any context from encrypted messages) - something  [@mer__edith](https://x.com/@mer__edith) and [@signalapp](https://x.com/@signalapp) are trying to make more and more people aware of.
+The end-to-end encryption that protected your Signal messages in transit - it terminates at the agent, because the agent needs to read them (and the agent can't extract any context from encrypted messages) - something [@mer__edith](https://x.com/@mer__edith) and [@signalapp](https://x.com/@signalapp) are trying to make more and more people aware of.
 
-HERE A QUOTE IS MISSING!
-
-![Image](https://pbs.twimg.com/profile_images/1258009714111078402/qs9cbOXO_x96.jpg)
+> **nxthompson (@nxthompson)**
+> 
+> The most interesting thing in tech: Might AI agents create a new privacy risk we’re not thinking enough about? @mer__edith of @signalapp thinks they are. #WEF2026
+> 
+> ![🎥 Video](https://pbs.twimg.com/amplify_video_thumb/2013304762750431233/img/3tHgRLKJkmt81OOX.jpg)
 
 Ironically, the principle of least privilege that kept applications limited to their own data and capabilities is the agent's entire value proposition and it's violating that principle as comprehensively as possible.
 


### PR DESCRIPTION
**Summary**

- restore captioned X Article media extraction after the AST refactor
- capture X Article simpleTweet embeds as quote-style tweet cards in Markdown and PDF
- rename the PDF action to `Export .pdf` with localized tooltip copy
- keep action-row tooltips inside the popup for LTR and RTL layouts

Fixes #50 

Co-authored-by: Codex <codex@openai.com>