### PR TITLE
chore(deps): bump undici to 7.28.0 to resolve Dependabot alerts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2365,9 +2365,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.25.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
-      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
       "dev": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
Bumps the transitive `undici` dependency (via `jsdom`, devDependency) from 7.25.0 → 7.28.0.

Resolves all 6 open Dependabot alerts:
- **High** #6 — cross-origin request routing via SOCKS5 proxy pool reuse
- **High** #3 — TLS certificate validation bypass via dropped requestTls in SOCKS5 ProxyAgent
- **Medium** #8 — HTTP header injection via Set-Cookie percent-decoding
- **Medium** #4 — cross-user information disclosure via shared cache whitespace bypass
- **Low** #9 — Set-Cookie SameSite attribute downgrade
- **Low** #5 — HTTP response queue poisoning via keep-alive socket reuse

All fixed in undici 7.28.0. `npm audit` reports 0 vulnerabilities; typecheck and full test suite (194 tests) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)