### PR TITLE
feat(export): HTML, JSON, TXT, CSV single-export formats (#54)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
+## [Unreleased]
+
+### Added
+
+- **More single-export formats** (issue #54): alongside Markdown and PDF, a single post can now be saved as **HTML** (a styled, self-contained file), **JSON** (the raw structured document), **TXT** (plain text, markup stripped), or **CSV** (one metadata row whose columns follow your selected Default/Obsidian frontmatter fields). Four new icon buttons sit below the PDF/Obsidian row in the popup.
+
+---
 ## [2.1.0] - 2026-06-12
 
 ### Added

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -23,6 +23,18 @@
   "btn_obsidian": {
     "message": "Add to Obsidian"
   },
+  "btn_html_hint": {
+    "message": "Save as a styled, self-contained HTML file."
+  },
+  "btn_json_hint": {
+    "message": "Save the raw structured document (AST) as JSON."
+  },
+  "btn_txt_hint": {
+    "message": "Save as plain text with markup stripped."
+  },
+  "btn_csv_hint": {
+    "message": "Save one metadata row using your selected frontmatter fields."
+  },
   "btn_batch": {
     "message": "Export bookmarks"
   },

--- a/src/background/background.ts
+++ b/src/background/background.ts
@@ -253,8 +253,9 @@ chrome.runtime.onMessage.addListener(
         }
       }
 
+      const mime = message.mime || 'text/markdown';
       const dataUrl =
-        'data:text/markdown;charset=utf-8,' +
+        `data:${mime};charset=utf-8,` +
         encodeURIComponent(message.content);
 
       chrome.downloads.download(

--- a/src/popup/actions.ts
+++ b/src/popup/actions.ts
@@ -3,8 +3,9 @@
 // current selections from the DOM refs and the settings-form field maps; it
 // does not own any settings state.
 
-import type { ExtractResponse, DownloadRequest } from '../types/messages';
-import { postProcess, resolveDownloadImages, type PostProcessResult } from '../shared/post-process';
+import type { ExtractResponse, DownloadRequest, ExtractedContent } from '../types/messages';
+import { postProcess, resolveDownloadImages, buildFilename, type PostProcessResult } from '../shared/post-process';
+import { buildFormatExport, type ExportFormat } from '../shared/export-formats';
 import { buildObsidianUrl } from '../shared/obsidian';
 import { hostMatches } from '../shared/media';
 import { currentFrontmatterFields } from './settings-form';
@@ -13,6 +14,10 @@ import {
   btnCopy,
   btnPdf,
   btnObsidian,
+  btnHtml,
+  btnJson,
+  btnTxt,
+  btnCsv,
   statusEl,
   chkMetadata,
   chkInlineStats,
@@ -23,6 +28,11 @@ import {
   txtObsidianVault,
   txtObsidianFolder,
 } from './dom';
+
+// Every button the export flows disable while one of them is running, so a
+// second click can't race an in-flight extraction.
+const formatButtons = [btnHtml, btnJson, btnTxt, btnCsv];
+const allExportButtons = [btnDownload, btnCopy, btnPdf, btnObsidian, ...formatButtons];
 
 function showStatus(
   message: string,
@@ -40,10 +50,7 @@ function showStatus(
 }
 
 function setLoading(loading: boolean, target?: 'download' | 'copy' | 'obsidian' | 'pdf'): void {
-  btnDownload.disabled = loading;
-  btnCopy.disabled = loading;
-  btnObsidian.disabled = loading;
-  btnPdf.disabled = loading;
+  for (const btn of allExportButtons) btn.disabled = loading;
 
   // Only animate the button that was actually clicked
   if (target === 'download' || !target) {
@@ -84,9 +91,10 @@ function setLoading(loading: boolean, target?: 'download' | 'copy' | 'obsidian' 
   }
 }
 
-async function extractMarkdown(
-  forAction: 'download' | 'copy' | 'obsidian' = 'download',
-): Promise<PostProcessResult> {
+// Shared up-front guard + extraction: resolve the active tab, confirm it's a
+// specific X.com status page, and run EXTRACT. Both the Markdown flows and the
+// alternate-format exports build on the ExtractedContent it returns.
+async function extractContent(includeMetadata: boolean): Promise<ExtractedContent> {
   const [tab] = await chrome.tabs.query({
     active: true,
     currentWindow: true,
@@ -107,6 +115,21 @@ async function extractMarkdown(
     );
   }
 
+  const response: ExtractResponse = await chrome.tabs.sendMessage(tab.id, {
+    action: 'EXTRACT',
+    includeMetadata,
+  });
+
+  if (!response.success || !response.data) {
+    throw new Error(response.error || chrome.i18n.getMessage('error_failed') || 'Failed to extract content.');
+  }
+
+  return response.data;
+}
+
+async function extractMarkdown(
+  forAction: 'download' | 'copy' | 'obsidian' = 'download',
+): Promise<PostProcessResult> {
   const includeMetadata = chkMetadata.checked;
   const inlineStats = chkInlineStats.checked;
   // "Add to Obsidian" is *the* Obsidian path — force the Obsidian schema
@@ -119,17 +142,10 @@ async function extractMarkdown(
   const downloadImages =
     forAction === 'obsidian' ? false : resolveDownloadImages(forAction, chkDownloadImages.checked);
 
-  const response: ExtractResponse = await chrome.tabs.sendMessage(tab.id, {
-    action: 'EXTRACT',
-    // Need engagement data if either renderer wants it.
-    includeMetadata: includeMetadata || inlineStats,
-  });
+  // Need engagement data if either renderer wants it.
+  const data = await extractContent(includeMetadata || inlineStats);
 
-  if (!response.success || !response.data) {
-    throw new Error(response.error || chrome.i18n.getMessage('error_failed') || 'Failed to extract content.');
-  }
-
-  return postProcess(response.data, {
+  return postProcess(data, {
     includeMetadata,
     downloadImages,
     inlineStats,
@@ -288,4 +304,59 @@ export function initActions(): void {
       handleExtractionError(err);
     }
   });
+
+  // ─── Alternate-format exports (HTML / JSON / TXT / CSV) ───
+  const formatTargets: { btn: HTMLButtonElement; format: ExportFormat }[] = [
+    { btn: btnHtml, format: 'html' },
+    { btn: btnJson, format: 'json' },
+    { btn: btnTxt, format: 'txt' },
+    { btn: btnCsv, format: 'csv' },
+  ];
+  for (const { btn, format } of formatTargets) {
+    btn.addEventListener('click', () => runFormatExport(format, btn));
+  }
+}
+
+// Build one of the alternate formats from the current page and hand it to the
+// background download handler. Metadata is always requested so CSV/JSON/HTML
+// have engagement counts available regardless of the popup toggles.
+async function runFormatExport(format: ExportFormat, btn: HTMLButtonElement): Promise<void> {
+  for (const b of allExportButtons) b.disabled = true;
+  btn.classList.add('loading');
+  statusEl.className = 'status hidden';
+
+  try {
+    const data = await extractContent(true);
+    const obsidianFriendly = chkObsidianFriendly.checked;
+    const exported = buildFormatExport(format, data, {
+      includeEngagement: chkInlineStats.checked,
+      obsidianFriendly,
+      frontmatterFields: currentFrontmatterFields(obsidianFriendly),
+      obsidianTagsTemplate: txtObsidianTags.value.trim(),
+    });
+
+    const filename = buildFilename(data, txtFilenameTemplate.value.trim()).replace(/\.md$/i, `.${exported.ext}`);
+
+    const downloadMsg: DownloadRequest = {
+      action: 'DOWNLOAD_MD',
+      content: exported.content,
+      filename,
+      mime: exported.mime,
+    };
+
+    chrome.runtime.sendMessage(downloadMsg, (downloadResponse) => {
+      if (chrome.runtime.lastError || !downloadResponse?.success) {
+        showStatus(downloadResponse?.error || chrome.i18n.getMessage('download_failed') || 'Download failed.', 'error');
+      } else {
+        showStatus(`✓ .${exported.ext} ${chrome.i18n.getMessage('downloaded') || 'Downloaded!'}`, 'success');
+      }
+      btn.classList.remove('loading');
+      for (const b of allExportButtons) b.disabled = false;
+    });
+  } catch (err) {
+    // handleExtractionError → setLoading(false) re-enables the buttons; it only
+    // clears the loading class on the Markdown/PDF buttons, so drop ours here.
+    btn.classList.remove('loading');
+    handleExtractionError(err);
+  }
 }

--- a/src/popup/dom.ts
+++ b/src/popup/dom.ts
@@ -10,6 +10,12 @@ export const btnPdf = document.getElementById('btn-pdf') as HTMLButtonElement;
 export const btnObsidian = document.getElementById('btn-obsidian') as HTMLButtonElement;
 export const statusEl = document.getElementById('status') as HTMLDivElement;
 
+// ─── Alternate single-export formats (HTML / JSON / TXT / CSV) ────────
+export const btnHtml = document.getElementById('btn-html') as HTMLButtonElement;
+export const btnJson = document.getElementById('btn-json') as HTMLButtonElement;
+export const btnTxt = document.getElementById('btn-txt') as HTMLButtonElement;
+export const btnCsv = document.getElementById('btn-csv') as HTMLButtonElement;
+
 // ─── Batch export (bookmarks) ────────────────────────────────────────
 export const btnBatch = document.getElementById('btn-batch') as HTMLButtonElement;
 export const btnBatchLabel = document.getElementById('btn-batch-label') as HTMLSpanElement;

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -261,6 +261,44 @@ body {
   color: var(--obsidian);
 }
 
+/* Alternate formats (HTML / JSON / TXT / CSV): four neutral buttons in one
+ * row below PDF/Obsidian. Kept grey so they don't compete with the colored
+ * Markdown/PDF/Obsidian actions above. Label is just the file extension. */
+.format-row {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  margin-bottom: 8px;
+}
+
+.btn-format {
+  flex: 1 1 0;
+  /* Tighter than the half-width action buttons — four fit the popup width. */
+  padding: 9px 6px;
+  gap: 4px;
+  font-size: 12px;
+  background: transparent;
+  color: var(--text-secondary);
+  border: 1px solid var(--text-secondary);
+}
+
+.btn-format .btn-icon {
+  width: 14px;
+  height: 14px;
+  color: currentColor;
+}
+
+.btn-format:hover {
+  background: var(--bg-hover);
+  color: var(--text-primary);
+  border-color: var(--text-primary);
+  box-shadow: none;
+}
+
+.btn-format:active {
+  box-shadow: none;
+}
+
 /* Download (.btn-primary) + Copy (.btn-secondary): outlined accent, matching
  * the PDF/Obsidian buttons. The old solid fill read like the active tab
  * toggle; outlining keeps all four action buttons consistent. */

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -112,29 +112,6 @@
         </button>
         </div>
 
-        <div class="action-row">
-          <button id="btn-pdf" class="btn-pdf btn-action" type="button"
-            data-tooltip="Generate a formatted PDF export with current settings, then choose where to save it."
-            data-i18n-tooltip="btn_pdf_hint">
-            <svg class="btn-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
-              stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-              <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
-              <polyline points="14 2 14 8 20 8" />
-              <text x="7.5" y="18" font-size="6" font-weight="700" fill="currentColor" stroke="none">PDF</text>
-            </svg>
-            <span class="btn-label" data-i18n="btn_pdf">Export .pdf</span>
-          </button>
-
-          <button id="btn-obsidian" class="btn-obsidian btn-action" type="button"
-            data-tooltip="Configure vault, subfolder, and frontmatter fields in Settings. Use the 'Download .md' button for long threads or images."
-            data-i18n-tooltip="btn_obsidian_hint">
-            <svg class="btn-icon" viewBox="0 0 24 24" aria-hidden="true" fill="currentColor">
-              <path d="M19.355 18.538a68.967 68.959 0 0 0 1.858-2.954.81.81 0 0 0-.062-.9c-.516-.685-1.504-2.075-2.042-3.362-.553-1.321-.636-3.375-.64-4.377a1.707 1.707 0 0 0-.358-1.05l-3.198-4.064a3.744 3.744 0 0 1-.076.543c-.106.503-.307 1.004-.536 1.5-.134.29-.29.6-.446.914l-.31.626c-.516 1.068-.997 2.227-1.132 3.59-.124 1.26.046 2.73.815 4.481.128.011.257.025.386.044a6.363 6.363 0 0 1 3.326 1.505c.916.79 1.744 1.922 2.415 3.5zM8.199 22.569c.073.012.146.02.22.02.78.024 2.095.092 3.16.29.87.16 2.593.64 4.01 1.055 1.083.316 2.198-.548 2.355-1.664.114-.814.33-1.735.725-2.58l-.01.005c-.67-1.87-1.522-3.078-2.416-3.849a5.295 5.295 0 0 0-2.778-1.257c-1.54-.216-2.952.19-3.84.45.532 2.218.368 4.829-1.425 7.531zM5.533 9.938c-.023.1-.056.197-.098.29L2.82 16.059a1.602 1.602 0 0 0 .313 1.772l4.116 4.24c2.103-3.101 1.796-6.02.836-8.3-.728-1.73-1.832-3.081-2.55-3.831zM9.32 14.01c.615-.183 1.606-.465 2.745-.534-.683-1.725-.848-3.233-.716-4.577.154-1.552.7-2.847 1.235-3.95.113-.235.223-.454.328-.664.149-.297.288-.577.419-.86.217-.47.379-.885.46-1.27.08-.38.08-.72-.014-1.043-.095-.325-.297-.675-.68-1.06a1.6 1.6 0 0 0-1.475.36l-4.95 4.452a1.602 1.602 0 0 0-.513.952l-.427 2.83c.672.59 2.328 2.316 3.335 4.711.09.21.175.43.253.653z" />
-            </svg>
-            <span class="btn-label" data-i18n="btn_obsidian">Add to Obsidian</span>
-          </button>
-        </div>
-
         <div class="format-row">
           <button id="btn-html" class="btn-format btn-action" type="button"
             data-tooltip="Save as a styled, self-contained HTML file." data-i18n-tooltip="btn_html_hint">
@@ -175,6 +152,29 @@
               <line x1="15" y1="4" x2="15" y2="20" />
             </svg>
             <span class="btn-label">.csv</span>
+          </button>
+        </div>
+
+        <div class="action-row">
+          <button id="btn-pdf" class="btn-pdf btn-action" type="button"
+            data-tooltip="Generate a formatted PDF export with current settings, then choose where to save it."
+            data-i18n-tooltip="btn_pdf_hint">
+            <svg class="btn-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+              stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+              <polyline points="14 2 14 8 20 8" />
+              <text x="7.5" y="18" font-size="6" font-weight="700" fill="currentColor" stroke="none">PDF</text>
+            </svg>
+            <span class="btn-label" data-i18n="btn_pdf">Export .pdf</span>
+          </button>
+
+          <button id="btn-obsidian" class="btn-obsidian btn-action" type="button"
+            data-tooltip="Configure vault, subfolder, and frontmatter fields in Settings. Use the 'Download .md' button for long threads or images."
+            data-i18n-tooltip="btn_obsidian_hint">
+            <svg class="btn-icon" viewBox="0 0 24 24" aria-hidden="true" fill="currentColor">
+              <path d="M19.355 18.538a68.967 68.959 0 0 0 1.858-2.954.81.81 0 0 0-.062-.9c-.516-.685-1.504-2.075-2.042-3.362-.553-1.321-.636-3.375-.64-4.377a1.707 1.707 0 0 0-.358-1.05l-3.198-4.064a3.744 3.744 0 0 1-.076.543c-.106.503-.307 1.004-.536 1.5-.134.29-.29.6-.446.914l-.31.626c-.516 1.068-.997 2.227-1.132 3.59-.124 1.26.046 2.73.815 4.481.128.011.257.025.386.044a6.363 6.363 0 0 1 3.326 1.505c.916.79 1.744 1.922 2.415 3.5zM8.199 22.569c.073.012.146.02.22.02.78.024 2.095.092 3.16.29.87.16 2.593.64 4.01 1.055 1.083.316 2.198-.548 2.355-1.664.114-.814.33-1.735.725-2.58l-.01.005c-.67-1.87-1.522-3.078-2.416-3.849a5.295 5.295 0 0 0-2.778-1.257c-1.54-.216-2.952.19-3.84.45.532 2.218.368 4.829-1.425 7.531zM5.533 9.938c-.023.1-.056.197-.098.29L2.82 16.059a1.602 1.602 0 0 0 .313 1.772l4.116 4.24c2.103-3.101 1.796-6.02.836-8.3-.728-1.73-1.832-3.081-2.55-3.831zM9.32 14.01c.615-.183 1.606-.465 2.745-.534-.683-1.725-.848-3.233-.716-4.577.154-1.552.7-2.847 1.235-3.95.113-.235.223-.454.328-.664.149-.297.288-.577.419-.86.217-.47.379-.885.46-1.27.08-.38.08-.72-.014-1.043-.095-.325-.297-.675-.68-1.06a1.6 1.6 0 0 0-1.475.36l-4.95 4.452a1.602 1.602 0 0 0-.513.952l-.427 2.83c.672.59 2.328 2.316 3.335 4.711.09.21.175.43.253.653z" />
+            </svg>
+            <span class="btn-label" data-i18n="btn_obsidian">Add to Obsidian</span>
           </button>
         </div>
       </div>

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -134,6 +134,49 @@
             <span class="btn-label" data-i18n="btn_obsidian">Add to Obsidian</span>
           </button>
         </div>
+
+        <div class="format-row">
+          <button id="btn-html" class="btn-format btn-action" type="button"
+            data-tooltip="Save as a styled, self-contained HTML file." data-i18n-tooltip="btn_html_hint">
+            <svg class="btn-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+              stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+              <polyline points="14 2 14 8 20 8" />
+            </svg>
+            <span class="btn-label">.html</span>
+          </button>
+          <button id="btn-json" class="btn-format btn-action" type="button"
+            data-tooltip="Save the raw structured document (AST) as JSON." data-i18n-tooltip="btn_json_hint">
+            <svg class="btn-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+              stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <path d="M8 3H7a2 2 0 0 0-2 2v4a2 2 0 0 1-2 2 2 2 0 0 1 2 2v4a2 2 0 0 0 2 2h1" />
+              <path d="M16 3h1a2 2 0 0 1 2 2v4a2 2 0 0 0 2 2 2 2 0 0 0-2 2v4a2 2 0 0 1-2 2h-1" />
+            </svg>
+            <span class="btn-label">.json</span>
+          </button>
+          <button id="btn-txt" class="btn-format btn-action" type="button"
+            data-tooltip="Save as plain text with markup stripped." data-i18n-tooltip="btn_txt_hint">
+            <svg class="btn-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+              stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+              <polyline points="14 2 14 8 20 8" />
+              <line x1="8" y1="13" x2="16" y2="13" />
+              <line x1="8" y1="17" x2="16" y2="17" />
+            </svg>
+            <span class="btn-label">.txt</span>
+          </button>
+          <button id="btn-csv" class="btn-format btn-action" type="button"
+            data-tooltip="Save one metadata row using your selected frontmatter fields." data-i18n-tooltip="btn_csv_hint">
+            <svg class="btn-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+              stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <rect x="3" y="4" width="18" height="16" rx="2" />
+              <line x1="3" y1="10" x2="21" y2="10" />
+              <line x1="9" y1="4" x2="9" y2="20" />
+              <line x1="15" y1="4" x2="15" y2="20" />
+            </svg>
+            <span class="btn-label">.csv</span>
+          </button>
+        </div>
       </div>
 
       <div id="batch-section" class="batch-section export-panel hidden">

--- a/src/shared/export-formats.ts
+++ b/src/shared/export-formats.ts
@@ -1,0 +1,173 @@
+// Alternate single-export formats (issue #54): HTML, JSON, TXT, CSV.
+//
+// Markdown / PDF have their own established paths (postProcess + renderPdfHtml).
+// These four reuse what already exists:
+//   - HTML reuses renderPdfHtml (the same standalone document the PDF flow prints)
+//   - JSON serializes the canonical AST Document (same shape as the batch JSON sink)
+//   - TXT strips markup from the AST-rendered Markdown, keeping link URLs
+//   - CSV emits one row whose columns are the active frontmatter fields
+//
+// The popup picks the format; this module turns an ExtractedContent (+ the
+// user's current settings) into { content, mime, ext } ready for DOWNLOAD_MD.
+
+import type { ExtractedContent } from '../types/messages';
+import { renderPdfHtml } from '../ast/render-pdf-html';
+import {
+  FRONTMATTER_FIELDS_DEFAULT,
+  FRONTMATTER_FIELDS_OBSIDIAN,
+  DEFAULT_TAGS_TEMPLATE,
+  applyTagsTemplate,
+  buildTitle,
+  buildDescription,
+  isoToDateOnly,
+  todayISODate,
+} from './post-process';
+
+export type ExportFormat = 'html' | 'json' | 'txt' | 'csv';
+
+export interface FormatExport {
+  content: string;
+  mime: string;
+  ext: string;
+}
+
+export interface FormatOptions {
+  // Render engagement metrics on HTML tweet cards (mirrors the PDF flow).
+  includeEngagement?: boolean;
+  // Selects which frontmatter field set drives the CSV columns.
+  obsidianFriendly?: boolean;
+  // Per-field opt-out, same map the Markdown frontmatter uses. Missing key =
+  // enabled.
+  frontmatterFields?: Record<string, boolean>;
+  // Tags template for the CSV `tags` column (Obsidian field set only).
+  obsidianTagsTemplate?: string;
+}
+
+export function buildFormatExport(
+  format: ExportFormat,
+  data: ExtractedContent,
+  opts: FormatOptions = {}
+): FormatExport {
+  switch (format) {
+    case 'html': {
+      if (!data.body) throw new Error('HTML export needs the document AST.');
+      return {
+        content: renderPdfHtml(data.body, { includeEngagement: opts.includeEngagement }),
+        mime: 'text/html',
+        ext: 'html',
+      };
+    }
+    case 'json':
+      // Prefer the structured AST; fall back to the wire object for older
+      // producers that didn't attach `body`.
+      return {
+        content: JSON.stringify(data.body ?? data, null, 2),
+        mime: 'application/json',
+        ext: 'json',
+      };
+    case 'txt':
+      return { content: markdownToPlainText(data.markdown), mime: 'text/plain', ext: 'txt' };
+    case 'csv':
+      return { content: buildCsvRow(data, opts), mime: 'text/csv', ext: 'csv' };
+  }
+}
+
+// ─── TXT ────────────────────────────────────────────────────────────
+//
+// The AST-rendered Markdown (data.markdown) is already plain prose with light
+// markup. Strip the markup but keep link URLs so the text stays useful offline.
+export function markdownToPlainText(markdown: string): string {
+  return (
+    markdown
+      // images: ![alt](url) → "alt: url" (or just the URL when alt is empty)
+      .replace(/!\[([^\]]*)\]\(([^)]+)\)/g, (_m, alt: string, url: string) =>
+        alt ? `${alt}: ${url}` : url
+      )
+      // links: [text](url) → "text (url)", but collapse when text === url
+      .replace(/\[([^\]]+)\]\(([^)]+)\)/g, (_m, text: string, url: string) =>
+        text === url ? url : `${text} (${url})`
+      )
+      // headings: drop leading #'s
+      .replace(/^#{1,6}\s+/gm, '')
+      // blockquote markers
+      .replace(/^>\s?/gm, '')
+      // bold / italic / inline code markers
+      .replace(/\*\*([^*]+)\*\*/g, '$1')
+      .replace(/(^|[^*])\*([^*]+)\*/g, '$1$2')
+      .replace(/`([^`]+)`/g, '$1')
+      // collapse 3+ blank lines
+      .replace(/\n{3,}/g, '\n\n')
+      .trim() + '\n'
+  );
+}
+
+// ─── CSV ────────────────────────────────────────────────────────────
+//
+// One header row + one data row. Columns are the active frontmatter fields for
+// the current mode (Default or Obsidian-friendly), honoring the per-field
+// toggles — the same selection the Markdown frontmatter uses. CSV is inherently
+// the metadata export, so it does not gate on the "Include metadata" toggle.
+export function buildCsvRow(data: ExtractedContent, opts: FormatOptions = {}): string {
+  const fieldOrder = opts.obsidianFriendly ? FRONTMATTER_FIELDS_OBSIDIAN : FRONTMATTER_FIELDS_DEFAULT;
+  const enabled = opts.frontmatterFields;
+  const includeField = (key: string) => !enabled || enabled[key] !== false;
+
+  const columns = fieldOrder.filter(includeField);
+  const header = columns.map(csvEscape).join(',');
+  const row = columns.map((key) => csvEscape(fieldValue(key, data, opts))).join(',');
+  return `${header}\n${row}\n`;
+}
+
+function fieldValue(key: string, data: ExtractedContent, opts: FormatOptions): string {
+  const m = data.metadata;
+  switch (key) {
+    case 'title':
+      return buildTitle(data);
+    case 'source':
+      return data.sourceUrl;
+    case 'author':
+      // Default field set shows the display name; the Obsidian set reserves
+      // `author` for the handle (it's the wikilink target there) and carries
+      // the name separately in `author_name`.
+      return opts.obsidianFriendly ? data.author.handle : data.author.name;
+    case 'author_name':
+      return data.author.name;
+    case 'handle':
+      return data.author.handle;
+    case 'date':
+      return data.date;
+    case 'published':
+      return isoToDateOnly(data.date);
+    case 'created':
+      return todayISODate();
+    case 'type':
+      return data.type;
+    case 'description':
+      return buildDescription(data.markdown);
+    case 'tags': {
+      const template = (opts.obsidianTagsTemplate ?? '').trim() || DEFAULT_TAGS_TEMPLATE;
+      return applyTagsTemplate(template, data).join(' ');
+    }
+    case 'likes':
+      return m?.likes !== undefined ? String(m.likes) : '';
+    case 'reposts':
+      return m?.reposts !== undefined ? String(m.reposts) : '';
+    case 'replies':
+      return m?.replies !== undefined ? String(m.replies) : '';
+    case 'bookmarks':
+      return m?.bookmarks !== undefined ? String(m.bookmarks) : '';
+    case 'views':
+      return m?.views !== undefined ? String(m.views) : '';
+    default:
+      return '';
+  }
+}
+
+// RFC 4180: quote when the value contains a comma, quote, CR or LF; escape
+// embedded quotes by doubling them.
+function csvEscape(value: string): string {
+  if (/[",\r\n]/.test(value)) {
+    return `"${value.replace(/"/g, '""')}"`;
+  }
+  return value;
+}

--- a/src/shared/post-process.ts
+++ b/src/shared/post-process.ts
@@ -59,11 +59,11 @@ export const DEFAULT_TAGS_TEMPLATE = 'clippings, x, {type}';
 
 const DESCRIPTION_MAX_CHARS = 200;
 
-function todayISODate(): string {
+export function todayISODate(): string {
   return new Date().toISOString().slice(0, 10);
 }
 
-function isoToDateOnly(iso: string): string {
+export function isoToDateOnly(iso: string): string {
   const m = iso.match(/^(\d{4}-\d{2}-\d{2})/);
   return m ? m[1] : iso;
 }
@@ -71,7 +71,7 @@ function isoToDateOnly(iso: string): string {
 // Pull a short, plain-text preview from the markdown body. Drops the
 // author H1, frontmatter, blockquotes, list bullets, link/image syntax,
 // and emoji-prefixed UI lines so the description reads like prose.
-function buildDescription(markdown: string): string {
+export function buildDescription(markdown: string): string {
   let body = markdown.replace(/^---[\s\S]*?---\s*/m, '');
   body = body.replace(/^# .*$/m, '');
   const lines = body.split('\n');
@@ -94,7 +94,7 @@ function buildDescription(markdown: string): string {
   return text.slice(0, DESCRIPTION_MAX_CHARS).replace(/\s+\S*$/, '') + '…';
 }
 
-function buildTitle(data: ExtractedContent): string {
+export function buildTitle(data: ExtractedContent): string {
   if (data.type === 'article' && data.title) return data.title;
   const noun = data.type === 'thread' ? 'Thread' : 'Post';
   return `${noun} by ${data.author.handle} on X`;

--- a/src/types/messages.ts
+++ b/src/types/messages.ts
@@ -37,6 +37,10 @@ export interface DownloadRequest {
   content: string;
   filename: string;
   images?: { url: string; filename: string }[];
+  // MIME type for the data: URL. Defaults to text/markdown. Set by the
+  // alternate-format exports (HTML/JSON/TXT/CSV) so the saved file carries the
+  // right type; Chrome still names the file from `filename`'s extension.
+  mime?: string;
 }
 
 export interface ExportPdfRequest {

--- a/tests/export-formats.test.ts
+++ b/tests/export-formats.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from 'vitest';
+import { buildFormatExport, buildCsvRow, markdownToPlainText } from '../src/shared/export-formats';
+import type { ExtractedContent } from '../src/types/messages';
+import type { Document } from '../src/ast/types';
+
+const doc: Document = {
+  version: 1,
+  metadata: {
+    type: 'tweet',
+    sourceUrl: 'https://x.com/jane/status/123',
+    tweetId: '123',
+    author: { name: 'Jane Doe', handle: '@jane' },
+    date: '2026-01-02T10:00:00.000Z',
+    engagement: { likes: 5, reposts: 2 },
+  },
+  body: {
+    type: 'tweet',
+    author: { name: 'Jane Doe', handle: '@jane' },
+    date: '2026-01-02T10:00:00.000Z',
+    tweetId: '123',
+    text: [{ type: 'text', value: 'Hello, world' }],
+    media: [],
+  },
+};
+
+const data: ExtractedContent = {
+  type: 'tweet',
+  author: { name: 'Jane Doe', handle: '@jane' },
+  markdown:
+    '# Jane Doe (@jane)\n\nHello **bold** and a [link](https://example.com)\n\n' +
+    '![pic](https://pbs.twimg.com/a.jpg)\n\n---\n\n> Source: https://x.com/jane/status/123\n> Date: 2026-01-02',
+  sourceUrl: 'https://x.com/jane/status/123',
+  date: '2026-01-02T10:00:00.000Z',
+  tweetId: '123',
+  metadata: { likes: 5, reposts: 2 },
+  body: doc,
+};
+
+describe('markdownToPlainText', () => {
+  it('strips markup but keeps link URLs', () => {
+    const txt = markdownToPlainText(data.markdown);
+    expect(txt).toContain('Hello bold and a link (https://example.com)');
+    expect(txt).toContain('pic: https://pbs.twimg.com/a.jpg');
+    expect(txt).not.toContain('**');
+    expect(txt).not.toContain('# Jane');
+    expect(txt).not.toMatch(/^>/m);
+    expect(txt.endsWith('\n')).toBe(true);
+  });
+});
+
+describe('buildCsvRow', () => {
+  it('emits the default field set as header + one row', () => {
+    const csv = buildCsvRow(data, { obsidianFriendly: false });
+    const [header, row] = csv.trimEnd().split('\n');
+    expect(header).toBe('author,handle,source,date,type,likes,reposts,replies,bookmarks,views');
+    const cols = row.split(',');
+    expect(cols[0]).toBe('Jane Doe');
+    expect(cols[1]).toBe('@jane');
+    expect(cols[5]).toBe('5'); // likes
+    expect(cols[6]).toBe('2'); // reposts
+    expect(cols[7]).toBe(''); // replies absent
+  });
+
+  it('honors per-field toggles', () => {
+    const csv = buildCsvRow(data, {
+      obsidianFriendly: false,
+      frontmatterFields: { likes: false, reposts: false, replies: false, bookmarks: false, views: false },
+    });
+    expect(csv.split('\n')[0]).toBe('author,handle,source,date,type');
+  });
+
+  it('uses the handle for author in the Obsidian field set', () => {
+    const csv = buildCsvRow(data, { obsidianFriendly: true });
+    const [header, row] = csv.trimEnd().split('\n');
+    const idx = header.split(',').indexOf('author');
+    expect(row.split(',')[idx]).toBe('@jane');
+  });
+
+  it('quotes values containing commas', () => {
+    const withComma: ExtractedContent = { ...data, author: { name: 'Doe, Jane', handle: '@jane' } };
+    const csv = buildCsvRow(withComma, { obsidianFriendly: false });
+    expect(csv.split('\n')[1].startsWith('"Doe, Jane"')).toBe(true);
+  });
+});
+
+describe('buildFormatExport', () => {
+  it('html reuses the standalone renderer', () => {
+    const out = buildFormatExport('html', data);
+    expect(out.ext).toBe('html');
+    expect(out.mime).toBe('text/html');
+    expect(out.content).toContain('<!doctype html>');
+  });
+
+  it('json serializes the AST document', () => {
+    const out = buildFormatExport('json', data);
+    expect(out.ext).toBe('json');
+    const parsed = JSON.parse(out.content);
+    expect(parsed.version).toBe(1);
+    expect(parsed.metadata.type).toBe('tweet');
+  });
+
+  it('txt and csv carry the right mime/ext', () => {
+    expect(buildFormatExport('txt', data).mime).toBe('text/plain');
+    expect(buildFormatExport('csv', data).ext).toBe('csv');
+  });
+});


### PR DESCRIPTION
Adds four single-export formats requested in #54, alongside the existing Markdown and PDF.

## Formats
- **HTML** — reuses `renderPdfHtml` (the same standalone styled document the PDF flow prints).
- **JSON** — serializes the canonical AST `Document` (same shape as the batch JSON sink).
- **TXT** — strips markup from the AST-rendered Markdown, keeping link URLs (the "related to MD" route).
- **CSV** — one row whose columns are the active **Default/Obsidian** frontmatter fields, honoring the per-field toggles; raw values, RFC-4180 escaped.

## UI
Four icon buttons, labelled by extension only (`.html` / `{} .json` / `.txt` / `⊞ .csv`), kept neutral grey so they don't compete with the colored Markdown/PDF/Obsidian actions. They sit **between** the two action rows:

```
Download .md | Copy .md
.html | .json | .txt | .csv
Export .pdf | Add to Obsidian
```

## Plumbing
- `DownloadRequest` gains an optional `mime` so the background `data:` URL carries the right type (Chrome still names the file from the extension).
- The popup's tab/host guard + `EXTRACT` is factored into a shared `extractContent()` used by both the Markdown and format flows.
- New `src/shared/export-formats.ts` centralizes the four renderers; a few helpers exported from `post-process.ts` for CSV value reuse (no behavior change).

## Tests
`tests/export-formats.test.ts` (8 new) covers TXT stripping, CSV columns/toggles/escaping, and HTML/JSON output. Full suite: **156 passing**, typecheck clean, build clean.

## Not included (separate follow-up)
Excel and ePub (each needs a new dependency), and batch/multi-row CSV — CSV is single-row only here, per scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)