### PR TITLE
feat(popup): collapsible "More formats" row + polish, Batch Beta badge

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -167,6 +167,9 @@
   "group_more_formats": {
     "message": "More formats"
   },
+  "beta": {
+    "message": "Beta"
+  },
   "group_single": {
     "message": "Single export"
   },

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -164,6 +164,9 @@
   "group_export": {
     "message": "Export settings"
   },
+  "group_more_formats": {
+    "message": "More formats"
+  },
   "group_single": {
     "message": "Single export"
   },

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -1606,6 +1606,21 @@ details.option-group[open] .option-group-chevron {
   box-shadow: 0 2px 8px var(--accent-glow);
 }
 
+/* "Beta" pill on the Batch tab. Outlined in currentColor so it stays legible
+ * in both tab states — grey when inactive, white-on-accent when active. */
+.beta-badge {
+  margin-inline-start: 5px;
+  padding: 1px 5px;
+  border: 1px solid currentColor;
+  border-radius: 999px;
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  vertical-align: middle;
+  opacity: 0.75;
+}
+
 /* Tier-1 panels (Single / Batch) are borderless — the mode tabs above carry
  * the framing, so the buttons keep full width (German labels need the room). */
 .export-panel {

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -159,7 +159,7 @@ body {
    * its label fit easily. Pinning the basis kills the asymmetry. */
   flex: 0 0 calc(50% - 4px);
   min-width: 0;
-  padding: 12px 10px;
+  padding: 10px 10px;
   /* Transparent 1px border so outlined variants (.btn-obsidian) have the
    * same computed height as filled ones — border-box only includes the
    * border when an explicit height is set; with height:auto, a border
@@ -284,7 +284,6 @@ body {
   display: flex;
   gap: 8px;
   align-items: center;
-  margin-bottom: 8px;
 }
 
 .btn-format {
@@ -316,13 +315,21 @@ body {
 }
 
 /* Collapsible wrapper around the secondary-format row. Open by default;
- * the caret lets users who never touch these formats tuck them away. */
+ * the caret lets users who never touch these formats tuck them away.
+ * Flex column so the summary↔row gap matches every other inter-row gap
+ * (the 8px set on .popup-main and .export-panel) rather than a separate
+ * margin that would stack on top of the panel's flex gap. */
+.format-details {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
 .format-summary {
   display: flex;
   align-items: center;
   gap: 6px;
   padding: 4px 2px;
-  margin-bottom: 8px;
   cursor: pointer;
   list-style: none;
   font-size: 12px;

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -283,6 +283,12 @@ body {
   display: flex;
   gap: 8px;
   align-items: center;
+  /* Gap up to the summary. Lives on the row (not a flex gap on the
+   * <details>) so it collapses away when the row is hidden — a flex gap
+   * would still apply between the summary and the zero-height
+   * ::details-content box, leaving more space below "More formats" than
+   * above it. */
+  margin-top: 8px;
 }
 
 .btn-format {
@@ -314,16 +320,7 @@ body {
 }
 
 /* Collapsible wrapper around the secondary-format row. Open by default;
- * the caret lets users who never touch these formats tuck them away.
- * Flex column so the summary↔row gap matches every other inter-row gap
- * (the 8px set on .popup-main and .export-panel) rather than a separate
- * margin that would stack on top of the panel's flex gap. */
-.format-details {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-}
-
+ * the caret lets users who never touch these formats tuck them away. */
 .format-summary {
   display: flex;
   align-items: center;

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -315,6 +315,47 @@ body {
   box-shadow: none;
 }
 
+/* Collapsible wrapper around the secondary-format row. Open by default;
+ * the caret lets users who never touch these formats tuck them away. */
+.format-summary {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 2px;
+  margin-bottom: 8px;
+  cursor: pointer;
+  list-style: none;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-secondary);
+  user-select: none;
+}
+
+.format-summary::-webkit-details-marker {
+  display: none;
+}
+
+.format-summary:hover {
+  color: var(--text-primary);
+}
+
+.format-caret {
+  width: 14px;
+  height: 14px;
+  flex-shrink: 0;
+  transition: transform 0.15s ease;
+}
+
+/* Chevron points down when open; rotate it to point toward the row's start
+ * edge (right in LTR, left in RTL) when collapsed. */
+.format-details:not([open]) .format-caret {
+  transform: rotate(-90deg);
+}
+
+[dir='rtl'] .format-details:not([open]) .format-caret {
+  transform: rotate(90deg);
+}
+
 /* ─── Review prompt banner ──────────────────────────────────── */
 .review-banner {
   position: relative;
@@ -764,6 +805,30 @@ body {
 .action-row .btn-action:first-child[data-tooltip]:focus-visible::after,
 .action-row .btn-action:last-child[data-tooltip]:hover::after,
 .action-row .btn-action:last-child[data-tooltip]:focus-visible::after {
+  transform: translateY(0);
+}
+
+/* The .html and .csv buttons sit at the format row's edges — a centered
+ * tooltip would spill off the popup and get clipped. Anchor them to the
+ * logical edges so each grows inward (mirrors the action-row rule above). */
+.format-row .btn-format:first-child[data-tooltip]::after {
+  left: auto;
+  right: auto;
+  inset-inline-start: 0;
+  transform: translateY(2px);
+}
+
+.format-row .btn-format:last-child[data-tooltip]::after {
+  left: auto;
+  right: auto;
+  inset-inline-end: 0;
+  transform: translateY(2px);
+}
+
+.format-row .btn-format:first-child[data-tooltip]:hover::after,
+.format-row .btn-format:first-child[data-tooltip]:focus-visible::after,
+.format-row .btn-format:last-child[data-tooltip]:hover::after,
+.format-row .btn-format:last-child[data-tooltip]:focus-visible::after {
   transform: translateY(0);
 }
 

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -237,7 +237,6 @@ body {
   display: flex;
   gap: 8px;
   align-items: center;
-  margin-bottom: 8px;
 }
 
 .btn-pdf {
@@ -329,7 +328,7 @@ body {
   display: flex;
   align-items: center;
   gap: 6px;
-  padding: 4px 2px;
+  padding: 0 2px;
   cursor: pointer;
   list-style: none;
   font-size: 12px;
@@ -1622,7 +1621,6 @@ details.option-group[open] .option-group-chevron {
   display: none;
 }
 
-.export-panel .action-row,
 .export-panel .batch-tabs {
   margin-bottom: 0;
 }

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -49,7 +49,8 @@
         <button id="tab-mode-single" class="export-tab active" type="button" role="tab"
           aria-selected="true" data-i18n="group_single">Single export</button>
         <button id="tab-mode-batch" class="export-tab" type="button" role="tab"
-          aria-selected="false" data-i18n="group_batch">Batch export</button>
+          aria-selected="false"><span data-i18n="group_batch">Batch export</span><span
+            class="beta-badge" data-i18n="beta">Beta</span></button>
       </div>
 
       <div class="options">

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -129,13 +129,22 @@
         </button>
         </div>
 
+        <details id="format-details" class="format-details" open>
+          <summary class="format-summary">
+            <svg class="format-caret" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+              stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <polyline points="6 9 12 15 18 9" />
+            </svg>
+            <span data-i18n="group_more_formats">More formats</span>
+          </summary>
         <div class="format-row">
           <button id="btn-html" class="btn-format btn-action" type="button"
             data-tooltip="Save as a styled, self-contained HTML file." data-i18n-tooltip="btn_html_hint">
             <svg class="btn-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
               stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-              <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
-              <polyline points="14 2 14 8 20 8" />
+              <path d="m18 16 4-4-4-4" />
+              <path d="m6 8-4 4 4 4" />
+              <path d="m14.5 4-5 16" />
             </svg>
             <span class="btn-label">.html</span>
           </button>
@@ -171,6 +180,7 @@
             <span class="btn-label">.csv</span>
           </button>
         </div>
+        </details>
 
         <div class="action-row">
           <button id="btn-pdf" class="btn-pdf btn-action" type="button"

--- a/src/popup/popup.ts
+++ b/src/popup/popup.ts
@@ -39,6 +39,21 @@ btnBack?.addEventListener('click', () => {
   btnSettings?.classList.remove('hidden');
 });
 
+// ─── Collapsible "More formats" row ───────────────────────────────────
+// The native <details> handles expand/collapse; we only remember the state
+// across popup opens. Defaults to open — only an explicit collapse sticks.
+
+const FORMATS_KEY = 'formatsExpanded';
+const formatDetails = document.getElementById('format-details') as HTMLDetailsElement | null;
+if (formatDetails) {
+  chrome.storage.local.get(FORMATS_KEY, (res) => {
+    if (res[FORMATS_KEY] === false) formatDetails.open = false;
+  });
+  formatDetails.addEventListener('toggle', () => {
+    chrome.storage.local.set({ [FORMATS_KEY]: formatDetails.open });
+  });
+}
+
 // ─── Feature modules ──────────────────────────────────────────────────
 
 initModeTabs();


### PR DESCRIPTION
## Summary

Tidies up the single-export popup: makes the secondary-format buttons collapsible, evens out the vertical rhythm, trims the oversized action buttons, and flags Batch export as Beta. No export logic changes — purely presentational (HTML/CSS/i18n, plus a small persistence hook).

## What changed

- **Collapsible "More formats" row** — the `.html / .json / .txt / .csv` buttons now live under a `<details open>` with a "More formats ▾" caret. Expanded by default; the open/closed state is remembered across popup opens (`chrome.storage.local`, mirroring how the Single/Batch mode is persisted).
- **`</>` icon for `.html`** — swapped the generic doc icon (near-identical to `.txt`) for a code glyph that reads as markup.
- **Fixed clipped tooltips** — the `.html` and `.csv` hints sat at the popup edges and got trimmed; anchored them to the logical edges so they grow inward, reusing the existing `.action-row` pattern.
- **Even spacing** — every inter-row gap is now a uniform 8px, matching the settings-box ↔ Download gap. Removed stacked `margin-bottom`s that were doubling onto the flex `gap`, and fixed an asymmetry in collapsed mode (a flex gap was still applying to the zero-height `::details-content` box).
- **Shorter action buttons** — `.btn-action` vertical padding 12px → 10px (~10%) so Download/Copy/PDF/Obsidian stop dwarfing the mode tabs.
- **Batch export "Beta" badge** — an outlined pill on the Batch tab to set expectations while the feature is still being tuned. Uses `currentColor`, so it stays legible in both the active (white-on-blue) and inactive (grey) tab states.
- Removed a dead `.action-row { margin-bottom }` that was always overridden.

## Verification

- `tsc --noEmit` + build pass.
- Rendered the popup via the screenshot harness and visually checked all four states: expanded, collapsed, Batch tab inactive, Batch tab active.

🤖 Generated with [Claude Code](https://claude.com/claude-code)