### PR TITLE
fix(popup): show reload hint when the content script is orphaned

### DIFF
--- a/src/popup/actions.ts
+++ b/src/popup/actions.ts
@@ -116,11 +116,19 @@ async function extractContent(includeMetadata: boolean): Promise<ExtractedConten
     );
   }
 
-  const response: ExtractResponse = await chrome.tabs.sendMessage(tab.id, {
+  const response: ExtractResponse | undefined = await chrome.tabs.sendMessage(tab.id, {
     action: 'EXTRACT',
     includeMetadata,
   });
 
+  // After an extension reload the content script already in the tab is
+  // orphaned: its async EXTRACT handler can't answer, so tabs.sendMessage
+  // resolves `undefined` (instead of rejecting with "Receiving end does not
+  // exist"). Surface the same "reload the page" hint rather than letting a
+  // raw `undefined.success` TypeError leak through.
+  if (!response) {
+    throw new Error(chrome.i18n.getMessage('error_reload') || 'Reload the page and try again.');
+  }
   if (!response.success || !response.data) {
     throw new Error(response.error || chrome.i18n.getMessage('error_failed') || 'Failed to extract content.');
   }


### PR DESCRIPTION
## Problem

After reloading the extension **without** reloading the open tab, exporting from the popup showed a raw `Cannot read properties of undefined (reading 'success')` instead of the friendly **"Reload the page and try again."** hint it used to show.

## Cause

The content script's `EXTRACT` handler is async — it returns `true` and answers via the promise. Once the extension is reloaded, that content script is **orphaned** (its `chrome.runtime` is invalidated), so it can never deliver the response. Chrome then **resolves `chrome.tabs.sendMessage` with `undefined`** rather than rejecting with "Receiving end does not exist."

`extractContent` read `response.success` with no guard, so on `undefined` it threw a `TypeError`. Because that message doesn't contain "Receiving end does not exist", it skipped the friendly branch in `handleExtractionError` and printed the raw error.

## Fix

Guard the `undefined` response in `extractContent` and throw the localized `error_reload` ("Reload the page and try again.") hint instead — restoring the previous UX.

Pre-existing bug (not introduced by a recent feature); surfaced by a shift in Chrome's orphaned-content-script messaging behavior.

## Testing

- `tsc --noEmit` clean.
- Manual: reload the unpacked extension, then (without reloading the X tab) click Download/Copy → now shows the reload hint instead of the TypeError.

## Note

The same unguarded `response.success` pattern exists in three `content/content.ts` spots (PDF / auto-extract / batch-worker → background). Those message the service worker rather than a content script, so they're far less likely to see `undefined`; left out of this minimal fix — happy to harden them if you'd like.

🤖 Generated with [Claude Code](https://claude.com/claude-code)