### PR TITLE
feat: batch UX — Fast on Profile/Likes, date range, reset queue, step lights (v2.4.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Renamed the batch **Reset dedup** button to **Reset history** (clearer: it forgets what past runs already exported).
+- When you're not on the right page, the **Bookmarks** and **Timeline** tabs now show an **Open Bookmarks / Open Timeline** button that takes you there (instead of a disabled button) — then scroll and export.
+- Moved the batch **Output** selector above **Format**.
 
 ---
 ## [2.3.0] - 2026-06-14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Include reposts toggle** — by default a profile batch exports only the owner's own posts (both Standard and Fast); turn this on to include their reposts too.
 - **Date-range filter for Fast Batch** — limit an export to posts within a date range (e.g. a single month). Out-of-range posts are skipped without being fetched in full, so you spend X's per-session quota only on the posts you want and can reach older ones without getting rate-limited.
 - **Fast Batch now works on Profiles and Likes**, not just Bookmarks — export a profile's own posts (reposts skipped) or your liked posts through your X session at the same ~10× speed. Selection stays Standard-only (its tab is disabled while Fast is on).
 - **Reset queue** — empties the posts gathered so far and restarts collecting from wherever you've scrolled to, so you can begin a batch at a specific post instead of always from the top.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Fast Batch now works on Profiles and Likes**, not just Bookmarks — export a profile's own posts (reposts skipped) or your liked posts through your X session at the same ~10× speed. Selection stays Standard-only (its tab is disabled while Fast is on).
 - **Reset queue** — empties the posts gathered so far and restarts collecting from wherever you've scrolled to, so you can begin a batch at a specific post instead of always from the top.
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Date-range filter for Fast Batch** — limit an export to posts within a date range (e.g. a single month). Out-of-range posts are skipped without being fetched in full, so you spend X's per-session quota only on the posts you want and can reach older ones without getting rate-limited.
 - **Fast Batch now works on Profiles and Likes**, not just Bookmarks — export a profile's own posts (reposts skipped) or your liked posts through your X session at the same ~10× speed. Selection stays Standard-only (its tab is disabled while Fast is on).
 - **Reset queue** — empties the posts gathered so far and restarts collecting from wherever you've scrolled to, so you can begin a batch at a specific post instead of always from the top.
+- **Timeline batch source** — a new **Timeline** tab exports the posts loaded in your home feed (`x.com/home`), the same way Bookmarks/Profile/Likes do. Standard only — its tab is disabled while Fast is on (the home feed isn't paginated the way Fast needs).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Reset queue** — empties the posts gathered so far and restarts collecting from wherever you've scrolled to, so you can begin a batch at a specific post instead of always from the top.
+
+### Changed
+
+- Renamed the batch **Reset dedup** button to **Reset history** (clearer: it forgets what past runs already exported).
+
+---
+## [2.3.0] - 2026-06-14
+
+### Added
+
 - **Fast Batch (beta)** — an opt-in second batch mode that exports your **bookmarks** far faster by fetching them directly through your already-logged-in X session instead of opening and rendering each post in a tab. It expands self-threads and full X Articles, and is careful with your account: it spreads requests out and **stops politely if X rate-limits you** (re-run a few minutes later and it picks up only what's left). Standard Batch stays the default and is unchanged — Fast Batch is off until you flip the red toggle, which asks for a one-time, X.com-only permission. Nothing leaves your browser: no API keys, no server, no password. (Bookmarks only for now.)
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Fast Batch step lights** — a small Page → Tweet → Fetch → Expand indicator shows, before you export, whether the page's feed and a tweet have been captured (green/red), then lights up the live phase during a run — so you know what (if anything) to do first.
 - **Include reposts toggle** — by default a profile batch exports only the owner's own posts (both Standard and Fast); turn this on to include their reposts too.
 - **Date-range filter for Fast Batch** — limit an export to posts within a date range (e.g. a single month). Out-of-range posts are skipped without being fetched in full, so you spend X's per-session quota only on the posts you want and can reach older ones without getting rate-limited.
 - **Fast Batch now works on Profiles and Likes**, not just Bookmarks — export a profile's own posts (reposts skipped) or your liked posts through your X session at the same ~10× speed. Selection stays Standard-only (its tab is disabled while Fast is on).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Date-range filter for Fast Batch** — limit an export to posts within a date range (e.g. a single month). Out-of-range posts are skipped without being fetched in full, so you spend X's per-session quota only on the posts you want and can reach older ones without getting rate-limited.
 - **Fast Batch now works on Profiles and Likes**, not just Bookmarks — export a profile's own posts (reposts skipped) or your liked posts through your X session at the same ~10× speed. Selection stays Standard-only (its tab is disabled while Fast is on).
 - **Reset queue** — empties the posts gathered so far and restarts collecting from wherever you've scrolled to, so you can begin a batch at a specific post instead of always from the top.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xclipper",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "description": "XClipper — free, source-available web clipper for X (Twitter). Download threads, posts, and articles as Markdown or PDF for Obsidian, research, and AI/RAG workflows. Works locally — no API, no accounts, no tracking.",
   "license": "PolyForm-Noncommercial-1.0.0",
   "private": true,

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -105,10 +105,16 @@
     "message": "already exported"
   },
   "batch_reset": {
-    "message": "Reset dedup"
+    "message": "Reset history"
   },
   "batch_reset_hint": {
-    "message": "Forget which bookmarks were already exported, so the next batch exports everything loaded."
+    "message": "Forget which posts were already exported in past runs, so the next batch exports everything loaded again."
+  },
+  "batch_reset_queue": {
+    "message": "Reset queue"
+  },
+  "batch_reset_queue_hint": {
+    "message": "Empty the gathered posts and restart collecting from where you've scrolled to — so you can begin at a specific post instead of the top."
   },
   "btn_batch_open_x": {
     "message": "Open x.com to batch-export bookmarks, a profile, or a selection."

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -101,6 +101,18 @@
   "fast_date_clear": {
     "message": "Clear"
   },
+  "fast_step_page": {
+    "message": "Page"
+  },
+  "fast_step_tweet": {
+    "message": "Tweet"
+  },
+  "fast_step_fetch": {
+    "message": "Fetch"
+  },
+  "fast_step_expand": {
+    "message": "Expand"
+  },
   "batch_pause": {
     "message": "Pause"
   },

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -389,6 +389,12 @@
   "opt_inline_stats": {
     "message": "Show engagement stats inline"
   },
+  "opt_include_reposts": {
+    "message": "Include reposts (profiles)"
+  },
+  "opt_include_reposts_title": {
+    "message": "When batch-exporting a profile, include reposts too. Off = the profile owner's own posts only."
+  },
   "opt_close_tab_title": {
     "message": "Close the tab automatically after exporting from a tweet's inline button or right-click menu"
   },

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -86,6 +86,21 @@
   "fast_locked": {
     "message": "An export is running — cancel or let it finish to switch modes."
   },
+  "fast_date_range": {
+    "message": "Date range"
+  },
+  "fast_date_range_hint": {
+    "message": "Only export posts whose date is in this range — out-of-range posts are skipped without being expanded, so you reach older posts without hitting X's rate limit."
+  },
+  "fast_date_from": {
+    "message": "From date"
+  },
+  "fast_date_to": {
+    "message": "To date"
+  },
+  "fast_date_clear": {
+    "message": "Clear"
+  },
   "batch_pause": {
     "message": "Pause"
   },

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -80,8 +80,14 @@
   "btn_batch_fast_no_selection": {
     "message": "Selection isn't available in Fast — turn Fast off to pick tweets by hand."
   },
+  "btn_batch_fast_no_timeline": {
+    "message": "Timeline isn't available in Fast — turn Fast off to export your home feed."
+  },
   "batch_tab_selection_fast": {
     "message": "Turn Fast off to pick tweets by hand"
+  },
+  "batch_tab_timeline_fast": {
+    "message": "Turn Fast off to export your home feed"
   },
   "fast_locked": {
     "message": "An export is running — cancel or let it finish to switch modes."
@@ -179,6 +185,15 @@
   "btn_batch_open_likes": {
     "message": "Open your Likes page on x.com to export the posts you have liked."
   },
+  "btn_batch_timeline": {
+    "message": "Export timeline"
+  },
+  "btn_batch_timeline_hint": {
+    "message": "Export every post loaded in your home timeline as Markdown files into one folder. Scroll to load more."
+  },
+  "btn_batch_open_timeline": {
+    "message": "Open x.com/home to export the posts in your timeline."
+  },
   "group_batch": {
     "message": "Batch export"
   },
@@ -193,6 +208,9 @@
   },
   "batch_tab_likes": {
     "message": "Likes"
+  },
+  "batch_tab_timeline": {
+    "message": "Timeline"
   },
   "btn_batch_select": {
     "message": "Select tweets…"

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -71,6 +71,18 @@
   "btn_batch_fast_only_bookmarks": {
     "message": "Fast Batch supports bookmarks only for now — switch to the Bookmarks tab, or turn off Fast."
   },
+  "btn_batch_fast_profile_hint": {
+    "message": "Fetch this profile's own posts through your X session — much faster. Reposts are skipped."
+  },
+  "btn_batch_fast_likes_hint": {
+    "message": "Fetch your liked posts through your X session — much faster. Expands threads & articles."
+  },
+  "btn_batch_fast_no_selection": {
+    "message": "Selection isn't available in Fast — turn Fast off to pick tweets by hand."
+  },
+  "batch_tab_selection_fast": {
+    "message": "Turn Fast off to pick tweets by hand"
+  },
   "fast_locked": {
     "message": "An export is running — cancel or let it finish to switch modes."
   },

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -165,7 +165,7 @@
     "message": "Open x.com to batch-export bookmarks, a profile, or a selection."
   },
   "btn_batch_open_bookmarks": {
-    "message": "Open x.com/i/bookmarks to export your bookmarks."
+    "message": "Open your Bookmarks page, then scroll to load posts and export."
   },
   "btn_batch_open_profile": {
     "message": "Open a profile page on x.com to export its posts. Reposts are skipped."
@@ -192,7 +192,13 @@
     "message": "Export every post loaded in your home timeline as Markdown files into one folder. Scroll to load more."
   },
   "btn_batch_open_timeline": {
-    "message": "Open x.com/home to export the posts in your timeline."
+    "message": "Open your home timeline, then scroll to load posts and export."
+  },
+  "btn_batch_go_bookmarks": {
+    "message": "Open Bookmarks"
+  },
+  "btn_batch_go_timeline": {
+    "message": "Open Timeline"
   },
   "group_batch": {
     "message": "Batch export"

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -63,7 +63,7 @@
     "message": "Fetches bookmarks through your X session — much faster. Bookmarks only for now."
   },
   "fast_batch_info": {
-    "message": "Fetches your bookmarks directly through your logged-in X session (its private API) — far faster than rendering each page, but bookmarks only for now. Before the first run, open any single tweet once so the request can be captured. Large runs can hit X's rate limit and briefly soft-block your session (\"Something went wrong\"); Fast Batch stops politely and you can re-run a few minutes later for the rest."
+    "message": "Exports your Bookmarks, a profile's posts, or your Likes far faster by fetching them directly through your logged-in X session (its private API) — no API key, no password, nothing leaves your browser. The step lights below show what to do first (reload the page / open one tweet). Big runs can hit X's rate limit — it stops politely so you can re-run, or use the date range to narrow the scope."
   },
   "btn_batch_fast_hint": {
     "message": "Fetch all your bookmarks through your X session — much faster. Expands threads & articles; stops politely if X rate-limits."
@@ -387,7 +387,7 @@
     "message": "Download images to a folder next to the Markdown file"
   },
   "opt_save_images": {
-    "message": "Save images locally"
+    "message": "Save images locally (only with .md)"
   },
   "opt_metadata_title": {
     "message": "Add likes, reposts, views as YAML frontmatter"

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -102,16 +102,16 @@
     "message": "Clear"
   },
   "fast_step_page": {
-    "message": "Page"
+    "message": "Reload x.com"
   },
   "fast_step_tweet": {
-    "message": "Tweet"
+    "message": "Open one tweet"
   },
   "fast_step_fetch": {
-    "message": "Fetch"
+    "message": "Fetching ..."
   },
   "fast_step_expand": {
-    "message": "Expand"
+    "message": "Expanding ..."
   },
   "batch_pause": {
     "message": "Pause"

--- a/src/background/batch-state.ts
+++ b/src/background/batch-state.ts
@@ -11,7 +11,7 @@ export interface BatchJob {
   id: string;
   status: 'running' | 'paused' | 'done' | 'cancelled';
   // Surface that launched the job; the popup scopes progress display to it.
-  origin?: 'bookmarks' | 'profile' | 'selection' | 'likes';
+  origin?: 'bookmarks' | 'profile' | 'selection' | 'likes' | 'timeline';
   // Profile owner's handle (only when origin === 'profile'); lets the popup
   // offer "add to queue" on the same profile but not a different one.
   handle?: string;

--- a/src/background/batch.ts
+++ b/src/background/batch.ts
@@ -91,7 +91,7 @@ async function recordExported(url: string): Promise<void> {
   await chrome.storage.local.set({ [EXPORTED_LEDGER_KEY]: appendToLedger(ledger, id) });
 }
 
-const JOB_ORIGINS = ['bookmarks', 'profile', 'selection', 'likes'] as const;
+const JOB_ORIGINS = ['bookmarks', 'profile', 'selection', 'likes', 'timeline'] as const;
 
 function coerceOrigin(raw: unknown): BatchJob['origin'] {
   return JOB_ORIGINS.includes(raw as (typeof JOB_ORIGINS)[number])

--- a/src/background/fast-batch.ts
+++ b/src/background/fast-batch.ts
@@ -238,7 +238,20 @@ export interface FastBatchResult {
   folder: string;
 }
 
+export type FastSource = 'bookmarks' | 'profile' | 'likes';
+
+// Which captured GraphQL operation backs each source, + a label for progress.
+const SOURCE_CONFIG: Record<FastSource, { op: string; label: string }> = {
+  bookmarks: { op: 'Bookmarks', label: 'bookmarks' },
+  profile: { op: 'UserTweets', label: 'posts' },
+  likes: { op: 'Likes', label: 'likes' },
+};
+
 export interface FastBatchOptions {
+  source?: FastSource;
+  // Profile owner's handle — reposts (author ≠ handle) are skipped, matching
+  // Standard profile export.
+  handle?: string;
   maxItems?: number;
   // Fetch TweetDetail for non-article tweets to expand self-threads (Articles
   // are always expanded — their body needs the fetch). On by default for
@@ -262,10 +275,13 @@ const TWEET_DETAIL_CONCURRENCY = 3;
 async function runFastBatchExport(opts: FastBatchOptions = {}): Promise<FastBatchResult | null> {
   const maxItems = opts.maxItems ?? BATCH_MAX_ITEMS;
   const expandThreads = opts.expandThreads ?? true;
+  const source = opts.source ?? 'bookmarks';
+  const handle = opts.handle?.replace(/^@/, '').toLowerCase();
+  const cfg = SOURCE_CONFIG[source];
   cancelRequested = false;
   setProgress({
     status: 'running',
-    phase: 'Fetching bookmarks…',
+    phase: `Fetching ${cfg.label}…`,
     done: 0,
     total: 0,
     exported: 0,
@@ -281,24 +297,25 @@ async function runFastBatchExport(opts: FastBatchOptions = {}): Promise<FastBatc
     return null;
   }
   await restoreSession(); // reload captured auth/templates if the SW restarted
-  // Fast Batch replays two captured requests: the bookmarks feed, and (to
-  // expand threads/articles) TweetDetail. After an extension reload neither has
-  // been seen yet. Check BOTH up front (before paginating) and give one plain
-  // hint covering whatever's missing — the user does it once, then it works.
-  const needBookmarks = !templates.Bookmarks;
+  // Fast Batch replays two captured requests: the source feed (bookmarks /
+  // profile / likes), and (to expand threads/articles) TweetDetail. After an
+  // extension reload neither has been seen yet. Check BOTH up front (before
+  // paginating) and give one plain hint — the user does it once, then it works.
+  const needFeed = !templates[cfg.op];
   const needTweetDetail = expandThreads && !templates.TweetDetail;
-  if (needBookmarks || needTweetDetail) {
+  if (needFeed || needTweetDetail) {
+    const feedHint = `Reload your ${cfg.label} page`;
     const msg =
-      needBookmarks && needTweetDetail
-        ? 'Reload your bookmarks page and open any one tweet, then click Export again.'
-        : needBookmarks
-          ? 'Reload your bookmarks page, then click Export again.'
+      needFeed && needTweetDetail
+        ? `${feedHint} and open any one tweet, then click Export again.`
+        : needFeed
+          ? `${feedHint}, then click Export again.`
           : 'Open any one tweet, then click Export again.';
-    log(`preconditions missing (bookmarks:${needBookmarks} tweetDetail:${needTweetDetail})`);
+    log(`preconditions missing (${cfg.op}:${needFeed} tweetDetail:${needTweetDetail})`);
     setProgress({ status: 'error', needTweetDetail, error: msg });
     return null;
   }
-  const template = templates.Bookmarks as string;
+  const template = templates[cfg.op];
 
   const settings = await loadSettings();
   const format = settings.batchFormat ?? 'md';
@@ -322,10 +339,12 @@ async function runFastBatchExport(opts: FastBatchOptions = {}): Promise<FastBatc
   delete vars.cursor;
   const initialUrl = setVariablesParam(template, JSON.stringify(vars));
 
-  // 1) Collect: paginate the bookmarks feed, mapping each root tweet, skipping
+  // 1) Collect: paginate the source feed, mapping each root tweet, skipping
   //    anything already exported. (Cheap — pure mapping, no per-item fetch yet.)
   //    `needsExpand` items get a TweetDetail fetch next; `ledger` decides whether
-  //    to mark the item done (false = re-run should retry it).
+  //    to mark the item done (false = re-run should retry it). For a profile,
+  //    `handle` is set and reposts (author ≠ handle) are skipped — matching
+  //    Standard profile export.
   interface Item {
     doc: Document;
     needsExpand: boolean;
@@ -338,6 +357,7 @@ async function runFastBatchExport(opts: FastBatchOptions = {}): Promise<FastBatc
       for (const raw of tweets) {
         if (selected.length >= maxItems) break;
         const doc = jsonToAst(raw);
+        if (handle && doc.metadata.author.handle.toLowerCase() !== handle) continue; // repost
         const id = doc.metadata.tweetId;
         if (id && ledger.has(id)) {
           skipped++;
@@ -519,8 +539,12 @@ export function initFastBatch(): void {
       sendResponse({ success: false, error: 'A Fast Batch run is already in progress.' } satisfies FastBatchStartResponse);
       return false;
     }
-    const expandThreads = (msg as { expandThreads?: boolean }).expandThreads;
-    void runFastBatchExport(expandThreads === undefined ? {} : { expandThreads });
+    const m = msg as { source?: FastSource; handle?: string; expandThreads?: boolean };
+    void runFastBatchExport({
+      ...(m.source ? { source: m.source } : {}),
+      ...(m.handle ? { handle: m.handle } : {}),
+      ...(m.expandThreads === undefined ? {} : { expandThreads: m.expandThreads }),
+    });
     sendResponse({ success: true } satisfies FastBatchStartResponse);
     return false;
   });

--- a/src/background/fast-batch.ts
+++ b/src/background/fast-batch.ts
@@ -226,6 +226,14 @@ async function mapLimit<T>(items: T[], limit: number, fn: (item: T) => Promise<v
   await Promise.all(Array.from({ length: Math.min(limit, items.length) }, worker));
 }
 
+// A retweet is a tweet by the profile owner (the retweeter) carrying the
+// original under legacy.retweeted_status_result — so an author===owner check
+// can't catch it. Detect it structurally instead.
+function isRepost(raw: unknown): boolean {
+  const t = (raw as { tweet?: unknown }).tweet ?? raw;
+  return !!(t as { legacy?: { retweeted_status_result?: unknown } }).legacy?.retweeted_status_result;
+}
+
 async function loadLedger(): Promise<string[]> {
   const r = await chrome.storage.local.get(EXPORTED_LEDGER_KEY);
   const raw = r[EXPORTED_LEDGER_KEY];
@@ -329,6 +337,8 @@ async function runFastBatchExport(opts: FastBatchOptions = {}): Promise<FastBatc
   const template = templates[cfg.op];
 
   const settings = await loadSettings();
+  // Profile: drop reposts unless the user opted to include them (matches Standard).
+  const skipReposts = source === 'profile' && !settings.includeReposts;
   const format = settings.batchFormat ?? 'md';
   // CSV is metadata-only — always one combined file (mirrors Standard batch).
   const output = format === 'csv' ? 'combined' : settings.batchOutput ?? 'separate';
@@ -371,7 +381,9 @@ async function runFastBatchExport(opts: FastBatchOptions = {}): Promise<FastBatc
       for (const raw of tweets) {
         if (selected.length >= maxItems) break;
         const doc = jsonToAst(raw);
-        if (handle && doc.metadata.author.handle.toLowerCase() !== handle) continue; // repost
+        if (skipReposts && (isRepost(raw) || (handle && doc.metadata.author.handle.toLowerCase() !== handle))) {
+          continue; // a retweet, or (rarely) a top-level original author ≠ owner
+        }
         if (dateFiltered) {
           const d = Date.parse(doc.metadata.date);
           if (Number.isNaN(d) || d < fromMs || d > toMs) continue; // outside the range — skip (not expanded)

--- a/src/background/fast-batch.ts
+++ b/src/background/fast-batch.ts
@@ -18,7 +18,12 @@
 // once, and re-run.
 
 import type { Document } from '../ast/types';
-import type { FastBatchProgress, FastBatchStartResponse, FastBatchStatusResponse } from '../types/messages';
+import type {
+  FastBatchProgress,
+  FastBatchReadyResponse,
+  FastBatchStartResponse,
+  FastBatchStatusResponse,
+} from '../types/messages';
 import { isExtensionPageSender } from './security';
 import { jsonToAst } from '../graphql/json-to-ast';
 import { tweetDetailToDocument } from '../graphql/tweet-detail';
@@ -548,7 +553,12 @@ export function initFastBatch(): void {
   chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
     if (!msg || typeof msg !== 'object') return false;
     const action = (msg as { action?: string }).action;
-    if (action !== 'FAST_BATCH_START' && action !== 'FAST_BATCH_STATUS' && action !== 'FAST_BATCH_CANCEL') {
+    if (
+      action !== 'FAST_BATCH_START' &&
+      action !== 'FAST_BATCH_STATUS' &&
+      action !== 'FAST_BATCH_CANCEL' &&
+      action !== 'FAST_BATCH_READY'
+    ) {
       return false;
     }
     if (!isExtensionPageSender(sender, chrome.runtime.id)) {
@@ -558,6 +568,17 @@ export function initFastBatch(): void {
     if (action === 'FAST_BATCH_STATUS') {
       sendResponse({ progress } satisfies FastBatchStatusResponse);
       return false;
+    }
+    if (action === 'FAST_BATCH_READY') {
+      const src = (msg as { source?: FastSource }).source ?? 'bookmarks';
+      void (async () => {
+        await restoreSession(); // templates may live in session storage after a SW restart
+        sendResponse({
+          feed: !!templates[SOURCE_CONFIG[src].op],
+          tweetDetail: !!templates.TweetDetail,
+        } satisfies FastBatchReadyResponse);
+      })();
+      return true; // async sendResponse
     }
     if (action === 'FAST_BATCH_CANCEL') {
       cancelRequested = true;

--- a/src/background/fast-batch.ts
+++ b/src/background/fast-batch.ts
@@ -252,6 +252,10 @@ export interface FastBatchOptions {
   // Profile owner's handle — reposts (author ≠ handle) are skipped, matching
   // Standard profile export.
   handle?: string;
+  // YYYY-MM-DD bounds on the tweet date; out-of-range items are skipped before
+  // expansion, so a tighter range avoids X's TweetDetail rate limit.
+  fromDate?: string;
+  toDate?: string;
   maxItems?: number;
   // Fetch TweetDetail for non-article tweets to expand self-threads (Articles
   // are always expanded — their body needs the fetch). On by default for
@@ -279,6 +283,10 @@ async function runFastBatchExport(opts: FastBatchOptions = {}): Promise<FastBatc
   const handleRaw = opts.handle?.replace(/^@/, ''); // original case, for display
   const handle = handleRaw?.toLowerCase(); // for the repost filter
   const cfg = SOURCE_CONFIG[source];
+  // Date bounds on the tweet date (inclusive). `to` extends to end-of-day.
+  const fromMs = opts.fromDate ? Date.parse(opts.fromDate) : -Infinity;
+  const toMs = opts.toDate ? Date.parse(opts.toDate) + 86399999 : Infinity;
+  const dateFiltered = fromMs !== -Infinity || toMs !== Infinity;
   cancelRequested = false;
   setProgress({
     status: 'running',
@@ -354,13 +362,20 @@ async function runFastBatchExport(opts: FastBatchOptions = {}): Promise<FastBatc
     ledger: boolean;
   }
   const selected: Item[] = [];
+  // Dig deeper through the (cheap) feed when a date range is set — bookmarks/
+  // likes are ordered by save date, not tweet date, so the range may be deep.
+  const maxPages = dateFiltered ? 50 : 25;
   try {
-    for await (const tweets of paginateTimeline(initialUrl, authedFetchJson, { maxPages: 25 })) {
+    for await (const tweets of paginateTimeline(initialUrl, authedFetchJson, { maxPages })) {
       if (cancelRequested) break;
       for (const raw of tweets) {
         if (selected.length >= maxItems) break;
         const doc = jsonToAst(raw);
         if (handle && doc.metadata.author.handle.toLowerCase() !== handle) continue; // repost
+        if (dateFiltered) {
+          const d = Date.parse(doc.metadata.date);
+          if (Number.isNaN(d) || d < fromMs || d > toMs) continue; // outside the range — skip (not expanded)
+        }
         const id = doc.metadata.tweetId;
         if (id && ledger.has(id)) {
           skipped++;
@@ -542,10 +557,18 @@ export function initFastBatch(): void {
       sendResponse({ success: false, error: 'A Fast Batch run is already in progress.' } satisfies FastBatchStartResponse);
       return false;
     }
-    const m = msg as { source?: FastSource; handle?: string; expandThreads?: boolean };
+    const m = msg as {
+      source?: FastSource;
+      handle?: string;
+      fromDate?: string;
+      toDate?: string;
+      expandThreads?: boolean;
+    };
     void runFastBatchExport({
       ...(m.source ? { source: m.source } : {}),
       ...(m.handle ? { handle: m.handle } : {}),
+      ...(m.fromDate ? { fromDate: m.fromDate } : {}),
+      ...(m.toDate ? { toDate: m.toDate } : {}),
       ...(m.expandThreads === undefined ? {} : { expandThreads: m.expandThreads }),
     });
     sendResponse({ success: true } satisfies FastBatchStartResponse);

--- a/src/background/fast-batch.ts
+++ b/src/background/fast-batch.ts
@@ -276,12 +276,15 @@ async function runFastBatchExport(opts: FastBatchOptions = {}): Promise<FastBatc
   const maxItems = opts.maxItems ?? BATCH_MAX_ITEMS;
   const expandThreads = opts.expandThreads ?? true;
   const source = opts.source ?? 'bookmarks';
-  const handle = opts.handle?.replace(/^@/, '').toLowerCase();
+  const handleRaw = opts.handle?.replace(/^@/, ''); // original case, for display
+  const handle = handleRaw?.toLowerCase(); // for the repost filter
   const cfg = SOURCE_CONFIG[source];
   cancelRequested = false;
   setProgress({
     status: 'running',
     phase: `Fetching ${cfg.label}…`,
+    source,
+    ...(handleRaw ? { handle: handleRaw } : {}),
     done: 0,
     total: 0,
     exported: 0,

--- a/src/content/injector.ts
+++ b/src/content/injector.ts
@@ -324,11 +324,15 @@ type HarvestSource =
   | { kind: 'bookmarks'; key: string }
   | { kind: 'profile'; key: string; handle: string }
   | { kind: 'likes'; key: string; handle: string }
+  | { kind: 'timeline'; key: string }
   | null;
 
 function harvestSourceOfPage(): HarvestSource {
   const path = window.location.pathname;
   if (path.startsWith('/i/bookmarks')) return { kind: 'bookmarks', key: 'bookmarks' };
+  // Home feed shows tweets by many authors (like Likes) — keep every author's
+  // permalink (no repost filter, which only applies to a profile).
+  if (path === '/home') return { kind: 'timeline', key: 'timeline' };
   // Likes live at /<handle>/likes and show tweets by many authors (the ones
   // the user liked) — so, unlike a profile, we keep every author's permalink.
   const liked = path.match(/^\/([A-Za-z0-9_]{1,15})\/likes$/);

--- a/src/content/injector.ts
+++ b/src/content/injector.ts
@@ -565,6 +565,14 @@ try {
       });
       return false;
     }
+    if (msg && msg.action === 'XCLIPPER_HARVEST_RESET') {
+      // Drop everything gathered so far, then re-seed from the current viewport
+      // so the collection restarts at wherever the user has scrolled to.
+      harvested.clear();
+      harvestTimeline();
+      sendResponse({ count: harvested.size });
+      return false;
+    }
     if (msg && msg.action === 'XCLIPPER_SELECTION') {
       if (msg.enable) enterSelection();
       else exitSelection();

--- a/src/content/injector.ts
+++ b/src/content/injector.ts
@@ -7,6 +7,7 @@ let decorated = new WeakSet<Element>();
 
 let inlineButtonCopies = false;
 let showInlineButton = false;
+let includeReposts = false; // profile batch: keep reposts too (default off)
 
 function removeAllInjectedButtons(): void {
   document.querySelectorAll(`[${BUTTON_ATTR}]`).forEach((btn) => {
@@ -35,7 +36,9 @@ function loadInlineMode(): void {
       const s = (result['xclipper_settings'] || {}) as {
         inlineButtonCopies?: boolean;
         showInlineButton?: boolean;
+        includeReposts?: boolean;
       };
+      includeReposts = s.includeReposts === true;
       inlineButtonCopies = s.inlineButtonCopies === true;
       const wasShown = showInlineButton;
       showInlineButton = s.showInlineButton === true; // default false in v2.0.0
@@ -358,7 +361,7 @@ function harvestTimeline(): HarvestSource {
   for (const article of document.querySelectorAll('article[role="article"]')) {
     const url = getStatusUrl(article);
     if (!url) continue;
-    if (source.kind === 'profile') {
+    if (source.kind === 'profile' && !includeReposts) {
       // Repost cells link to the original author's permalink — skip them so
       // a profile export contains the profile owner's own posts.
       const author = url.match(/x\.com\/([^/]+)\/status\//)?.[1] || '';

--- a/src/graphql/timeline.ts
+++ b/src/graphql/timeline.ts
@@ -28,20 +28,36 @@ interface RawEntry {
     cursorType?: string;
     value?: string;
     itemContent?: { tweet_results?: { result?: unknown } };
+    // Profile/likes self-thread cells wrap tweets in a module's `items`.
+    items?: { item?: { itemContent?: { tweet_results?: { result?: unknown } } } }[];
   };
 }
 
-// The timeline lives under different data keys per source; check the known ones.
+// The timeline lives under different data keys per source (bookmarks, profile,
+// likes…). Check the known keys, then fall back to a generic search for the
+// `instructions` array so a new source works without a hardcoded path.
 function findTimeline(raw: unknown): RawTimeline | null {
   const d = (raw as { data?: Record<string, unknown> } | null)?.data;
   if (!d) return null;
-  const paths: (RawTimeline | undefined)[] = [
+  const known: (RawTimeline | undefined)[] = [
     (d.bookmark_timeline_v2 as { timeline?: RawTimeline })?.timeline,
     (d.bookmark_timeline as { timeline?: RawTimeline })?.timeline,
     (d.user as { result?: { timeline_v2?: { timeline?: RawTimeline } } })?.result?.timeline_v2?.timeline,
     (d.user as { result?: { timeline?: { timeline?: RawTimeline } } })?.result?.timeline?.timeline,
   ];
-  return paths.find((t): t is RawTimeline => !!t?.instructions) ?? null;
+  return known.find((t): t is RawTimeline => !!t?.instructions) ?? searchTimeline(d);
+}
+
+// Depth-limited search for the first object carrying an `instructions` array.
+function searchTimeline(o: unknown, depth = 0): RawTimeline | null {
+  if (!o || typeof o !== 'object' || depth > 6) return null;
+  const obj = o as Record<string, unknown>;
+  if (Array.isArray(obj.instructions)) return obj as RawTimeline;
+  for (const v of Object.values(obj)) {
+    const found = searchTimeline(v, depth + 1);
+    if (found) return found;
+  }
+  return null;
 }
 
 export function parseTimelinePage(raw: unknown): TimelinePage {
@@ -53,11 +69,20 @@ export function parseTimelinePage(raw: unknown): TimelinePage {
   const tweetResults: unknown[] = [];
   let bottomCursor: string | null = null;
   for (const e of entries) {
-    if (e.entryId?.startsWith('tweet-')) {
-      const result = e.content?.itemContent?.tweet_results?.result;
-      if (result != null) tweetResults.push(result);
-    } else if (e.content?.cursorType === 'Bottom' && typeof e.content.value === 'string') {
-      bottomCursor = e.content.value;
+    const c = e.content;
+    if (c?.cursorType === 'Bottom' && typeof c.value === 'string') {
+      bottomCursor = c.value;
+      continue;
+    }
+    // A plain tweet cell, or a module (self-thread) wrapping several tweets.
+    const top = c?.itemContent?.tweet_results?.result;
+    if (top != null) {
+      tweetResults.push(top);
+      continue;
+    }
+    for (const it of c?.items ?? []) {
+      const r = it.item?.itemContent?.tweet_results?.result;
+      if (r != null) tweetResults.push(r);
     }
   }
   return { tweetResults, bottomCursor, done: tweetResults.length === 0 };

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "__MSG_extensionName__",
   "short_name": "XClipper",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "description": "__MSG_extensionDescription__",
   "default_locale": "en",
   "permissions": [

--- a/src/popup/batch-ui.ts
+++ b/src/popup/batch-ui.ts
@@ -148,29 +148,39 @@ async function refreshIdleUi(): Promise<void> {
   // bookmarks through the GraphQL session, so it doesn't need the bookmarks page
   // loaded. Phase 1 is bookmarks-only — other tabs point back to Bookmarks.
   if (getFastMode()) {
-    if (activeTab === 'bookmarks') {
-      // Fast paginates from the top via cursor (no harvested collection), so
-      // "Reset queue" is always greyed here; "Reset history" greys when the
-      // dedup ledger is empty. The row stays visible so layout doesn't jump.
-      const ledger = await loadLedgerSet();
-      btnBatchResetQueue.disabled = true;
-      btnBatchReset.disabled = ledger.size === 0;
-      batchDedupText.textContent =
-        ledger.size > 0 ? `${ledger.size} ${t('batch_already_exported', 'already exported')}` : '';
-      batchDedupRow.classList.remove('hidden');
-      setButton(
-        `⚡ ${t('btn_batch', 'Export bookmarks')}`,
-        !isFastActive(),
-        t('btn_batch_fast_hint', 'Fetch all your bookmarks through your X session — much faster. Expands threads & articles; stops politely if X rate-limits.')
-      );
-    } else {
+    // Selection isn't Fast-compatible (no feed to paginate).
+    if (activeTab === 'selection') {
       batchDedupRow.classList.add('hidden');
       setButton(
-        `⚡ ${t('btn_batch', 'Export bookmarks')}`,
+        t('btn_batch_select', 'Select tweets…'),
         false,
-        t('btn_batch_fast_only_bookmarks', 'Fast Batch supports bookmarks only for now — switch to the Bookmarks tab, or turn off Fast.')
+        t('btn_batch_fast_no_selection', "Selection isn't available in Fast — turn Fast off to pick tweets by hand.")
       );
+      return;
     }
+    // bookmarks / profile / likes — Fast paginates from the top via cursor (no
+    // harvested collection), so "Reset queue" is always greyed; "Reset history"
+    // greys when the ledger is empty. The row stays visible so layout is stable.
+    const ledger = await loadLedgerSet();
+    btnBatchResetQueue.disabled = true;
+    btnBatchReset.disabled = ledger.size === 0;
+    batchDedupText.textContent =
+      ledger.size > 0 ? `${ledger.size} ${t('batch_already_exported', 'already exported')}` : '';
+    batchDedupRow.classList.remove('hidden');
+    let label: string;
+    let hint: string;
+    if (activeTab === 'profile') {
+      const { handle } = await harvest();
+      label = `⚡ ${t('btn_batch_profile', 'Export posts')}${handle ? ` @${handle}` : ''}`;
+      hint = t('btn_batch_fast_profile_hint', "Fetch this profile's own posts through your X session — much faster. Reposts are skipped.");
+    } else if (activeTab === 'likes') {
+      label = `⚡ ${t('btn_batch_likes', 'Export likes')}`;
+      hint = t('btn_batch_fast_likes_hint', 'Fetch your liked posts through your X session — much faster. Expands threads & articles.');
+    } else {
+      label = `⚡ ${t('btn_batch', 'Export bookmarks')}`;
+      hint = t('btn_batch_fast_hint', 'Fetch all your bookmarks through your X session — much faster. Expands threads & articles; stops politely if X rate-limits.');
+    }
+    setButton(label, !isFastActive(), hint);
     return;
   }
 
@@ -277,6 +287,22 @@ async function refreshIdleUi(): Promise<void> {
   btnBatchReset.disabled = !historyEnabled;
   batchDedupText.textContent = historyEnabled ? `${skipped} ${t('batch_already_exported', 'already exported')}` : '';
   batchDedupRow.classList.remove('hidden');
+}
+
+// Fast can't do Selection, so disable that tab while Fast is armed (and bounce
+// off it if it was active). The tab dims via color, not opacity, so its tooltip
+// stays readable (issue #38).
+function applyFastTabGating(): void {
+  const fast = getFastMode();
+  const sel = TAB_BUTTONS.selection;
+  sel.disabled = fast;
+  sel.setAttribute(
+    'data-tooltip',
+    fast
+      ? t('batch_tab_selection_fast', 'Turn Fast off to pick tweets by hand')
+      : t('batch_tab_selection', 'Selection')
+  );
+  if (fast && activeTab === 'selection') setActiveTab('bookmarks');
 }
 
 function setActiveTab(tab: BatchTab): void {
@@ -395,10 +421,12 @@ async function control(controlAction: 'pause' | 'resume' | 'cancel'): Promise<vo
 }
 
 async function startExport(): Promise<void> {
-  // Armed Fast Batch routes bookmarks through the GraphQL path (own progress
-  // poller in fast-batch-ui). Other tabs can't be Fast yet (Phase 1).
-  if (getFastMode() && activeTab === 'bookmarks') {
-    await startFastExport();
+  // Armed Fast Batch routes the paginated sources (bookmarks/profile/likes)
+  // through the GraphQL path (own progress poller in fast-batch-ui). Selection
+  // isn't Fast-compatible (its tab is disabled while Fast is armed).
+  if (getFastMode() && activeTab !== 'selection') {
+    const { handle } = await harvest();
+    await startFastExport(activeTab, activeTab === 'profile' ? handle : undefined);
     return;
   }
 
@@ -473,8 +501,12 @@ async function resetQueue(): Promise<void> {
 export async function initBatchUi(): Promise<void> {
   btnBatch.addEventListener('click', () => void (appendable ? appendExport() : startExport()));
   btnBatchCancel.addEventListener('click', () => void (isFastActive() ? cancelFast() : control('cancel')));
-  // Fast toggle armed/disarmed, or a fast run finished → re-evaluate the button.
-  window.addEventListener('xclipper-fast-changed', () => void refreshIdleUi());
+  // Fast toggle armed/disarmed, or a fast run finished → re-evaluate the button
+  // and the Selection tab (which Fast disables).
+  window.addEventListener('xclipper-fast-changed', () => {
+    applyFastTabGating();
+    void refreshIdleUi();
+  });
   btnBatchPause.addEventListener('click', () => {
     const resuming = lastJob?.status === 'paused';
     void control(resuming ? 'resume' : 'pause');
@@ -507,6 +539,7 @@ export async function initBatchUi(): Promise<void> {
   // still focus e.g. Bookmarks. Selection is the last resort (any x.com page).
   const { source } = await harvest();
   setActiveTab(activeJob?.origin ?? source ?? sourceFromUrl(tab?.url) ?? (pageIsX ? 'selection' : 'bookmarks'));
+  applyFastTabGating(); // reflect Fast state if it was restored armed
 }
 
 // Best-effort page type from the URL, for initial tab focus when the injector

--- a/src/popup/batch-ui.ts
+++ b/src/popup/batch-ui.ts
@@ -89,6 +89,9 @@ let jobPollTimer: ReturnType<typeof setInterval> | undefined;
 let countPollTimer: ReturnType<typeof setInterval> | undefined;
 let pageTabId: number | undefined;
 let pageIsX = false;
+// Current page URL — lets Fast read the profile handle without the injector
+// (Fast uses captured GraphQL, so it works even when the page wasn't reloaded).
+let pageUrl: string | undefined;
 
 async function fetchJob(): Promise<JobSnapshot | undefined> {
   try {
@@ -170,7 +173,8 @@ async function refreshIdleUi(): Promise<void> {
     let label: string;
     let hint: string;
     if (activeTab === 'profile') {
-      const { handle } = await harvest();
+      // Handle from the URL, not the injector — Fast doesn't need the page.
+      const handle = handleFromUrl(pageUrl);
       label = `⚡ ${t('btn_batch_profile', 'Export posts')}${handle ? ` @${handle}` : ''}`;
       hint = t('btn_batch_fast_profile_hint', "Fetch this profile's own posts through your X session — much faster. Reposts are skipped.");
     } else if (activeTab === 'likes') {
@@ -436,8 +440,8 @@ async function startExport(): Promise<void> {
   // through the GraphQL path (own progress poller in fast-batch-ui). Selection
   // isn't Fast-compatible (its tab is disabled while Fast is armed).
   if (getFastMode() && activeTab !== 'selection') {
-    const { handle } = await harvest();
-    await startFastExport(activeTab, activeTab === 'profile' ? handle : undefined);
+    // Fast reads the profile handle from the URL (no injector needed).
+    await startFastExport(activeTab, activeTab === 'profile' ? handleFromUrl(pageUrl) : undefined);
     return;
   }
 
@@ -534,6 +538,7 @@ export async function initBatchUi(): Promise<void> {
   const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
   pageIsX = !!tab?.id && hostMatches(tab.url || '', 'x.com', 'www.x.com');
   if (pageIsX) pageTabId = tab!.id;
+  pageUrl = tab?.url;
 
   const job = await fetchJob();
   const activeJob =
@@ -572,4 +577,15 @@ function sourceFromUrl(url: string | undefined): BatchTab | null {
   const reserved = new Set(['/home', '/explore', '/notifications', '/messages', '/search', '/settings', '/i', '/compose']);
   if (/^\/[A-Za-z0-9_]{1,15}$/.test(path) && !reserved.has(path)) return 'profile';
   return null;
+}
+
+// Profile handle straight from the URL — Fast doesn't need the injector, so this
+// works even when the page wasn't reloaded after an extension update.
+function handleFromUrl(url: string | undefined): string | undefined {
+  if (sourceFromUrl(url) !== 'profile') return undefined;
+  try {
+    return new URL(url as string).pathname.replace(/^\/+|\/+$/g, '').split('/')[0] || undefined;
+  } catch {
+    return undefined;
+  }
 }

--- a/src/popup/batch-ui.ts
+++ b/src/popup/batch-ui.ts
@@ -42,7 +42,7 @@ import {
   tabBatchLikes,
 } from './dom';
 import { setExportMode } from './mode';
-import { getFastMode, isFastActive, startFastExport, cancelFast, setStandardJobActive } from './fast-batch-ui';
+import { getFastMode, isFastActive, startFastExport, cancelFast, setStandardJobActive, resumeFastIfActive } from './fast-batch-ui';
 
 type JobSnapshot = NonNullable<BatchStatusResponse['job']>;
 type BatchTab = 'bookmarks' | 'profile' | 'selection' | 'likes';
@@ -542,6 +542,10 @@ export async function initBatchUi(): Promise<void> {
     setExportMode(false, false); // reopening mid-job lands on Batch, not Single
     render(activeJob); // sets jobIsActive, so tab setup below keeps Start disabled
     startJobPolling();
+  } else if (await resumeFastIfActive()) {
+    // A Fast Batch run is still going in the background — land on Batch so its
+    // progress (with whose export) is visible; fast-batch-ui owns the polling.
+    setExportMode(false, false);
   }
 
   // Land on the running job's origin tab (so its progress is visible), else the

--- a/src/popup/batch-ui.ts
+++ b/src/popup/batch-ui.ts
@@ -150,15 +150,14 @@ async function refreshIdleUi(): Promise<void> {
   if (getFastMode()) {
     if (activeTab === 'bookmarks') {
       // Fast paginates from the top via cursor (no harvested collection), so
-      // there's no "Reset queue" here — only the dedup history. Fast can't know
-      // up front which are already exported, so show the ledger size + Reset.
+      // "Reset queue" is always greyed here; "Reset history" greys when the
+      // dedup ledger is empty. The row stays visible so layout doesn't jump.
       const ledger = await loadLedgerSet();
-      btnBatchResetQueue.classList.add('hidden');
-      btnBatchReset.classList.toggle('hidden', ledger.size === 0);
-      batchDedupRow.classList.toggle('hidden', ledger.size === 0);
-      if (ledger.size > 0) {
-        batchDedupText.textContent = `${ledger.size} ${t('batch_already_exported', 'already exported')}`;
-      }
+      btnBatchResetQueue.disabled = true;
+      btnBatchReset.disabled = ledger.size === 0;
+      batchDedupText.textContent =
+        ledger.size > 0 ? `${ledger.size} ${t('batch_already_exported', 'already exported')}` : '';
+      batchDedupRow.classList.remove('hidden');
       setButton(
         `⚡ ${t('btn_batch', 'Export bookmarks')}`,
         !isFastActive(),
@@ -268,16 +267,16 @@ async function refreshIdleUi(): Promise<void> {
         ? t('btn_batch_likes_hint', 'Export every liked post loaded on this page as Markdown files into one folder. Scroll your Likes page to load more.')
         : t('btn_batch_hint', 'Export every bookmark loaded on this page as Markdown files into one folder. Scroll the bookmarks page to load more.');
   setButton(base + suffix, fresh.length > 0, tooltip);
-  // The control row carries two independent affordances:
-  //  • Reset queue — when there's a gathered collection to restart.
-  //  • Reset history ("N already exported") — when past runs skipped items.
-  // Both hidden while appending to a live job (its queue-exclusion handles it).
-  const showQueue = urls.length > 0 && !onSameSourceJob;
-  const showHistory = skipped > 0 && !onSameSourceJob;
-  btnBatchResetQueue.classList.toggle('hidden', !showQueue);
-  btnBatchReset.classList.toggle('hidden', !showHistory);
-  batchDedupText.textContent = showHistory ? `${skipped} ${t('batch_already_exported', 'already exported')}` : '';
-  batchDedupRow.classList.toggle('hidden', !showQueue && !showHistory);
+  // The control row is always shown here (stable layout); the two buttons just
+  // GREY OUT when not applicable instead of disappearing:
+  //  • Reset queue — enabled when there's a gathered collection to restart.
+  //  • Reset history ("N already exported") — enabled when past runs skipped items.
+  // Both disabled while appending to a live job (its queue-exclusion handles it).
+  btnBatchResetQueue.disabled = !(urls.length > 0) || onSameSourceJob;
+  const historyEnabled = skipped > 0 && !onSameSourceJob;
+  btnBatchReset.disabled = !historyEnabled;
+  batchDedupText.textContent = historyEnabled ? `${skipped} ${t('batch_already_exported', 'already exported')}` : '';
+  batchDedupRow.classList.remove('hidden');
 }
 
 function setActiveTab(tab: BatchTab): void {

--- a/src/popup/batch-ui.ts
+++ b/src/popup/batch-ui.ts
@@ -35,6 +35,7 @@ import {
   btnBatchLabel,
   btnBatchPause,
   btnBatchReset,
+  btnBatchResetQueue,
   tabBatchBookmarks,
   tabBatchProfile,
   tabBatchSelection,
@@ -148,9 +149,12 @@ async function refreshIdleUi(): Promise<void> {
   // loaded. Phase 1 is bookmarks-only — other tabs point back to Bookmarks.
   if (getFastMode()) {
     if (activeTab === 'bookmarks') {
-      // Fast can't know up front which bookmarks are already exported (it
-      // discovers that mid-run), so show the ledger size + Reset affordance.
+      // Fast paginates from the top via cursor (no harvested collection), so
+      // there's no "Reset queue" here — only the dedup history. Fast can't know
+      // up front which are already exported, so show the ledger size + Reset.
       const ledger = await loadLedgerSet();
+      btnBatchResetQueue.classList.add('hidden');
+      btnBatchReset.classList.toggle('hidden', ledger.size === 0);
       batchDedupRow.classList.toggle('hidden', ledger.size === 0);
       if (ledger.size > 0) {
         batchDedupText.textContent = `${ledger.size} ${t('batch_already_exported', 'already exported')}`;
@@ -264,12 +268,16 @@ async function refreshIdleUi(): Promise<void> {
         ? t('btn_batch_likes_hint', 'Export every liked post loaded on this page as Markdown files into one folder. Scroll your Likes page to load more.')
         : t('btn_batch_hint', 'Export every bookmark loaded on this page as Markdown files into one folder. Scroll the bookmarks page to load more.');
   setButton(base + suffix, fresh.length > 0, tooltip);
-  // The "already exported" note is about past jobs; while appending to a live
-  // job the queue-exclusion handles dupes, so hide it there.
-  batchDedupRow.classList.toggle('hidden', skipped === 0 || onSameSourceJob);
-  if (skipped > 0 && !onSameSourceJob) {
-    batchDedupText.textContent = `${skipped} ${t('batch_already_exported', 'already exported')}`;
-  }
+  // The control row carries two independent affordances:
+  //  • Reset queue — when there's a gathered collection to restart.
+  //  • Reset history ("N already exported") — when past runs skipped items.
+  // Both hidden while appending to a live job (its queue-exclusion handles it).
+  const showQueue = urls.length > 0 && !onSameSourceJob;
+  const showHistory = skipped > 0 && !onSameSourceJob;
+  btnBatchResetQueue.classList.toggle('hidden', !showQueue);
+  btnBatchReset.classList.toggle('hidden', !showHistory);
+  batchDedupText.textContent = showHistory ? `${skipped} ${t('batch_already_exported', 'already exported')}` : '';
+  batchDedupRow.classList.toggle('hidden', !showQueue && !showHistory);
 }
 
 function setActiveTab(tab: BatchTab): void {
@@ -451,6 +459,18 @@ async function appendExport(): Promise<void> {
   await refreshIdleUi();
 }
 
+// Empty the injector's gathered collection so it restarts from the current
+// scroll position, then refresh the count.
+async function resetQueue(): Promise<void> {
+  if (pageTabId === undefined) return;
+  try {
+    await chrome.tabs.sendMessage(pageTabId, { action: 'XCLIPPER_HARVEST_RESET' });
+  } catch {
+    // injector gone (page needs a reload) — refreshIdleUi will surface that
+  }
+  await refreshIdleUi();
+}
+
 export async function initBatchUi(): Promise<void> {
   btnBatch.addEventListener('click', () => void (appendable ? appendExport() : startExport()));
   btnBatchCancel.addEventListener('click', () => void (isFastActive() ? cancelFast() : control('cancel')));
@@ -464,6 +484,7 @@ export async function initBatchUi(): Promise<void> {
   btnBatchReset.addEventListener('click', () => {
     chrome.storage.local.remove(EXPORTED_LEDGER_KEY, () => void refreshIdleUi());
   });
+  btnBatchResetQueue.addEventListener('click', () => void resetQueue());
   (Object.keys(TAB_BUTTONS) as BatchTab[]).forEach((tab) => {
     TAB_BUTTONS[tab].addEventListener('click', () => setActiveTab(tab));
   });

--- a/src/popup/batch-ui.ts
+++ b/src/popup/batch-ui.ts
@@ -180,13 +180,13 @@ async function refreshIdleUi(): Promise<void> {
     if (activeTab === 'profile') {
       // Handle from the URL, not the injector — Fast doesn't need the page.
       const handle = handleFromUrl(pageUrl);
-      label = `⚡ ${t('btn_batch_profile', 'Export posts')}${handle ? ` @${handle}` : ''}`;
+      label = `${t('btn_batch_profile', 'Export posts')}${handle ? ` @${handle}` : ''}`;
       hint = t('btn_batch_fast_profile_hint', "Fetch this profile's own posts through your X session — much faster. Reposts are skipped.");
     } else if (activeTab === 'likes') {
-      label = `⚡ ${t('btn_batch_likes', 'Export likes')}`;
+      label = t('btn_batch_likes', 'Export likes');
       hint = t('btn_batch_fast_likes_hint', 'Fetch your liked posts through your X session — much faster. Expands threads & articles.');
     } else {
-      label = `⚡ ${t('btn_batch', 'Export bookmarks')}`;
+      label = t('btn_batch', 'Export bookmarks');
       hint = t('btn_batch_fast_hint', 'Fetch all your bookmarks through your X session — much faster. Expands threads & articles; stops politely if X rate-limits.');
     }
     setButton(label, !isFastActive(), hint);

--- a/src/popup/batch-ui.ts
+++ b/src/popup/batch-ui.ts
@@ -311,8 +311,8 @@ function setActiveTab(tab: BatchTab): void {
     TAB_BUTTONS[k].classList.toggle('active', k === tab);
     TAB_ICONS[k].classList.toggle('hidden', k !== tab);
   });
-  // Progress and reports belong to the tab the job was started from; other
-  // tabs just show their (disabled) start button.
+  // A running job's progress follows the job, not the tab — keep it visible on
+  // every tab while active; only hide it once idle.
   if (jobIsActive && lastJob) {
     render(lastJob);
   } else if (!isFastActive()) {
@@ -323,12 +323,21 @@ function setActiveTab(tab: BatchTab): void {
   startCountPolling();
 }
 
+// Short label for whose/which job is running, so progress stays meaningful even
+// when you've navigated to a different page (e.g. another profile).
+function jobWho(job: JobSnapshot): string {
+  if (job.origin === 'profile' && job.handle) return `@${job.handle}`;
+  if (job.origin === 'bookmarks') return t('group_bookmarks', 'Bookmarks');
+  if (job.origin === 'likes') return t('batch_tab_likes', 'Likes');
+  if (job.origin === 'selection') return t('batch_tab_selection', 'Selection');
+  return '';
+}
+
 function render(job: JobSnapshot): void {
   lastJob = job;
-  // Show progress only on the tab the job came from (no origin = legacy
-  // job from before origins existed — show everywhere).
-  const onOriginTab = !job.origin || job.origin === activeTab;
-  batchProgress.classList.toggle('hidden', !onOriginTab);
+  // Always show the running job's progress — it belongs to the job, not to a
+  // tab/page, so navigating elsewhere (e.g. another profile) must not hide it.
+  batchProgress.classList.remove('hidden');
   const processed = job.completed + job.failed;
   const pct = job.total > 0 ? Math.round((processed / job.total) * 100) : 0;
   batchBarFill.style.width = `${pct}%`;
@@ -352,16 +361,18 @@ function render(job: JobSnapshot): void {
     paused ? t('batch_resume', 'Resume') : t('batch_pause', 'Pause')
   );
 
+  const who = jobWho(job);
+  const prefix = who ? `${who} · ` : '';
   const failedSuffix =
     job.failed > 0 ? ` · ${job.failed} ${t('batch_failed', 'failed')}` : '';
   if (job.status === 'running') {
-    batchProgressText.textContent = `${processed}/${job.total}${failedSuffix}`;
+    batchProgressText.textContent = `${prefix}${processed}/${job.total}${failedSuffix}`;
   } else if (job.status === 'paused') {
     const reason = job.pauseReason ? ` · ${job.pauseReason}` : '';
-    batchProgressText.textContent = `${t('batch_paused', 'Paused')} — ${processed}/${job.total}${failedSuffix}${reason}`;
+    batchProgressText.textContent = `${prefix}${t('batch_paused', 'Paused')} — ${processed}/${job.total}${failedSuffix}${reason}`;
   } else {
     const label = job.status === 'done' ? t('batch_done', 'Done') : t('batch_stopped', 'Stopped');
-    batchProgressText.textContent = `${label} — ${job.completed} ${t('batch_exported', 'exported')}${failedSuffix}`;
+    batchProgressText.textContent = `${prefix}${label} — ${job.completed} ${t('batch_exported', 'exported')}${failedSuffix}`;
   }
 }
 

--- a/src/popup/batch-ui.ts
+++ b/src/popup/batch-ui.ts
@@ -77,6 +77,13 @@ const TAB_ICONS: Record<BatchTab, SVGElement> = {
   timeline: btnBatchIconTimeline,
 };
 
+// Sources with a fixed URL we can open directly (no handle needed). Profile and
+// Likes are per-account, so they can't be opened generically.
+const OPEN_URLS: Partial<Record<BatchTab, string>> = {
+  bookmarks: 'https://x.com/i/bookmarks',
+  timeline: 'https://x.com/home',
+};
+
 let activeTab: BatchTab = 'bookmarks';
 // One job at a time (the background enforces this — one worker window,
 // politeness throttle toward X). Tabs stay browsable mid-job; this flag
@@ -86,6 +93,10 @@ let jobIsActive = false;
 // True when the action button should ADD the loaded items to the running
 // job's queue (same-source job in progress) instead of starting a new one.
 let appendable = false;
+// When the active tab's source has a canonical URL but the user isn't on it,
+// the action button becomes "Open <page>" and navigates there instead of
+// exporting. Only sources that need no handle (bookmarks, timeline) qualify.
+let openTarget: string | undefined;
 // Last polled snapshot, so a tab switch can re-evaluate progress visibility
 // immediately instead of waiting for the next poll.
 let lastJob: JobSnapshot | undefined;
@@ -150,6 +161,7 @@ function setButton(label: string, enabled: boolean, tooltip: string): void {
 // user at the right page.
 async function refreshIdleUi(): Promise<void> {
   appendable = false;
+  openTarget = undefined;
   // Reset buttons are always shown (stacked beside Export); default them to
   // disabled so early-return branches leave them greyed, and the main/fast
   // paths re-enable as appropriate below.
@@ -236,10 +248,11 @@ async function refreshIdleUi(): Promise<void> {
 
   if (activeTab === 'bookmarks' && source !== 'bookmarks') {
     batchDedupRow.classList.add('hidden');
+    openTarget = OPEN_URLS.bookmarks;
     setButton(
-      t('btn_batch', 'Export bookmarks'),
-      false,
-      t('btn_batch_open_bookmarks', 'Open x.com/i/bookmarks to export your bookmarks.')
+      t('btn_batch_go_bookmarks', 'Open Bookmarks'),
+      true,
+      t('btn_batch_open_bookmarks', 'Open your Bookmarks page, then scroll to load posts and export.')
     );
     return;
   }
@@ -263,10 +276,11 @@ async function refreshIdleUi(): Promise<void> {
   }
   if (activeTab === 'timeline' && source !== 'timeline') {
     batchDedupRow.classList.add('hidden');
+    openTarget = OPEN_URLS.timeline;
     setButton(
-      t('btn_batch_timeline', 'Export timeline'),
-      false,
-      t('btn_batch_open_timeline', 'Open x.com/home to export the posts in your timeline.')
+      t('btn_batch_go_timeline', 'Open Timeline'),
+      true,
+      t('btn_batch_open_timeline', 'Open your home timeline, then scroll to load posts and export.')
     );
     return;
   }
@@ -538,6 +552,18 @@ async function appendExport(): Promise<void> {
   await refreshIdleUi();
 }
 
+// Take the user to a source's page (Bookmarks/Timeline) when they aren't on it:
+// navigate the current x.com tab if there is one, else open a new tab. They then
+// scroll to load posts and export (Standard reads the loaded DOM).
+function openSourcePage(url: string): void {
+  if (pageIsX && pageTabId !== undefined) {
+    void chrome.tabs.update(pageTabId, { url });
+  } else {
+    void chrome.tabs.create({ url });
+  }
+  window.close();
+}
+
 // Empty the injector's gathered collection so it restarts from the current
 // scroll position, then refresh the count.
 async function resetQueue(): Promise<void> {
@@ -551,7 +577,10 @@ async function resetQueue(): Promise<void> {
 }
 
 export async function initBatchUi(): Promise<void> {
-  btnBatch.addEventListener('click', () => void (appendable ? appendExport() : startExport()));
+  btnBatch.addEventListener('click', () => {
+    if (openTarget) return void openSourcePage(openTarget);
+    void (appendable ? appendExport() : startExport());
+  });
   btnBatchCancel.addEventListener('click', () => void (isFastActive() ? cancelFast() : control('cancel')));
   // Fast toggle armed/disarmed, or a fast run finished → re-evaluate the button
   // and the Selection tab (which Fast disables).

--- a/src/popup/batch-ui.ts
+++ b/src/popup/batch-ui.ts
@@ -32,6 +32,7 @@ import {
   btnBatchIconProfile,
   btnBatchIconSelection,
   btnBatchIconLikes,
+  btnBatchIconTimeline,
   btnBatchLabel,
   btnBatchPause,
   btnBatchReset,
@@ -40,12 +41,13 @@ import {
   tabBatchProfile,
   tabBatchSelection,
   tabBatchLikes,
+  tabBatchTimeline,
 } from './dom';
 import { setExportMode } from './mode';
 import { getFastMode, isFastActive, startFastExport, cancelFast, setStandardJobActive, resumeFastIfActive, updateFastSteps } from './fast-batch-ui';
 
 type JobSnapshot = NonNullable<BatchStatusResponse['job']>;
-type BatchTab = 'bookmarks' | 'profile' | 'selection' | 'likes';
+type BatchTab = 'bookmarks' | 'profile' | 'selection' | 'likes' | 'timeline';
 
 // The pause button swaps between a pause and a play (resume) glyph.
 const icoPause = btnBatchPause.querySelector('.batch-ico-pause');
@@ -62,15 +64,17 @@ const TAB_BUTTONS: Record<BatchTab, HTMLButtonElement> = {
   profile: tabBatchProfile,
   selection: tabBatchSelection,
   likes: tabBatchLikes,
+  timeline: tabBatchTimeline,
 };
 
-// Per-tab action-button icons (bookmark, user, check-square, heart) — all
+// Per-tab action-button icons (bookmark, user, check-square, heart, home) — all
 // live in the HTML; the inactive ones are hidden.
 const TAB_ICONS: Record<BatchTab, SVGElement> = {
   bookmarks: btnBatchIconBookmarks,
   profile: btnBatchIconProfile,
   selection: btnBatchIconSelection,
   likes: btnBatchIconLikes,
+  timeline: btnBatchIconTimeline,
 };
 
 let activeTab: BatchTab = 'bookmarks';
@@ -156,13 +160,17 @@ async function refreshIdleUi(): Promise<void> {
   // bookmarks through the GraphQL session, so it doesn't need the bookmarks page
   // loaded. Phase 1 is bookmarks-only — other tabs point back to Bookmarks.
   if (getFastMode()) {
-    // Selection isn't Fast-compatible (no feed to paginate).
-    if (activeTab === 'selection') {
+    // Selection and Timeline aren't Fast-compatible (no GET-paginated feed).
+    if (activeTab === 'selection' || activeTab === 'timeline') {
       batchDedupRow.classList.add('hidden');
       setButton(
-        t('btn_batch_select', 'Select tweets…'),
+        activeTab === 'timeline'
+          ? t('btn_batch_timeline', 'Export timeline')
+          : t('btn_batch_select', 'Select tweets…'),
         false,
-        t('btn_batch_fast_no_selection', "Selection isn't available in Fast — turn Fast off to pick tweets by hand.")
+        activeTab === 'timeline'
+          ? t('btn_batch_fast_no_timeline', "Timeline isn't available in Fast — turn Fast off to export your home feed.")
+          : t('btn_batch_fast_no_selection', "Selection isn't available in Fast — turn Fast off to pick tweets by hand.")
       );
       return;
     }
@@ -205,7 +213,8 @@ async function refreshIdleUi(): Promise<void> {
       activeTab === 'bookmarks' ? t('btn_batch', 'Export bookmarks')
         : activeTab === 'profile' ? t('btn_batch_profile', 'Export posts')
           : activeTab === 'likes' ? t('btn_batch_likes', 'Export likes')
-            : t('btn_batch_select', 'Select tweets…');
+            : activeTab === 'timeline' ? t('btn_batch_timeline', 'Export timeline')
+              : t('btn_batch_select', 'Select tweets…');
     // Keep it ENABLED — a disabled button can't show its tooltip in Chrome, so
     // the reason would be invisible. Clicking surfaces the reload hint (like
     // Single export does), which the user found clear.
@@ -252,6 +261,15 @@ async function refreshIdleUi(): Promise<void> {
     );
     return;
   }
+  if (activeTab === 'timeline' && source !== 'timeline') {
+    batchDedupRow.classList.add('hidden');
+    setButton(
+      t('btn_batch_timeline', 'Export timeline'),
+      false,
+      t('btn_batch_open_timeline', 'Open x.com/home to export the posts in your timeline.')
+    );
+    return;
+  }
 
   // On the running job's own source the button appends loaded items to its
   // queue instead of starting a new job — bookmarks always; a profile only
@@ -277,7 +295,9 @@ async function refreshIdleUi(): Promise<void> {
       ? `${t('btn_batch_profile', 'Export posts')}${handle ? ` @${handle}` : ''}`
       : activeTab === 'likes'
         ? t('btn_batch_likes', 'Export likes')
-        : t('btn_batch', 'Export bookmarks');
+        : activeTab === 'timeline'
+          ? t('btn_batch_timeline', 'Export timeline')
+          : t('btn_batch', 'Export bookmarks');
   const suffix = skipped > 0 ? ` (${fresh.length} ${t('batch_new', 'new')})` : ` (${fresh.length})`;
   const tooltip = onSameSourceJob
     ? t('btn_batch_add_hint', 'Add the newly-loaded posts to the running batch queue.')
@@ -285,7 +305,9 @@ async function refreshIdleUi(): Promise<void> {
       ? t('btn_batch_profile_hint', "Export this profile's own posts loaded on the page as Markdown files into one folder. Reposts are skipped; scroll to load more.")
       : activeTab === 'likes'
         ? t('btn_batch_likes_hint', 'Export every liked post loaded on this page as Markdown files into one folder. Scroll your Likes page to load more.')
-        : t('btn_batch_hint', 'Export every bookmark loaded on this page as Markdown files into one folder. Scroll the bookmarks page to load more.');
+        : activeTab === 'timeline'
+          ? t('btn_batch_timeline_hint', 'Export every post loaded in your home timeline as Markdown files into one folder. Scroll to load more.')
+          : t('btn_batch_hint', 'Export every bookmark loaded on this page as Markdown files into one folder. Scroll the bookmarks page to load more.');
   setButton(base + suffix, fresh.length > 0, tooltip);
   // The control row is always shown here (stable layout); the two buttons just
   // GREY OUT when not applicable instead of disappearing:
@@ -299,9 +321,9 @@ async function refreshIdleUi(): Promise<void> {
   batchDedupRow.classList.remove('hidden');
 }
 
-// Fast can't do Selection, so disable that tab while Fast is armed (and bounce
-// off it if it was active). The tab dims via color, not opacity, so its tooltip
-// stays readable (issue #38).
+// Fast can't do Selection or Timeline (no GET-paginated feed), so disable those
+// tabs while Fast is armed (and bounce off them if active). The tabs dim via
+// color, not opacity, so their tooltips stay readable (issue #38).
 function applyFastTabGating(): void {
   const fast = getFastMode();
   const sel = TAB_BUTTONS.selection;
@@ -312,7 +334,15 @@ function applyFastTabGating(): void {
       ? t('batch_tab_selection_fast', 'Turn Fast off to pick tweets by hand')
       : t('batch_tab_selection', 'Selection')
   );
-  if (fast && activeTab === 'selection') setActiveTab('bookmarks');
+  const tl = TAB_BUTTONS.timeline;
+  tl.disabled = fast;
+  tl.setAttribute(
+    'data-tooltip',
+    fast
+      ? t('batch_tab_timeline_fast', 'Turn Fast off to export your home feed')
+      : t('batch_tab_timeline', 'Timeline')
+  );
+  if (fast && (activeTab === 'selection' || activeTab === 'timeline')) setActiveTab('bookmarks');
 }
 
 function setActiveTab(tab: BatchTab): void {
@@ -339,6 +369,7 @@ function jobWho(job: JobSnapshot): string {
   if (job.origin === 'profile' && job.handle) return `@${job.handle}`;
   if (job.origin === 'bookmarks') return t('group_bookmarks', 'Bookmarks');
   if (job.origin === 'likes') return t('batch_tab_likes', 'Likes');
+  if (job.origin === 'timeline') return t('batch_tab_timeline', 'Timeline');
   if (job.origin === 'selection') return t('batch_tab_selection', 'Selection');
   return '';
 }
@@ -445,7 +476,7 @@ async function startExport(): Promise<void> {
   // Armed Fast Batch routes the paginated sources (bookmarks/profile/likes)
   // through the GraphQL path (own progress poller in fast-batch-ui). Selection
   // isn't Fast-compatible (its tab is disabled while Fast is armed).
-  if (getFastMode() && activeTab !== 'selection') {
+  if (getFastMode() && activeTab !== 'selection' && activeTab !== 'timeline') {
     // Fast reads the profile handle from the URL (no injector needed).
     await startFastExport(activeTab, activeTab === 'profile' ? handleFromUrl(pageUrl) : undefined);
     return;
@@ -579,6 +610,7 @@ function sourceFromUrl(url: string | undefined): BatchTab | null {
     return null;
   }
   if (path === '/i/bookmarks') return 'bookmarks';
+  if (path === '/home') return 'timeline';
   if (/\/likes$/.test(path)) return 'likes';
   const reserved = new Set(['/home', '/explore', '/notifications', '/messages', '/search', '/settings', '/i', '/compose']);
   if (/^\/[A-Za-z0-9_]{1,15}$/.test(path) && !reserved.has(path)) return 'profile';

--- a/src/popup/batch-ui.ts
+++ b/src/popup/batch-ui.ts
@@ -146,6 +146,11 @@ function setButton(label: string, enabled: boolean, tooltip: string): void {
 // user at the right page.
 async function refreshIdleUi(): Promise<void> {
   appendable = false;
+  // Reset buttons are always shown (stacked beside Export); default them to
+  // disabled so early-return branches leave them greyed, and the main/fast
+  // paths re-enable as appropriate below.
+  btnBatchResetQueue.disabled = true;
+  btnBatchReset.disabled = true;
 
   // Fast Batch (armed via the red toggle) overrides per-page gating: it fetches
   // bookmarks through the GraphQL session, so it doesn't need the bookmarks page

--- a/src/popup/batch-ui.ts
+++ b/src/popup/batch-ui.ts
@@ -42,7 +42,7 @@ import {
   tabBatchLikes,
 } from './dom';
 import { setExportMode } from './mode';
-import { getFastMode, isFastActive, startFastExport, cancelFast, setStandardJobActive, resumeFastIfActive } from './fast-batch-ui';
+import { getFastMode, isFastActive, startFastExport, cancelFast, setStandardJobActive, resumeFastIfActive, updateFastSteps } from './fast-batch-ui';
 
 type JobSnapshot = NonNullable<BatchStatusResponse['job']>;
 type BatchTab = 'bookmarks' | 'profile' | 'selection' | 'likes';
@@ -185,6 +185,7 @@ async function refreshIdleUi(): Promise<void> {
       hint = t('btn_batch_fast_hint', 'Fetch all your bookmarks through your X session — much faster. Expands threads & articles; stops politely if X rate-limits.');
     }
     setButton(label, !isFastActive(), hint);
+    void updateFastSteps(activeTab); // refresh the Page/Tweet readiness lights
     return;
   }
 

--- a/src/popup/dom.ts
+++ b/src/popup/dom.ts
@@ -60,6 +60,7 @@ export const chkCloseTab = document.getElementById('chk-close-tab') as HTMLInput
 export const chkInlineCopies = document.getElementById('chk-inline-copies') as HTMLInputElement;
 export const chkShowInline = document.getElementById('chk-show-inline') as HTMLInputElement;
 export const chkInlineStats = document.getElementById('chk-inline-stats') as HTMLInputElement;
+export const chkIncludeReposts = document.getElementById('chk-include-reposts') as HTMLInputElement;
 export const chkObsidianFriendly = document.getElementById('chk-obsidian-friendly') as HTMLInputElement;
 
 // ─── Settings text inputs ────────────────────────────────────────────

--- a/src/popup/dom.ts
+++ b/src/popup/dom.ts
@@ -37,10 +37,12 @@ export const btnBatchIconBookmarks = document.getElementById('btn-batch-icon-boo
 export const btnBatchIconProfile = document.getElementById('btn-batch-icon-profile') as unknown as SVGElement;
 export const btnBatchIconSelection = document.getElementById('btn-batch-icon-selection') as unknown as SVGElement;
 export const btnBatchIconLikes = document.getElementById('btn-batch-icon-likes') as unknown as SVGElement;
+export const btnBatchIconTimeline = document.getElementById('btn-batch-icon-timeline') as unknown as SVGElement;
 export const tabBatchBookmarks = document.getElementById('tab-batch-bookmarks') as HTMLButtonElement;
 export const tabBatchProfile = document.getElementById('tab-batch-profile') as HTMLButtonElement;
 export const tabBatchSelection = document.getElementById('tab-batch-selection') as HTMLButtonElement;
 export const tabBatchLikes = document.getElementById('tab-batch-likes') as HTMLButtonElement;
+export const tabBatchTimeline = document.getElementById('tab-batch-timeline') as HTMLButtonElement;
 
 // ─── Fast Batch (ADR 0003) ───────────────────────────────────────────
 export const viewMain = document.getElementById('view-main') as HTMLElement;

--- a/src/popup/dom.ts
+++ b/src/popup/dom.ts
@@ -51,6 +51,11 @@ export const fastDateRange = document.getElementById('fast-date-range') as HTMLD
 export const fastDateFrom = document.getElementById('fast-date-from') as HTMLInputElement;
 export const fastDateTo = document.getElementById('fast-date-to') as HTMLInputElement;
 export const fastDateClear = document.getElementById('fast-date-clear') as HTMLButtonElement;
+export const fastSteps = document.getElementById('fast-steps') as HTMLDivElement;
+export const fastStepPage = document.getElementById('fast-step-page') as HTMLSpanElement;
+export const fastStepTweet = document.getElementById('fast-step-tweet') as HTMLSpanElement;
+export const fastStepFetch = document.getElementById('fast-step-fetch') as HTMLSpanElement;
+export const fastStepExpand = document.getElementById('fast-step-expand') as HTMLSpanElement;
 export const batchSection = document.getElementById('batch-section') as HTMLDivElement;
 
 // ─── Settings checkboxes ─────────────────────────────────────────────

--- a/src/popup/dom.ts
+++ b/src/popup/dom.ts
@@ -47,6 +47,10 @@ export const viewMain = document.getElementById('view-main') as HTMLElement;
 export const fastBatchBar = document.getElementById('fast-batch-bar') as HTMLDivElement;
 export const chkFastBatch = document.getElementById('chk-fast-batch') as HTMLInputElement;
 export const fastLockedHint = document.getElementById('fast-locked-hint') as HTMLParagraphElement;
+export const fastDateRange = document.getElementById('fast-date-range') as HTMLDivElement;
+export const fastDateFrom = document.getElementById('fast-date-from') as HTMLInputElement;
+export const fastDateTo = document.getElementById('fast-date-to') as HTMLInputElement;
+export const fastDateClear = document.getElementById('fast-date-clear') as HTMLButtonElement;
 export const batchSection = document.getElementById('batch-section') as HTMLDivElement;
 
 // ─── Settings checkboxes ─────────────────────────────────────────────

--- a/src/popup/dom.ts
+++ b/src/popup/dom.ts
@@ -27,6 +27,7 @@ export const btnBatchCancel = document.getElementById('btn-batch-cancel') as HTM
 export const batchDedupRow = document.getElementById('batch-dedup-row') as HTMLDivElement;
 export const batchDedupText = document.getElementById('batch-dedup-text') as HTMLSpanElement;
 export const btnBatchReset = document.getElementById('btn-batch-reset') as HTMLButtonElement;
+export const btnBatchResetQueue = document.getElementById('btn-batch-reset-queue') as HTMLButtonElement;
 export const batchFormatControls = document.getElementById('batch-format-controls') as HTMLDivElement;
 export const batchFormatSelect = document.getElementById('batch-format') as HTMLSelectElement;
 export const outSeparate = document.getElementById('out-separate') as HTMLInputElement;

--- a/src/popup/fast-batch-ui.ts
+++ b/src/popup/fast-batch-ui.ts
@@ -8,7 +8,12 @@
 // Decoupled from batch-ui via DOM events: this module never imports batch-ui
 // (batch-ui imports the small query helpers here), so there's no cycle.
 
-import type { FastBatchProgress, FastBatchStartResponse, FastBatchStatusResponse } from '../types/messages';
+import type {
+  FastBatchProgress,
+  FastBatchReadyResponse,
+  FastBatchStartResponse,
+  FastBatchStatusResponse,
+} from '../types/messages';
 import {
   batchBarFill,
   batchProgress,
@@ -23,8 +28,21 @@ import {
   fastDateFrom,
   fastDateTo,
   fastDateClear,
+  fastSteps,
+  fastStepPage,
+  fastStepTweet,
+  fastStepFetch,
+  fastStepExpand,
   viewMain,
 } from './dom';
+
+type StepState = 'ready' | 'missing' | 'active' | 'done' | 'pending';
+function setStep(el: HTMLElement | undefined, state: StepState, tooltip = ''): void {
+  if (!el) return;
+  el.dataset.state = state;
+  if (tooltip) el.setAttribute('data-tooltip', tooltip);
+  else el.removeAttribute('data-tooltip');
+}
 
 const ACCESS: chrome.permissions.Permissions = { permissions: ['webRequest'], origins: ['*://x.com/*'] };
 const FAST_MODE_KEY = 'fastBatchMode';
@@ -61,8 +79,36 @@ function notifyChanged(): void {
 function applyGlow(): void {
   const red = inBatchMode && (fastActive || (fastMode && !standardJobActive));
   viewMain?.classList.toggle('fast-on', red);
-  // The date-range filter is Fast-only — show it whenever Fast is armed in Batch.
-  fastDateRange?.classList.toggle('hidden', !(fastMode && inBatchMode));
+  // The date-range filter + step lights are Fast-only — show whenever armed.
+  const showExtras = fastMode && inBatchMode;
+  fastDateRange?.classList.toggle('hidden', !showExtras);
+  fastSteps?.classList.toggle('hidden', !showExtras);
+}
+
+// Step lights when idle: Page/Tweet show readiness (what to do before Export);
+// Fetch/Expand are pending. During a run, render() drives them by phase.
+export async function updateFastSteps(source: 'bookmarks' | 'profile' | 'likes'): Promise<void> {
+  if (fastActive) return; // a run owns the steps (see render)
+  let r: FastBatchReadyResponse | undefined;
+  try {
+    r = (await chrome.runtime.sendMessage({ action: 'FAST_BATCH_READY', source })) as
+      | FastBatchReadyResponse
+      | undefined;
+  } catch {
+    return;
+  }
+  setStep(fastStepPage, r?.feed ? 'ready' : 'missing', r?.feed ? '' : 'Reload this page so its feed request is captured');
+  setStep(fastStepTweet, r?.tweetDetail ? 'ready' : 'missing', r?.tweetDetail ? '' : 'Open any one tweet so threads & articles can be expanded');
+  setStep(fastStepFetch, 'pending');
+  setStep(fastStepExpand, 'pending');
+}
+
+function stepsFromProgress(p: FastBatchProgress): void {
+  setStep(fastStepPage, 'done');
+  setStep(fastStepTweet, 'done');
+  const phase = p.phase || '';
+  setStep(fastStepFetch, phase.startsWith('Fetching') ? 'active' : 'done');
+  setStep(fastStepExpand, phase.startsWith('Expanding') ? 'active' : phase.startsWith('Writing') ? 'done' : 'pending');
 }
 
 // Lock the toggle (can't switch modes mid-export) while either session runs.
@@ -257,6 +303,8 @@ function render(p: FastBatchProgress): void {
   // value so it's visibly "working" without implying a fraction.
   const pct = p.total > 0 ? Math.round((p.done / p.total) * 100) : running ? 8 : 100;
   batchBarFill.style.width = `${pct}%`;
+
+  if (running) stepsFromProgress(p);
 
   const who = fastWho(p);
   const prefix = who ? `${who} · ` : '';

--- a/src/popup/fast-batch-ui.ts
+++ b/src/popup/fast-batch-ui.ts
@@ -58,13 +58,18 @@ function applyGlow(): void {
 }
 
 // Lock the toggle (can't switch modes mid-export) while either session runs.
+// The "why" hint is NOT shown just because something's running — only when the
+// user actually tries to flip the locked toggle (see the click handler).
 function updateToggleLock(): void {
   const locked = standardJobActive || fastActive;
   if (chkFastBatch) chkFastBatch.disabled = locked;
   fastBatchBar?.classList.toggle('locked', locked);
-  // Visible reason so a disabled toggle doesn't look broken. Only while in
-  // Batch mode (the bar is hidden in Single).
-  fastLockedHint?.classList.toggle('hidden', !(locked && inBatchMode));
+  if (!locked) fastLockedHint?.classList.add('hidden'); // clear once unlocked
+}
+
+// Reveal the locked reason only on an actual attempt to toggle while locked.
+function showLockHint(): void {
+  if (inBatchMode) fastLockedHint?.classList.remove('hidden');
 }
 
 // Called by batch-ui as the Standard job starts/stops.
@@ -79,6 +84,7 @@ export function setStandardJobActive(active: boolean): void {
 export function syncFastBatchMode(single: boolean): void {
   inBatchMode = !single;
   fastBatchBar?.classList.toggle('hidden', single);
+  if (single) fastLockedHint?.classList.add('hidden');
   updateToggleLock();
   applyGlow();
 }
@@ -102,6 +108,12 @@ export function initFastBatchUi(): void {
       if (granted) setFastMode(true);
       else setFastMode(false);
     });
+  });
+
+  // Clicking the toggle while it's locked doesn't fire `change` (disabled
+  // input), but the label still gets the click — surface the reason then.
+  chkFastBatch.closest('.fast-toggle')?.addEventListener('click', () => {
+    if (chkFastBatch.disabled) showLockHint();
   });
 
   chkFastBatch.addEventListener('change', () => {

--- a/src/popup/fast-batch-ui.ts
+++ b/src/popup/fast-batch-ui.ts
@@ -50,6 +50,7 @@ const FAST_FROM_KEY = 'fastDateFrom';
 const FAST_TO_KEY = 'fastDateTo';
 const FAST_POLL_MS = 800;
 const batchControls = document.querySelector('.batch-controls');
+const batchProgressRow = document.querySelector('.batch-progress-row');
 
 let fastMode = false;
 let fastActive = false;
@@ -295,6 +296,9 @@ function fastWho(p: FastBatchProgress): string {
 function render(p: FastBatchProgress): void {
   batchProgress.classList.remove('hidden');
   const running = p.status === 'running';
+  // On an error (e.g. preconditions not met) show only the message — no bar,
+  // which would otherwise look like a finished run.
+  batchProgressRow?.classList.toggle('hidden', p.status === 'error');
   batchControls?.classList.toggle('hidden', !running);
   btnBatchCancel.classList.toggle('hidden', !running);
   btnBatchPause.classList.add('hidden'); // Fast Batch has no pause

--- a/src/popup/fast-batch-ui.ts
+++ b/src/popup/fast-batch-ui.ts
@@ -19,11 +19,17 @@ import {
   chkFastBatch,
   fastBatchBar,
   fastLockedHint,
+  fastDateRange,
+  fastDateFrom,
+  fastDateTo,
+  fastDateClear,
   viewMain,
 } from './dom';
 
 const ACCESS: chrome.permissions.Permissions = { permissions: ['webRequest'], origins: ['*://x.com/*'] };
 const FAST_MODE_KEY = 'fastBatchMode';
+const FAST_FROM_KEY = 'fastDateFrom';
+const FAST_TO_KEY = 'fastDateTo';
 const FAST_POLL_MS = 800;
 const batchControls = document.querySelector('.batch-controls');
 
@@ -55,6 +61,8 @@ function notifyChanged(): void {
 function applyGlow(): void {
   const red = inBatchMode && (fastActive || (fastMode && !standardJobActive));
   viewMain?.classList.toggle('fast-on', red);
+  // The date-range filter is Fast-only — show it whenever Fast is armed in Batch.
+  fastDateRange?.classList.toggle('hidden', !(fastMode && inBatchMode));
 }
 
 // Lock the toggle (can't switch modes mid-export) while either session runs.
@@ -134,6 +142,23 @@ export function initFastBatchUi(): void {
       });
     });
   });
+
+  // Date-range filter: restore, persist on change, and clear.
+  chrome.storage.local.get([FAST_FROM_KEY, FAST_TO_KEY], (res) => {
+    if (fastDateFrom && typeof res[FAST_FROM_KEY] === 'string') fastDateFrom.value = res[FAST_FROM_KEY];
+    if (fastDateTo && typeof res[FAST_TO_KEY] === 'string') fastDateTo.value = res[FAST_TO_KEY];
+  });
+  fastDateFrom?.addEventListener('change', () =>
+    chrome.storage.local.set({ [FAST_FROM_KEY]: fastDateFrom.value })
+  );
+  fastDateTo?.addEventListener('change', () =>
+    chrome.storage.local.set({ [FAST_TO_KEY]: fastDateTo.value })
+  );
+  fastDateClear?.addEventListener('click', () => {
+    if (fastDateFrom) fastDateFrom.value = '';
+    if (fastDateTo) fastDateTo.value = '';
+    chrome.storage.local.set({ [FAST_FROM_KEY]: '', [FAST_TO_KEY]: '' });
+  });
 }
 
 // ─── Fast export run + progress polling ──────────────────────────────
@@ -143,11 +168,17 @@ export async function startFastExport(
   handle?: string
 ): Promise<void> {
   btnBatch.disabled = true;
+  // Optional date range; swap if the user entered them backwards.
+  let fromDate = fastDateFrom?.value || undefined;
+  let toDate = fastDateTo?.value || undefined;
+  if (fromDate && toDate && fromDate > toDate) [fromDate, toDate] = [toDate, fromDate];
   // Expand threads + articles by default (correctness over raw speed).
   const resp = (await chrome.runtime.sendMessage({
     action: 'FAST_BATCH_START',
     source,
     ...(handle ? { handle } : {}),
+    ...(fromDate ? { fromDate } : {}),
+    ...(toDate ? { toDate } : {}),
     expandThreads: true,
   })) as FastBatchStartResponse | undefined;
   if (!resp?.success) {

--- a/src/popup/fast-batch-ui.ts
+++ b/src/popup/fast-batch-ui.ts
@@ -207,6 +207,14 @@ async function poll(): Promise<void> {
   }
 }
 
+// Whose/which Fast export — shown so progress stays meaningful after navigating.
+function fastWho(p: FastBatchProgress): string {
+  if (p.source === 'profile' && p.handle) return `@${p.handle}`;
+  if (p.source === 'bookmarks') return 'Bookmarks';
+  if (p.source === 'likes') return 'Likes';
+  return '';
+}
+
 function render(p: FastBatchProgress): void {
   batchProgress.classList.remove('hidden');
   const running = p.status === 'running';
@@ -219,15 +227,38 @@ function render(p: FastBatchProgress): void {
   const pct = p.total > 0 ? Math.round((p.done / p.total) * 100) : running ? 8 : 100;
   batchBarFill.style.width = `${pct}%`;
 
+  const who = fastWho(p);
+  const prefix = who ? `${who} · ` : '';
   if (running) {
     batchProgressText.textContent =
-      p.total > 0 ? `${p.phase} ${p.done}/${p.total}` : `${p.phase} ${p.done}`;
+      p.total > 0 ? `${prefix}${p.phase} ${p.done}/${p.total}` : `${prefix}${p.phase} ${p.done}`;
   } else if (p.status === 'done' || p.status === 'cancelled') {
     const label = p.status === 'cancelled' ? 'Cancelled' : 'Done';
     const skipped = p.skipped ? ` · ${p.skipped} skipped` : '';
     const limited = p.rateLimited ? ' · rate-limited — re-run for the rest' : '';
-    batchProgressText.textContent = `${label} — ${p.exported} exported${skipped}${limited}`;
+    batchProgressText.textContent = `${prefix}${label} — ${p.exported} exported${skipped}${limited}`;
   } else if (p.status === 'error') {
     batchProgressText.textContent = p.error || 'Fast Batch failed';
   }
+}
+
+// On popup (re)open, resume showing a Fast run that's still going in the
+// background — the popup is a fresh page, so its state was lost. Returns true if
+// a run is in progress (caller forces Batch mode so the bar is visible).
+export async function resumeFastIfActive(): Promise<boolean> {
+  let p: FastBatchProgress | undefined;
+  try {
+    const resp = (await chrome.runtime.sendMessage({
+      action: 'FAST_BATCH_STATUS',
+    })) as FastBatchStatusResponse | undefined;
+    p = resp?.progress;
+  } catch {
+    return false;
+  }
+  if (p?.status !== 'running') return false;
+  fastActive = true;
+  updateToggleLock();
+  applyGlow();
+  startPolling();
+  return true;
 }

--- a/src/popup/fast-batch-ui.ts
+++ b/src/popup/fast-batch-ui.ts
@@ -126,11 +126,16 @@ export function initFastBatchUi(): void {
 
 // ─── Fast export run + progress polling ──────────────────────────────
 
-export async function startFastExport(): Promise<void> {
+export async function startFastExport(
+  source: 'bookmarks' | 'profile' | 'likes',
+  handle?: string
+): Promise<void> {
   btnBatch.disabled = true;
   // Expand threads + articles by default (correctness over raw speed).
   const resp = (await chrome.runtime.sendMessage({
     action: 'FAST_BATCH_START',
+    source,
+    ...(handle ? { handle } : {}),
     expandThreads: true,
   })) as FastBatchStartResponse | undefined;
   if (!resp?.success) {

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -1078,13 +1078,15 @@ body {
   color: var(--error);
 }
 
+/* Solid red track + white knob — the red-tinted bar background made a
+ * translucent red switch nearly invisible when on. */
 .fast-toggle .toggle-input:checked + .toggle-switch {
-  background: var(--error-tint);
+  background: var(--error);
   box-shadow: 0 0 8px var(--error-glow);
 }
 
 .fast-toggle .toggle-input:checked + .toggle-switch::after {
-  background: var(--error);
+  background: #fff;
 }
 
 /* When Fast Batch is armed, recolor ONLY the source box (tabs + Export button

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -1090,12 +1090,12 @@ body {
   background: #fff;
 }
 
-/* When Fast Batch is armed, recolor ONLY the source box (tabs + Export button
- * + progress) from blue to red — a clear, contained signal that the GraphQL
- * path is active. Done by overriding the box's accent tokens. */
-#view-main.fast-on #batch-section {
-  --batch: var(--error);
-  --batch-glow: var(--error-glow);
+/* When Fast Batch is armed, the only red signals are the Fast bar, the step
+ * lights, and the ACTIVE source tab — everything else (Export button, progress,
+ * reset buttons) stays the normal blue to avoid a wall of red. */
+#view-main.fast-on .batch-tab.active {
+  background: var(--error);
+  box-shadow: 0 2px 8px var(--error-glow);
 }
 
 /* ─── Options Toggles ───────────────────────────────────────── */
@@ -1865,6 +1865,11 @@ details.option-group[open] .option-group-chevron {
   width: auto;
   flex: 1;
   min-width: 0;
+}
+
+/* The Export button is text-only (no leading source icon). */
+.btn-batch .btn-icon {
+  display: none;
 }
 
 .batch-reset-stack {

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -1955,6 +1955,11 @@ details.option-group[open] .option-group-chevron {
 
 .batch-tab:disabled {
   cursor: default;
+  /* Dim via color, not opacity, so the tab's [data-tooltip] stays readable. */
+  color: color-mix(in srgb, var(--text-secondary) 45%, transparent);
+}
+.batch-tab:disabled .batch-tab-icon {
+  opacity: 0.45;
 }
 
 /* Icon tabs lean on tooltips for their names; the first/last sit at the

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -1892,6 +1892,10 @@ details.option-group[open] .option-group-chevron {
   gap: 8px;
 }
 
+.batch-progress-row.hidden {
+  display: none;
+}
+
 .batch-progress-text {
   display: block;
   margin-top: 6px;

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -974,6 +974,39 @@ body {
   display: none;
 }
 
+/* Fast Batch date-range filter (shown only while Fast is armed). */
+.fast-date-range {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  color: var(--text-secondary);
+}
+
+.fast-date-range.hidden {
+  display: none;
+}
+
+.fast-date-label {
+  margin-right: 2px;
+}
+
+.fast-date-input {
+  font-family: var(--font);
+  font-size: 12px;
+  padding: 3px 6px;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  flex: 1;
+  min-width: 0;
+}
+
+.fast-date-sep {
+  opacity: 0.6;
+}
+
 /* Lightning icon + label stay red in both states. The extra .fast-batch-bar
  * ancestor beats the generic ".toggle-label:has(:checked) .toggle-icon" rule
  * that would otherwise paint it blue (--accent) when checked. */

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -1871,6 +1871,12 @@ details.option-group[open] .option-group-chevron {
   display: none;
 }
 
+.batch-ctl-group {
+  display: inline-flex;
+  gap: 6px;
+  flex-shrink: 0;
+}
+
 /* Dim only the disabled button's children — NOT the button itself. A
  * parent-level opacity cascades into the [data-tooltip]::after
  * pseudo-element and renders the hint semi-transparent (same rule as the

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -906,8 +906,8 @@ body {
   align-items: center;
   gap: 10px;
   padding: 6px 12px;
-  background: var(--error-bg);
-  border: 1px solid var(--error-tint);
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-subtle);
   border-radius: var(--radius-sm);
 }
 
@@ -921,7 +921,7 @@ body {
 .fast-info {
   display: flex;
   align-items: center;
-  color: var(--error);
+  color: var(--text-secondary);
   cursor: help;
   flex-shrink: 0;
 }
@@ -1075,19 +1075,29 @@ body {
   opacity: 0.85;
 }
 
-.fast-toggle:has(.toggle-input:checked) .toggle-text {
+/* The Fast Batch label is the bar's red signal in both states. The extra
+ * .fast-batch-bar ancestor (and the :has variant) beats the generic
+ * ".toggle-label:has(:checked) .toggle-text" rule that would otherwise paint
+ * it --text-primary when checked. The BETA badge inherits currentColor, so
+ * pin it back to neutral. */
+.fast-batch-bar .fast-toggle .toggle-text,
+.fast-batch-bar .fast-toggle:has(.toggle-input:checked) .toggle-text {
   color: var(--error);
 }
 
-/* Solid red track + white knob — the red-tinted bar background made a
- * translucent red switch nearly invisible when on. */
+.fast-batch-bar .fast-toggle .beta-badge {
+  color: var(--text-secondary);
+}
+
+/* Plain red switch — translucent red track + solid red knob, matching the
+ * other toggles' style. */
 .fast-toggle .toggle-input:checked + .toggle-switch {
-  background: var(--error);
+  background: var(--error-glow);
   box-shadow: 0 0 8px var(--error-glow);
 }
 
 .fast-toggle .toggle-input:checked + .toggle-switch::after {
-  background: #fff;
+  background: var(--error);
 }
 
 /* When Fast Batch is armed, the only red signals are the Fast bar, the step

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -1878,9 +1878,13 @@ details.option-group[open] .option-group-chevron {
 }
 
 /* Reset buttons stay put and just grey out when not applicable, so the row
- * doesn't change size/layout as a collection grows or a run finishes. */
+ * doesn't change size/layout as a collection grows or a run finishes.
+ * Grey via color/border, NOT opacity — opacity on the button cascades into its
+ * [data-tooltip]::after and renders the hint half-transparent (issue #38). The
+ * tooltip sets its own color, so a color/border change leaves it fully legible. */
 .batch-ctl:disabled {
-  opacity: 0.4;
+  color: color-mix(in srgb, var(--batch) 42%, transparent);
+  border-color: color-mix(in srgb, var(--batch) 28%, transparent);
   cursor: default;
 }
 .batch-ctl:disabled:hover {

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -1007,6 +1007,64 @@ body {
   opacity: 0.6;
 }
 
+/* Fast Batch step lights: Page → Tweet → Fetch → Expand. */
+.fast-steps {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  font-size: 11px;
+  color: var(--text-secondary);
+}
+
+.fast-steps.hidden {
+  display: none;
+}
+
+.fast-step {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+}
+
+.fast-step-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--toggle-off-bg);
+  flex-shrink: 0;
+}
+
+/* States set on the .fast-step container. */
+.fast-step[data-state="ready"] .fast-step-dot,
+.fast-step[data-state="done"] .fast-step-dot {
+  background: var(--success);
+}
+.fast-step[data-state="missing"] .fast-step-dot {
+  background: var(--error);
+}
+.fast-step[data-state="active"] .fast-step-dot {
+  background: var(--accent);
+  animation: fast-step-pulse 1s ease-in-out infinite;
+}
+.fast-step[data-state="missing"] .fast-step-label {
+  color: var(--error);
+}
+
+@keyframes fast-step-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.35; }
+}
+
+/* Anchor step tooltips to the start edge so the leftmost one doesn't clip. */
+.fast-step[data-tooltip]::after {
+  left: 0;
+  transform: translateX(0) translateY(2px);
+}
+.fast-step[data-tooltip]:hover::after,
+.fast-step[data-tooltip]:focus-visible::after {
+  transform: translateX(0) translateY(0);
+}
+
 /* Lightning icon + label stay red in both states. The extra .fast-batch-bar
  * ancestor beats the generic ".toggle-label:has(:checked) .toggle-icon" rule
  * that would otherwise paint it blue (--accent) when checked. */

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -1854,15 +1854,14 @@ details.option-group[open] .option-group-chevron {
   border: 1px solid var(--batch);
 }
 
-/* Export button + a stacked pair of Reset buttons beside it. */
-.batch-action-row {
+/* Fast Batch bar + a stacked pair of Reset buttons beside it. */
+.batch-fast-row {
   display: flex;
   align-items: stretch;
   gap: 8px;
 }
 
-.batch-action-row .btn-batch {
-  width: auto;
+.batch-fast-row .fast-batch-bar {
   flex: 1;
   min-width: 0;
 }

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -905,7 +905,7 @@ body {
   flex-direction: row;
   align-items: center;
   gap: 10px;
-  padding: 8px 12px;
+  padding: 6px 12px;
   background: var(--error-bg);
   border: 1px solid var(--error-tint);
   border-radius: var(--radius-sm);
@@ -1011,7 +1011,8 @@ body {
 .fast-steps {
   display: flex;
   align-items: center;
-  gap: 14px;
+  justify-content: space-between;
+  gap: 6px;
   font-size: 11px;
   color: var(--text-secondary);
 }
@@ -1132,7 +1133,7 @@ details.option-group:not([open]) {
   gap: 8px;
   cursor: pointer;
   list-style: none;
-  padding: 2px 0;
+  padding: 0;
   user-select: none;
 }
 
@@ -1852,6 +1853,31 @@ details.option-group[open] .option-group-chevron {
   color: var(--batch);
   border: 1px solid var(--batch);
 }
+
+/* Export button + a stacked pair of Reset buttons beside it. */
+.batch-action-row {
+  display: flex;
+  align-items: stretch;
+  gap: 8px;
+}
+
+.batch-action-row .btn-batch {
+  width: auto;
+  flex: 1;
+  min-width: 0;
+}
+
+.batch-reset-stack {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 4px;
+  flex-shrink: 0;
+}
+
+.batch-reset-stack .batch-ctl {
+  white-space: nowrap;
+}
 .btn-batch .btn-icon {
   color: var(--batch);
 }
@@ -2024,7 +2050,7 @@ details.option-group[open] .option-group-chevron {
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 8px 0;
+  padding: 7px 0;
   border: none;
   border-radius: var(--radius-sm);
   background: transparent;

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -1877,6 +1877,16 @@ details.option-group[open] .option-group-chevron {
   flex-shrink: 0;
 }
 
+/* Reset buttons stay put and just grey out when not applicable, so the row
+ * doesn't change size/layout as a collection grows or a run finishes. */
+.batch-ctl:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+.batch-ctl:disabled:hover {
+  background: transparent;
+}
+
 /* Dim only the disabled button's children — NOT the button itself. A
  * parent-level opacity cascades into the [data-tooltip]::after
  * pseudo-element and renders the hint semi-transparent (same rule as the

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -312,9 +312,14 @@
         </button>
         <div id="batch-dedup-row" class="batch-dedup-row hidden">
           <span id="batch-dedup-text"></span>
-          <button id="btn-batch-reset" class="batch-ctl" type="button"
-            data-tooltip="Forget which bookmarks were already exported, so the next batch exports everything loaded."
-            data-i18n-tooltip="batch_reset_hint" data-i18n="batch_reset">Reset dedup</button>
+          <span class="batch-ctl-group">
+            <button id="btn-batch-reset-queue" class="batch-ctl hidden" type="button"
+              data-tooltip="Empty the gathered posts and restart collecting from where you've scrolled to — so you can begin at a specific post instead of the top."
+              data-i18n-tooltip="batch_reset_queue_hint" data-i18n="batch_reset_queue">Reset queue</button>
+            <button id="btn-batch-reset" class="batch-ctl hidden" type="button"
+              data-tooltip="Forget which posts were already exported in past runs, so the next batch exports everything loaded again."
+              data-i18n-tooltip="batch_reset_hint" data-i18n="batch_reset">Reset history</button>
+          </span>
         </div>
         <div id="batch-progress" class="batch-progress hidden">
           <div class="batch-progress-row">

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -313,10 +313,10 @@
         <div id="batch-dedup-row" class="batch-dedup-row hidden">
           <span id="batch-dedup-text"></span>
           <span class="batch-ctl-group">
-            <button id="btn-batch-reset-queue" class="batch-ctl hidden" type="button"
+            <button id="btn-batch-reset-queue" class="batch-ctl" type="button"
               data-tooltip="Empty the gathered posts and restart collecting from where you've scrolled to — so you can begin at a specific post instead of the top."
               data-i18n-tooltip="batch_reset_queue_hint" data-i18n="batch_reset_queue">Reset queue</button>
-            <button id="btn-batch-reset" class="batch-ctl hidden" type="button"
+            <button id="btn-batch-reset" class="batch-ctl" type="button"
               data-tooltip="Forget which posts were already exported in past runs, so the next batch exports everything loaded again."
               data-i18n-tooltip="batch_reset_hint" data-i18n="batch_reset">Reset history</button>
           </span>

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -89,6 +89,13 @@
         <button id="fast-date-clear" class="batch-ctl" type="button" data-i18n="fast_date_clear">Clear</button>
       </div>
 
+      <div id="fast-steps" class="fast-steps hidden" role="status">
+        <span class="fast-step" id="fast-step-page"><span class="fast-step-dot"></span><span class="fast-step-label" data-i18n="fast_step_page">Page</span></span>
+        <span class="fast-step" id="fast-step-tweet"><span class="fast-step-dot"></span><span class="fast-step-label" data-i18n="fast_step_tweet">Tweet</span></span>
+        <span class="fast-step" id="fast-step-fetch"><span class="fast-step-dot"></span><span class="fast-step-label" data-i18n="fast_step_fetch">Fetch</span></span>
+        <span class="fast-step" id="fast-step-expand"><span class="fast-step-dot"></span><span class="fast-step-label" data-i18n="fast_step_expand">Expand</span></span>
+      </div>
+
       <div class="options">
         <details id="export-settings" class="option-group" open>
           <summary class="option-group-summary">

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -133,6 +133,20 @@
             <input type="checkbox" id="chk-include-metadata" class="toggle-input" />
             <span class="toggle-switch"></span>
           </label>
+          <label class="toggle-label" data-tooltip="When batch-exporting a profile, include reposts too. Off = the profile owner's own posts only." data-i18n-tooltip="opt_include_reposts_title">
+            <span class="toggle-text">
+              <svg class="toggle-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+                stroke-linecap="round" stroke-linejoin="round">
+                <polyline points="17 1 21 5 17 9" />
+                <path d="M3 11V9a4 4 0 0 1 4-4h14" />
+                <polyline points="7 23 3 19 7 15" />
+                <path d="M21 13v2a4 4 0 0 1-4 4H3" />
+              </svg>
+              <span data-i18n="opt_include_reposts">Include reposts (profiles)</span>
+            </span>
+            <input type="checkbox" id="chk-include-reposts" class="toggle-input" />
+            <span class="toggle-switch"></span>
+          </label>
         </details>
         <div id="batch-format-controls" class="batch-format-controls hidden">
           <label class="batch-field">

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -125,6 +125,20 @@
             <span class="toggle-switch"></span>
           </label>
           <div id="batch-format-controls" class="batch-format-controls hidden">
+          <label class="toggle-label" data-tooltip="When batch-exporting a profile, include reposts too. Off = the profile owner's own posts only." data-i18n-tooltip="opt_include_reposts_title">
+            <span class="toggle-text">
+              <svg class="toggle-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+                stroke-linecap="round" stroke-linejoin="round">
+                <polyline points="17 1 21 5 17 9" />
+                <path d="M3 11V9a4 4 0 0 1 4-4h14" />
+                <polyline points="7 23 3 19 7 15" />
+                <path d="M21 13v2a4 4 0 0 1-4 4H3" />
+              </svg>
+              <span data-i18n="opt_include_reposts">Include reposts (profiles)</span>
+            </span>
+            <input type="checkbox" id="chk-include-reposts" class="toggle-input" />
+            <span class="toggle-switch"></span>
+          </label>
           <label class="batch-field">
             <span class="batch-field-label" data-i18n="batch_format">Format</span>
             <select id="batch-format" class="batch-select">
@@ -148,20 +162,6 @@
               <label for="out-combined" class="seg-label" data-i18n="batch_out_combined">Combined</label>
             </div>
           </div>
-          <label class="toggle-label" data-tooltip="When batch-exporting a profile, include reposts too. Off = the profile owner's own posts only." data-i18n-tooltip="opt_include_reposts_title">
-            <span class="toggle-text">
-              <svg class="toggle-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
-                stroke-linecap="round" stroke-linejoin="round">
-                <polyline points="17 1 21 5 17 9" />
-                <path d="M3 11V9a4 4 0 0 1 4-4h14" />
-                <polyline points="7 23 3 19 7 15" />
-                <path d="M21 13v2a4 4 0 0 1-4 4H3" />
-              </svg>
-              <span data-i18n="opt_include_reposts">Include reposts (profiles)</span>
-            </span>
-            <input type="checkbox" id="chk-include-reposts" class="toggle-input" />
-            <span class="toggle-switch"></span>
-          </label>
         </div>
         </details>
       </div>

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -80,6 +80,15 @@
         An export is running — cancel or let it finish to switch modes.
       </p>
 
+      <div id="fast-date-range" class="fast-date-range hidden">
+        <span class="fast-date-label" data-i18n="fast_date_range" data-tooltip="Only export posts whose date is in this range — out-of-range posts are skipped without being expanded, so you reach older posts without hitting X's rate limit."
+          data-i18n-tooltip="fast_date_range_hint">Date range</span>
+        <input type="date" id="fast-date-from" class="fast-date-input" aria-label="From date" data-i18n-aria-label="fast_date_from" />
+        <span class="fast-date-sep">→</span>
+        <input type="date" id="fast-date-to" class="fast-date-input" aria-label="To date" data-i18n-aria-label="fast_date_to" />
+        <button id="fast-date-clear" class="batch-ctl" type="button" data-i18n="fast_date_clear">Clear</button>
+      </div>
+
       <div class="options">
         <details id="export-settings" class="option-group" open>
           <summary class="option-group-summary">

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -309,6 +309,7 @@
           <input type="date" id="fast-date-to" class="fast-date-input" aria-label="To date" data-i18n-aria-label="fast_date_to" />
           <button id="fast-date-clear" class="batch-ctl" type="button" data-i18n="fast_date_clear">Clear</button>
         </div>
+        <div class="batch-action-row">
         <button id="btn-batch" class="btn-batch btn-action" type="button"
           data-tooltip="Export every bookmark loaded on this page as Markdown files into one folder. Scroll the bookmarks page to load more."
           data-i18n-tooltip="btn_batch_hint">
@@ -332,22 +333,23 @@
           </svg>
           <span class="btn-label" id="btn-batch-label" data-i18n="btn_batch">Export bookmarks</span>
         </button>
-        <div id="fast-steps" class="fast-steps hidden" role="status">
-          <span class="fast-step" id="fast-step-page"><span class="fast-step-dot"></span><span class="fast-step-label" data-i18n="fast_step_page">Page</span></span>
-          <span class="fast-step" id="fast-step-tweet"><span class="fast-step-dot"></span><span class="fast-step-label" data-i18n="fast_step_tweet">Tweet</span></span>
-          <span class="fast-step" id="fast-step-fetch"><span class="fast-step-dot"></span><span class="fast-step-label" data-i18n="fast_step_fetch">Fetch</span></span>
-          <span class="fast-step" id="fast-step-expand"><span class="fast-step-dot"></span><span class="fast-step-label" data-i18n="fast_step_expand">Expand</span></span>
-        </div>
-        <div id="batch-dedup-row" class="batch-dedup-row hidden">
-          <span id="batch-dedup-text"></span>
-          <span class="batch-ctl-group">
+          <div class="batch-reset-stack">
             <button id="btn-batch-reset-queue" class="batch-ctl" type="button"
               data-tooltip="Empty the gathered posts and restart collecting from where you've scrolled to — so you can begin at a specific post instead of the top."
               data-i18n-tooltip="batch_reset_queue_hint" data-i18n="batch_reset_queue">Reset queue</button>
             <button id="btn-batch-reset" class="batch-ctl" type="button"
               data-tooltip="Forget which posts were already exported in past runs, so the next batch exports everything loaded again."
               data-i18n-tooltip="batch_reset_hint" data-i18n="batch_reset">Reset history</button>
-          </span>
+          </div>
+        </div>
+        <div id="fast-steps" class="fast-steps hidden" role="status">
+          <span class="fast-step" id="fast-step-page"><span class="fast-step-dot"></span><span class="fast-step-label" data-i18n="fast_step_page">Reload x.com</span></span>
+          <span class="fast-step" id="fast-step-tweet"><span class="fast-step-dot"></span><span class="fast-step-label" data-i18n="fast_step_tweet">Open one tweet</span></span>
+          <span class="fast-step" id="fast-step-fetch"><span class="fast-step-dot"></span><span class="fast-step-label" data-i18n="fast_step_fetch">Fetching ...</span></span>
+          <span class="fast-step" id="fast-step-expand"><span class="fast-step-dot"></span><span class="fast-step-label" data-i18n="fast_step_expand">Expanding ...</span></span>
+        </div>
+        <div id="batch-dedup-row" class="batch-dedup-row hidden">
+          <span id="batch-dedup-text"></span>
         </div>
         <div id="batch-progress" class="batch-progress hidden">
           <div class="batch-progress-row">

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -52,33 +52,6 @@
           aria-selected="false"><span data-i18n="group_batch">Batch export</span></button>
       </div>
 
-      <div id="fast-batch-bar" class="fast-batch-bar hidden">
-        <span class="fast-info" tabindex="0" role="img" aria-label="About Fast Batch"
-          data-tooltip="Exports your Bookmarks, a profile's posts, or your Likes far faster by fetching them directly through your logged-in X session (its private API) — no API key, no password, nothing leaves your browser. The step lights below show what to do first (reload the page / open one tweet). Big runs can hit X's rate limit — it stops politely so you can re-run, or use the date range to narrow the scope."
-          data-i18n-tooltip="fast_batch_info">
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
-            stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-            <circle cx="12" cy="12" r="10" />
-            <line x1="12" y1="16" x2="12" y2="12" />
-            <line x1="12" y1="8" x2="12.01" y2="8" />
-          </svg>
-        </span>
-        <label class="toggle-label fast-toggle">
-          <span class="toggle-text">
-            <svg class="toggle-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
-              stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-              <polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2" />
-            </svg>
-            <span data-i18n="fast_batch">Fast Batch</span>
-            <span class="beta-badge" data-i18n="beta">Beta</span>
-          </span>
-          <input type="checkbox" id="chk-fast-batch" class="toggle-input" />
-          <span class="toggle-switch"></span>
-        </label>
-      </div>
-      <p id="fast-locked-hint" class="fast-locked-hint hidden" data-i18n="fast_locked">
-        An export is running — cancel or let it finish to switch modes.
-      </p>
 
       <div class="options">
         <details id="export-settings" class="option-group" open>
@@ -301,6 +274,43 @@
             </svg>
           </button>
         </div>
+        <div class="batch-fast-row">
+          <div id="fast-batch-bar" class="fast-batch-bar hidden">
+            <span class="fast-info" tabindex="0" role="img" aria-label="About Fast Batch"
+              data-tooltip="Exports your Bookmarks, a profile's posts, or your Likes far faster by fetching them directly through your logged-in X session (its private API) — no API key, no password, nothing leaves your browser. The step lights below show what to do first (reload the page / open one tweet). Big runs can hit X's rate limit — it stops politely so you can re-run, or use the date range to narrow the scope."
+              data-i18n-tooltip="fast_batch_info">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+                stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                <circle cx="12" cy="12" r="10" />
+                <line x1="12" y1="16" x2="12" y2="12" />
+                <line x1="12" y1="8" x2="12.01" y2="8" />
+              </svg>
+            </span>
+            <label class="toggle-label fast-toggle">
+              <span class="toggle-text">
+                <svg class="toggle-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+                  stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                  <polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2" />
+                </svg>
+                <span data-i18n="fast_batch">Fast Batch</span>
+                <span class="beta-badge" data-i18n="beta">Beta</span>
+              </span>
+              <input type="checkbox" id="chk-fast-batch" class="toggle-input" />
+              <span class="toggle-switch"></span>
+            </label>
+          </div>
+          <div class="batch-reset-stack">
+            <button id="btn-batch-reset-queue" class="batch-ctl" type="button"
+              data-tooltip="Empty the gathered posts and restart collecting from where you've scrolled to — so you can begin at a specific post instead of the top."
+              data-i18n-tooltip="batch_reset_queue_hint" data-i18n="batch_reset_queue">Reset queue</button>
+            <button id="btn-batch-reset" class="batch-ctl" type="button"
+              data-tooltip="Forget which posts were already exported in past runs, so the next batch exports everything loaded again."
+              data-i18n-tooltip="batch_reset_hint" data-i18n="batch_reset">Reset history</button>
+          </div>
+        </div>
+        <p id="fast-locked-hint" class="fast-locked-hint hidden" data-i18n="fast_locked">
+          An export is running — cancel or let it finish to switch modes.
+        </p>
         <div id="fast-date-range" class="fast-date-range hidden">
           <span class="fast-date-label" data-i18n="fast_date_range" data-tooltip="Only export posts whose date is in this range — out-of-range posts are skipped without being expanded, so you reach older posts without hitting X's rate limit."
             data-i18n-tooltip="fast_date_range_hint">Date range</span>
@@ -309,7 +319,6 @@
           <input type="date" id="fast-date-to" class="fast-date-input" aria-label="To date" data-i18n-aria-label="fast_date_to" />
           <button id="fast-date-clear" class="batch-ctl" type="button" data-i18n="fast_date_clear">Clear</button>
         </div>
-        <div class="batch-action-row">
         <button id="btn-batch" class="btn-batch btn-action" type="button"
           data-tooltip="Export every bookmark loaded on this page as Markdown files into one folder. Scroll the bookmarks page to load more."
           data-i18n-tooltip="btn_batch_hint">
@@ -333,15 +342,6 @@
           </svg>
           <span class="btn-label" id="btn-batch-label" data-i18n="btn_batch">Export bookmarks</span>
         </button>
-          <div class="batch-reset-stack">
-            <button id="btn-batch-reset-queue" class="batch-ctl" type="button"
-              data-tooltip="Empty the gathered posts and restart collecting from where you've scrolled to — so you can begin at a specific post instead of the top."
-              data-i18n-tooltip="batch_reset_queue_hint" data-i18n="batch_reset_queue">Reset queue</button>
-            <button id="btn-batch-reset" class="batch-ctl" type="button"
-              data-tooltip="Forget which posts were already exported in past runs, so the next batch exports everything loaded again."
-              data-i18n-tooltip="batch_reset_hint" data-i18n="batch_reset">Reset history</button>
-          </div>
-        </div>
         <div id="fast-steps" class="fast-steps hidden" role="status">
           <span class="fast-step" id="fast-step-page"><span class="fast-step-dot"></span><span class="fast-step-label" data-i18n="fast_step_page">Reload x.com</span></span>
           <span class="fast-step" id="fast-step-tweet"><span class="fast-step-dot"></span><span class="fast-step-label" data-i18n="fast_step_tweet">Open one tweet</span></span>

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -112,16 +112,6 @@
             <input type="checkbox" id="chk-include-reposts" class="toggle-input" />
             <span class="toggle-switch"></span>
           </label>
-          <label class="batch-field">
-            <span class="batch-field-label" data-i18n="batch_format">Format</span>
-            <select id="batch-format" class="batch-select">
-              <option value="md">Markdown (.md)</option>
-              <option value="txt">Text (.txt)</option>
-              <option value="html">HTML (.html)</option>
-              <option value="json">JSON (.json)</option>
-              <option value="csv">CSV (.csv)</option>
-            </select>
-          </label>
           <div class="batch-field">
             <span class="batch-field-label" data-i18n="batch_output">Output</span>
             <div class="segmented" role="radiogroup" aria-label="Output"
@@ -135,6 +125,16 @@
               <label for="out-combined" class="seg-label" data-i18n="batch_out_combined">Combined</label>
             </div>
           </div>
+          <label class="batch-field">
+            <span class="batch-field-label" data-i18n="batch_format">Format</span>
+            <select id="batch-format" class="batch-select">
+              <option value="md">Markdown (.md)</option>
+              <option value="txt">Text (.txt)</option>
+              <option value="html">HTML (.html)</option>
+              <option value="json">JSON (.json)</option>
+              <option value="csv">CSV (.csv)</option>
+            </select>
+          </label>
         </div>
         </details>
       </div>

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -54,7 +54,7 @@
 
       <div id="fast-batch-bar" class="fast-batch-bar hidden">
         <span class="fast-info" tabindex="0" role="img" aria-label="About Fast Batch"
-          data-tooltip="Fetches your bookmarks directly through your logged-in X session (its private API) — far faster than rendering each page, but bookmarks only for now. Before the first run, open any single tweet once so the request can be captured. Large runs can hit X's rate limit and briefly soft-block your session (&quot;Something went wrong&quot;); Fast Batch stops politely and you can re-run a few minutes later for the rest."
+          data-tooltip="Exports your Bookmarks, a profile's posts, or your Likes far faster by fetching them directly through your logged-in X session (its private API) — no API key, no password, nothing leaves your browser. The step lights below show what to do first (reload the page / open one tweet). Big runs can hit X's rate limit — it stops politely so you can re-run, or use the date range to narrow the scope."
           data-i18n-tooltip="fast_batch_info">
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
             stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
@@ -80,22 +80,6 @@
         An export is running — cancel or let it finish to switch modes.
       </p>
 
-      <div id="fast-date-range" class="fast-date-range hidden">
-        <span class="fast-date-label" data-i18n="fast_date_range" data-tooltip="Only export posts whose date is in this range — out-of-range posts are skipped without being expanded, so you reach older posts without hitting X's rate limit."
-          data-i18n-tooltip="fast_date_range_hint">Date range</span>
-        <input type="date" id="fast-date-from" class="fast-date-input" aria-label="From date" data-i18n-aria-label="fast_date_from" />
-        <span class="fast-date-sep">→</span>
-        <input type="date" id="fast-date-to" class="fast-date-input" aria-label="To date" data-i18n-aria-label="fast_date_to" />
-        <button id="fast-date-clear" class="batch-ctl" type="button" data-i18n="fast_date_clear">Clear</button>
-      </div>
-
-      <div id="fast-steps" class="fast-steps hidden" role="status">
-        <span class="fast-step" id="fast-step-page"><span class="fast-step-dot"></span><span class="fast-step-label" data-i18n="fast_step_page">Page</span></span>
-        <span class="fast-step" id="fast-step-tweet"><span class="fast-step-dot"></span><span class="fast-step-label" data-i18n="fast_step_tweet">Tweet</span></span>
-        <span class="fast-step" id="fast-step-fetch"><span class="fast-step-dot"></span><span class="fast-step-label" data-i18n="fast_step_fetch">Fetch</span></span>
-        <span class="fast-step" id="fast-step-expand"><span class="fast-step-dot"></span><span class="fast-step-label" data-i18n="fast_step_expand">Expand</span></span>
-      </div>
-
       <div class="options">
         <details id="export-settings" class="option-group" open>
           <summary class="option-group-summary">
@@ -113,7 +97,7 @@
                 <circle cx="8.5" cy="8.5" r="1.5" />
                 <polyline points="21 15 16 10 5 21" />
               </svg>
-              <span data-i18n="opt_save_images">Save images locally</span>
+              <span data-i18n="opt_save_images">Save images locally (only with .md)</span>
             </span>
             <input type="checkbox" id="chk-download-images" class="toggle-input" />
             <span class="toggle-switch"></span>
@@ -138,20 +122,6 @@
               <span data-i18n="opt_metadata">Include metadata</span>
             </span>
             <input type="checkbox" id="chk-include-metadata" class="toggle-input" />
-            <span class="toggle-switch"></span>
-          </label>
-          <label class="toggle-label" data-tooltip="When batch-exporting a profile, include reposts too. Off = the profile owner's own posts only." data-i18n-tooltip="opt_include_reposts_title">
-            <span class="toggle-text">
-              <svg class="toggle-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
-                stroke-linecap="round" stroke-linejoin="round">
-                <polyline points="17 1 21 5 17 9" />
-                <path d="M3 11V9a4 4 0 0 1 4-4h14" />
-                <polyline points="7 23 3 19 7 15" />
-                <path d="M21 13v2a4 4 0 0 1-4 4H3" />
-              </svg>
-              <span data-i18n="opt_include_reposts">Include reposts (profiles)</span>
-            </span>
-            <input type="checkbox" id="chk-include-reposts" class="toggle-input" />
             <span class="toggle-switch"></span>
           </label>
         </details>
@@ -179,6 +149,20 @@
               <label for="out-combined" class="seg-label" data-i18n="batch_out_combined">Combined</label>
             </div>
           </div>
+          <label class="toggle-label" data-tooltip="When batch-exporting a profile, include reposts too. Off = the profile owner's own posts only." data-i18n-tooltip="opt_include_reposts_title">
+            <span class="toggle-text">
+              <svg class="toggle-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+                stroke-linecap="round" stroke-linejoin="round">
+                <polyline points="17 1 21 5 17 9" />
+                <path d="M3 11V9a4 4 0 0 1 4-4h14" />
+                <polyline points="7 23 3 19 7 15" />
+                <path d="M21 13v2a4 4 0 0 1-4 4H3" />
+              </svg>
+              <span data-i18n="opt_include_reposts">Include reposts (profiles)</span>
+            </span>
+            <input type="checkbox" id="chk-include-reposts" class="toggle-input" />
+            <span class="toggle-switch"></span>
+          </label>
         </div>
       </div>
 
@@ -317,6 +301,14 @@
             </svg>
           </button>
         </div>
+        <div id="fast-date-range" class="fast-date-range hidden">
+          <span class="fast-date-label" data-i18n="fast_date_range" data-tooltip="Only export posts whose date is in this range — out-of-range posts are skipped without being expanded, so you reach older posts without hitting X's rate limit."
+            data-i18n-tooltip="fast_date_range_hint">Date range</span>
+          <input type="date" id="fast-date-from" class="fast-date-input" aria-label="From date" data-i18n-aria-label="fast_date_from" />
+          <span class="fast-date-sep">→</span>
+          <input type="date" id="fast-date-to" class="fast-date-input" aria-label="To date" data-i18n-aria-label="fast_date_to" />
+          <button id="fast-date-clear" class="batch-ctl" type="button" data-i18n="fast_date_clear">Clear</button>
+        </div>
         <button id="btn-batch" class="btn-batch btn-action" type="button"
           data-tooltip="Export every bookmark loaded on this page as Markdown files into one folder. Scroll the bookmarks page to load more."
           data-i18n-tooltip="btn_batch_hint">
@@ -340,6 +332,12 @@
           </svg>
           <span class="btn-label" id="btn-batch-label" data-i18n="btn_batch">Export bookmarks</span>
         </button>
+        <div id="fast-steps" class="fast-steps hidden" role="status">
+          <span class="fast-step" id="fast-step-page"><span class="fast-step-dot"></span><span class="fast-step-label" data-i18n="fast_step_page">Page</span></span>
+          <span class="fast-step" id="fast-step-tweet"><span class="fast-step-dot"></span><span class="fast-step-label" data-i18n="fast_step_tweet">Tweet</span></span>
+          <span class="fast-step" id="fast-step-fetch"><span class="fast-step-dot"></span><span class="fast-step-label" data-i18n="fast_step_fetch">Fetch</span></span>
+          <span class="fast-step" id="fast-step-expand"><span class="fast-step-dot"></span><span class="fast-step-label" data-i18n="fast_step_expand">Expand</span></span>
+        </div>
         <div id="batch-dedup-row" class="batch-dedup-row hidden">
           <span id="batch-dedup-text"></span>
           <span class="batch-ctl-group">

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -264,6 +264,15 @@
               <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z" />
             </svg>
           </button>
+          <button id="tab-batch-timeline" class="batch-tab" type="button" role="tab"
+            aria-label="Timeline" data-i18n-aria-label="batch_tab_timeline"
+            data-tooltip="Timeline" data-i18n-tooltip="batch_tab_timeline">
+            <svg class="batch-tab-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+              stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" />
+              <polyline points="9 22 9 12 15 12 15 22" />
+            </svg>
+          </button>
           <button id="tab-batch-selection" class="batch-tab" type="button" role="tab"
             aria-label="Selection" data-i18n-aria-label="batch_tab_selection"
             data-tooltip="Selection" data-i18n-tooltip="batch_tab_selection">
@@ -339,6 +348,11 @@
           <svg id="btn-batch-icon-likes" class="btn-icon hidden" viewBox="0 0 24 24" fill="none" stroke="currentColor"
             stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
             <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z" />
+          </svg>
+          <svg id="btn-batch-icon-timeline" class="btn-icon hidden" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+            stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" />
+            <polyline points="9 22 9 12 15 12 15 22" />
           </svg>
           <span class="btn-label" id="btn-batch-label" data-i18n="btn_batch">Export bookmarks</span>
         </button>

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -124,8 +124,7 @@
             <input type="checkbox" id="chk-include-metadata" class="toggle-input" />
             <span class="toggle-switch"></span>
           </label>
-        </details>
-        <div id="batch-format-controls" class="batch-format-controls hidden">
+          <div id="batch-format-controls" class="batch-format-controls hidden">
           <label class="batch-field">
             <span class="batch-field-label" data-i18n="batch_format">Format</span>
             <select id="batch-format" class="batch-select">
@@ -164,6 +163,7 @@
             <span class="toggle-switch"></span>
           </label>
         </div>
+        </details>
       </div>
 
       <div id="panel-single" class="export-panel">

--- a/src/popup/settings-form.ts
+++ b/src/popup/settings-form.ts
@@ -34,6 +34,7 @@ import {
   chkInlineCopies,
   chkShowInline,
   chkInlineStats,
+  chkIncludeReposts,
   chkObsidianFriendly,
   txtObsidianVault,
   txtDownloadFolder,
@@ -72,6 +73,7 @@ function persistAll(): void {
     inlineButtonCopies: chkInlineCopies.checked,
     showInlineButton: chkShowInline.checked,
     inlineStats: chkInlineStats.checked,
+    includeReposts: chkIncludeReposts.checked,
     obsidianFriendly: chkObsidianFriendly.checked,
     obsidianVault: txtObsidianVault.value.trim(),
     obsidianFolder: txtObsidianFolder.value.trim(),
@@ -297,6 +299,7 @@ export function initSettingsForm(): void {
     chkInlineCopies.checked = settings.inlineButtonCopies;
     chkShowInline.checked = settings.showInlineButton;
     chkInlineStats.checked = settings.inlineStats;
+    chkIncludeReposts.checked = settings.includeReposts;
     chkObsidianFriendly.checked = settings.obsidianFriendly;
     txtObsidianVault.value = settings.obsidianVault;
     txtObsidianFolder.value = settings.obsidianFolder;
@@ -409,6 +412,7 @@ export function initSettingsForm(): void {
     persistAll();
   });
   chkInlineStats.addEventListener('change', persistAll);
+  chkIncludeReposts.addEventListener('change', persistAll);
   chkObsidianFriendly.addEventListener('change', () => {
     // Obsidian-friendly only reshapes the frontmatter — turning it on while
     // Include metadata is off would leave nothing to reshape. Flip metadata on

--- a/src/shared/settings.ts
+++ b/src/shared/settings.ts
@@ -26,6 +26,8 @@ export interface Settings {
   inlineButtonCopies: boolean;
   showInlineButton: boolean;
   inlineStats: boolean;
+  // Profile batch: include reposts (off = the profile owner's own posts only).
+  includeReposts: boolean;
   obsidianFriendly: boolean;
   obsidianVault: string;
   obsidianFolder: string;
@@ -58,6 +60,7 @@ export const DEFAULT_SETTINGS: Settings = {
   inlineButtonCopies: false, // inline button downloads by default
   showInlineButton: false, // off by default in v2.0.0 — avoids DOM conflicts with other X/Twitter extensions; v1.9.0 migrants keep their stored value
   inlineStats: false, // off — changes visible content, opt-in
+  includeReposts: false, // off — profile exports own posts only, matching prior behavior
   obsidianFriendly: false, // off — changes frontmatter shape, opt-in
   obsidianVault: '', // empty → let Obsidian pick the last-used vault
   obsidianFolder: '', // empty → create note at the vault root

--- a/src/types/messages.ts
+++ b/src/types/messages.ts
@@ -238,6 +238,10 @@ export interface FastBatchProgress {
   status: 'idle' | 'running' | 'done' | 'cancelled' | 'error';
   // Human-readable phase for the progress label (e.g. "Fetching bookmarks").
   phase: string;
+  // Which source + (for profile) whose posts — so the popup can show who's
+  // running even after navigating elsewhere / reopening.
+  source?: 'bookmarks' | 'profile' | 'likes';
+  handle?: string;
   done: number;
   total: number;
   exported: number;

--- a/src/types/messages.ts
+++ b/src/types/messages.ts
@@ -218,6 +218,10 @@ export interface ContextUrlRequest {
 // worker-tab batch job model on purpose — Fast Batch has no per-item tab.
 export interface FastBatchStartRequest {
   action: 'FAST_BATCH_START';
+  // Which paginated source to export (Selection isn't Fast-compatible).
+  source?: 'bookmarks' | 'profile' | 'likes';
+  // Profile owner's handle — used to skip reposts (export only their own posts).
+  handle?: string;
   expandThreads?: boolean;
 }
 export interface FastBatchStartResponse {

--- a/src/types/messages.ts
+++ b/src/types/messages.ts
@@ -222,6 +222,10 @@ export interface FastBatchStartRequest {
   source?: 'bookmarks' | 'profile' | 'likes';
   // Profile owner's handle — used to skip reposts (export only their own posts).
   handle?: string;
+  // Optional YYYY-MM-DD bounds on the tweet's date; out-of-range items are
+  // skipped (and never expanded), so the TweetDetail budget is spared.
+  fromDate?: string;
+  toDate?: string;
   expandThreads?: boolean;
 }
 export interface FastBatchStartResponse {

--- a/src/types/messages.ts
+++ b/src/types/messages.ts
@@ -165,6 +165,15 @@ export interface HarvestResponse {
   urls: string[];
 }
 
+// Popup → injector: empty the gathered collection so it restarts from the
+// current scroll position ("Reset queue"). Re-seeds from the viewport.
+export interface HarvestResetRequest {
+  action: 'XCLIPPER_HARVEST_RESET';
+}
+export interface HarvestResetResponse {
+  count: number;
+}
+
 // Popup → injector content script: enter/exit tweet selection mode — the
 // injector overlays checkboxes on timeline cells and a floating export bar.
 export interface SelectionRequest {
@@ -251,6 +260,7 @@ export type MessageRequest =
   | BatchControlRequest
   | BatchStatusRequest
   | HarvestRequest
+  | HarvestResetRequest
   | SelectionRequest
   | BatchItemResultMessage
   | FastBatchStartRequest

--- a/src/types/messages.ts
+++ b/src/types/messages.ts
@@ -92,7 +92,7 @@ export interface BatchStartRequest {
   urls: string[];
   // Which surface launched the job — the popup scopes progress display to
   // the matching tab.
-  origin?: 'bookmarks' | 'profile' | 'selection' | 'likes';
+  origin?: 'bookmarks' | 'profile' | 'selection' | 'likes' | 'timeline';
   // Profile owner's handle when origin === 'profile'.
   handle?: string;
   // File format + grouping for the job (defaults: 'md' / 'separate'). PDF
@@ -132,7 +132,7 @@ export interface BatchStatusResponse {
   job?: {
     id: string;
     status: 'running' | 'paused' | 'done' | 'cancelled';
-    origin?: 'bookmarks' | 'profile' | 'selection' | 'likes';
+    origin?: 'bookmarks' | 'profile' | 'selection' | 'likes' | 'timeline';
     // Set when origin === 'profile' — the popup only offers "add to queue"
     // on the same profile.
     handle?: string;
@@ -159,7 +159,7 @@ export interface HarvestRequest {
 }
 
 export interface HarvestResponse {
-  source: 'bookmarks' | 'profile' | 'likes' | null;
+  source: 'bookmarks' | 'profile' | 'likes' | 'timeline' | null;
   // Profile owner's handle when source is 'profile'.
   handle?: string;
   urls: string[];

--- a/src/types/messages.ts
+++ b/src/types/messages.ts
@@ -238,6 +238,15 @@ export interface FastBatchCancelRequest {
 export interface FastBatchStatusRequest {
   action: 'FAST_BATCH_STATUS';
 }
+// Readiness for the step lights: are the needed request templates captured?
+export interface FastBatchReadyRequest {
+  action: 'FAST_BATCH_READY';
+  source?: 'bookmarks' | 'profile' | 'likes';
+}
+export interface FastBatchReadyResponse {
+  feed: boolean; // the source's feed template was observed (page visited)
+  tweetDetail: boolean; // a tweet was opened (expansion possible)
+}
 export interface FastBatchProgress {
   status: 'idle' | 'running' | 'done' | 'cancelled' | 'error';
   // Human-readable phase for the progress label (e.g. "Fetching bookmarks").
@@ -277,4 +286,5 @@ export type MessageRequest =
   | BatchItemResultMessage
   | FastBatchStartRequest
   | FastBatchCancelRequest
-  | FastBatchStatusRequest;
+  | FastBatchStatusRequest
+  | FastBatchReadyRequest;

--- a/tests/timeline.test.ts
+++ b/tests/timeline.test.ts
@@ -52,6 +52,56 @@ describe('parseTimelinePage', () => {
     expect(p.bottomCursor).toBeNull();
     expect(p.done).toBe(true);
   });
+
+  it('finds a profile/likes user timeline and pulls module (self-thread) tweets', () => {
+    const raw = {
+      data: {
+        user: {
+          result: {
+            timeline_v2: {
+              timeline: {
+                instructions: [
+                  {
+                    type: 'TimelineAddEntries',
+                    entries: [
+                      { entryId: 'tweet-1', content: { itemContent: { tweet_results: { result: { rest_id: '1' } } } } },
+                      {
+                        entryId: 'profile-conversation-9',
+                        content: {
+                          entryType: 'TimelineTimelineModule',
+                          items: [
+                            { item: { itemContent: { tweet_results: { result: { rest_id: '2' } } } } },
+                            { item: { itemContent: { tweet_results: { result: { rest_id: '3' } } } } },
+                          ],
+                        },
+                      },
+                      { entryId: 'cursor-bottom-x', content: { cursorType: 'Bottom', value: 'CUR' } },
+                    ],
+                  },
+                ],
+              },
+            },
+          },
+        },
+      },
+    };
+    const p = parseTimelinePage(raw);
+    expect(ids(p.tweetResults)).toEqual(['1', '2', '3']);
+    expect(p.bottomCursor).toBe('CUR');
+  });
+
+  it('falls back to a generic search when the data key is unknown', () => {
+    const raw = {
+      data: {
+        some_new_timeline: {
+          timeline: { instructions: [{ type: 'TimelineAddEntries', entries: [
+            { entryId: 'tweet-7', content: { itemContent: { tweet_results: { result: { rest_id: '7' } } } } },
+          ] }] },
+        },
+      },
+    };
+    expect(ids(parseTimelinePage(raw).tweetResults)).toEqual(['7']);
+  });
 });
 
 describe('request URL helpers', () => {


### PR DESCRIPTION
Batch-export UX improvements (v2.4.0), building on the merged Fast Batch (#70). Standard batch behavior is unchanged unless noted.

## Fast Batch: more sources
- **Profile** and **Likes** now work in Fast, not just Bookmarks — same ~10× path. The timeline parser was generalized (robust source-agnostic timeline finder + module/self-thread cells). Profile skips **reposts** by default (detected structurally via `retweeted_status_result`, since a retweet's top-level author is the retweeter).
- **Selection** stays Standard-only — its tab is disabled while Fast is armed (Fast has no feed to paginate).

## New sources & controls
- **Timeline tab (Standard)** — a 5th batch source exporting the posts loaded in your home feed (`x.com/home`), through the same worker-tab extractor as Bookmarks/Profile/Likes. Standard-only; the tab is disabled while Fast is armed (the home feed is `HomeTimeline`/`HomeLatestTimeline` — **POST** with cursor in the body, which Fast's GET-with-URL pagination engine doesn't support; deferred).
- **Open page from the tab** — when you're not on the right page, the **Bookmarks** and **Timeline** tabs show an **Open Bookmarks / Open Timeline** button that navigates the active x.com tab there (or opens a new tab) instead of a disabled dead-end. Standard still reads the loaded DOM, so you scroll then export. Profile/Likes keep the hint (per-account, no canonical URL without a handle).
- **Date-range filter (Fast)** — From/To bounds on the tweet date. Out-of-range posts are skipped *before* the per-item TweetDetail expansion, so X's ~150/15-min TweetDetail quota is spent only on in-range posts → reach older targets without soft-blocking. (Filters by tweet date; bumps feed page depth since Bookmarks/Likes are ordered by save date.)
- **Reset queue** — empties the gathered collection and restarts from the current scroll position, so you can begin a batch at a specific post. (Standard sources; injector `XCLIPPER_HARVEST_RESET`.)
- **Reset history** — renamed from the unclear "Reset dedup".
- **Include reposts toggle** — default off (own posts only); honored by **both** Standard (injector harvest filter) and Fast.
- **Step status lights (Fast)** — Page → Tweet → Fetch → Expand. Page/Tweet are red/green readiness lights (reload page / open one tweet) so you know what to do before Export; Fetch/Expand light up the live phase.

## Layout & styling
- Batch **Output** selector moved above **Format**.
- Fast Batch bar flattened: red text (not a red fill), neutral `(i)` + BETA, and a plain red toggle — less wall-of-red while keeping Fast clearly marked.

## Running-job display + reliability fixes
- A running job's progress now stays visible on every tab/page and is labeled with **who/which** is running (`@handle · 2/6`), Standard and Fast.
- **Fast progress survives popup reopen** (re-attaches to the background run; was lost because the popup is a fresh page each open).
- Fast reads the **profile handle from the URL**, not the injector — so it shows the name and filters reposts even when the page wasn't reloaded after an extension update.
- Fast captured **auth + request templates persist to `chrome.storage.session`** so they survive MV3 service-worker teardown between runs.
- Reset buttons **grey out instead of hiding** (stable layout); greyed via color, not opacity, so their tooltips stay readable (issue #38).
- After an extension reload: URL-based tab focus + clickable "Reload the page" hint (a disabled button can't show its tooltip in Chrome); plain combined Fast precondition hint.
- Cancel writes only the items actually processed ("stop at 5" → ~5 files); the Fast lock hint shows only on a toggle attempt, not during any export.

## Notes
- Version bumped 2.3.0 → 2.4.0; CHANGELOG updated.
- New pure logic (timeline finder/module parse, date filter, repost detection) is unit-tested — **194 tests pass**; `tsc --noEmit` + build green.
- Profile/Likes GraphQL response shapes are schema-modeled (Bookmarks was validated against a real capture); the parser is defensive and was exercised live, but worth a reviewer's eye.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
