### PR TITLE
fix(theme): swap popup logo in dark mode + popup-driven toolbar icon

### DIFF
--- a/src/background/background.ts
+++ b/src/background/background.ts
@@ -132,6 +132,10 @@ async function ensureThemeWatcher(): Promise<void> {
   }
 }
 
+// Theme reports arrive from two places: the offscreen watcher (covers the
+// at-rest toolbar, even if the popup never opens) and the popup itself (a
+// guaranteed-correct prefers-color-scheme oracle that also catches cases the
+// offscreen document may miss). Both send XCLIPPER_THEME; last write wins.
 chrome.runtime.onMessage.addListener((message: ThemeReport, _sender, _sendResponse) => {
   if (!message || message.action !== 'XCLIPPER_THEME') return false;
   chrome.action.setIcon({ path: message.dark ? ICON_DARK : ICON_LIGHT });

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -101,6 +101,22 @@ body {
   object-fit: contain;
 }
 
+/* Swap the header mark for its light-slash variant in dark mode so the slash
+ * doesn't vanish against the dark popup. The popup is a rendered page, so this
+ * media query reliably follows the active color scheme. */
+.logo-icon-dark {
+  display: none;
+}
+
+@media (prefers-color-scheme: dark) {
+  .logo-icon-light {
+    display: none;
+  }
+  .logo-icon-dark {
+    display: inline-block;
+  }
+}
+
 .logo-text {
   font-size: 20px;
   font-weight: 700;

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -20,7 +20,8 @@
     </button>
     <header class="popup-header">
       <div class="logo-row">
-        <img src="icons/icon-48.png" alt="XClipper" class="logo-icon" />
+        <img src="icons/icon-48.png" alt="XClipper" class="logo-icon logo-icon-light" />
+        <img src="icons/icon-48-dark.png" alt="" aria-hidden="true" class="logo-icon logo-icon-dark" />
         <h1 class="logo-text">X<span class="accent">Clipper</span></h1>
       </div>
       <p class="tagline" data-i18n="tagline">Convert threads &amp; articles to Markdown</p>

--- a/src/popup/popup.ts
+++ b/src/popup/popup.ts
@@ -46,3 +46,15 @@ initSettingsForm();
 initActions();
 void initBatchUi();
 void initReviewBanner();
+
+// ─── Toolbar-icon theme oracle ────────────────────────────────────────
+// The popup is a real rendered page, so its prefers-color-scheme is
+// authoritative. Report it to the background (which swaps the toolbar icon)
+// whenever the popup opens — this corrects the icon even in cases the offscreen
+// watcher may miss.
+const themeMedia = matchMedia('(prefers-color-scheme: dark)');
+const reportTheme = () => {
+  void chrome.runtime.sendMessage({ action: 'XCLIPPER_THEME', dark: themeMedia.matches }).catch(() => {});
+};
+themeMedia.addEventListener('change', reportTheme);
+reportTheme();


### PR DESCRIPTION
Follow-up to the dark-mode icon work (#62): the toolbar icon wasn't swapping and the **popup header logo** never swapped at all.

## Root cause
The offscreen→`setIcon` mechanism is correct (verified by loading the extension and tracing the chain — offscreen reports the scheme and `setIcon` succeeds). The weak link is **detection**: it reads `prefers-color-scheme`, which only flips on **OS-level** dark mode. A dark toolbar from a Chrome theme while the OS is light is invisible to it.

## Changes
1. **Popup header logo** now swaps to the white-slash variant via a CSS `prefers-color-scheme` media query (the popup is a rendered page, so this is reliable). ✅ Verified in an emulated-dark screenshot.
2. **Toolbar icon** — the popup now also reports its color scheme to the background on open/change (an authoritative oracle), as a second path alongside the offscreen watcher. Reuses the existing `XCLIPPER_THEME` handler. ✅ Verified the message fires and drives `setIcon`.

Confirmed working by the reporter after enabling OS dark mode.

## Scope note
Both paths detect **OS dark mode**. A dark toolbar from a Chrome *theme* (OS light) can't be detected via `prefers-color-scheme` — that would need a single dual-legible icon instead. Out of scope here.

154 tests pass, build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)