### PR TITLE
Fast Batch: quarantine incomplete exports and retry them first

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
-## [2.5.0] - 2026-06-15
+## [Unreleased]
+
+### Fixed
+
+- **Fast Batch separates incomplete exports**: when X rate-limits a run mid-expansion, posts whose thread or article couldn't be fully fetched are now saved into an `_incomplete_rerun_to_complete/` subfolder — and kept out of the combined file and `data.json` — instead of sitting alongside complete exports where you couldn't tell them apart. They stay un-tracked so re-running Fast Batch a few minutes later completes them.
+
+---
+## [2.5.0] - 2026-06-17
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
-## [Unreleased]
+## [2.5.1] - 2026-07-11
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **Fast Batch separates incomplete exports**: when X rate-limits a run mid-expansion, posts whose thread or article couldn't be fully fetched are now saved into an `_incomplete_rerun_to_complete/` subfolder — and kept out of the combined file and `data.json` — instead of sitting alongside complete exports where you couldn't tell them apart. They stay un-tracked so re-running Fast Batch a few minutes later completes them.
+- **Fast Batch retries incomplete posts first**: the next run now expands the posts a previous rate-limited run left incomplete before any fresh ones, so the stable bookmark order can't keep postponing the same tail of posts run after run.
 
 ---
 ## [2.5.0] - 2026-06-17

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -141,7 +141,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Rebrand to XClipper**: The extension is renamed from *tweet2md* to *XClipper* across the toolbar icon, popup wordmark, context-menu label, and Chrome Web Store listing. The new icon — a paperclip with a stylized X — replaces the markdown-arrow logo. Chrome Web Store titles across all 12 locales now lead with "X / Twitter Web Clipper" plus each locale's natural save verb, the PDF format, and a "Free, no API" trust signal.
 - **Inline button defaults to off for new installs**: New installs no longer inject the per-tweet action-bar download button by default, reducing the chance of layout conflicts with other X extensions. Existing v1.9.0 users keep their stored choice; flip it in Settings → *Show inline button on tweets*.
 
-### Migration
+### Changed
 
 - **Settings carry over automatically from v1.9.0**: Preferences saved under the previous `tweet2md_settings` storage key are copied to the new `xclipper_settings` key on first run after the update. Subfolder, filename template, Obsidian vault, frontmatter selections, and every toggle state come across transparently — no reconfiguration needed.
 
@@ -266,7 +266,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Duplicate Video Poster**: Deduplicated cases where X hydrated both a poster `<img>` and a `<video>` for the same clip. (thanks @BigCactusLabs, #7)
 
-### Internal
+### Changed
 
 - **Contributing Guide**: Added `CONTRIBUTING.md` covering snapshot-test discipline and fixture capture.
 - **CI Pipeline**: GitHub Actions CI for tests and build. (thanks @BigCactusLabs, #8)
@@ -355,7 +355,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Tweet Metadata**: Added a toggle to include engagement metrics (likes, reposts, replies, bookmarks, views) as YAML frontmatter at the top of the generated markdown file.
 - **Settings Persistence**: Popup toggles now remember your preferences between sessions.
 
-### Improved
+### Changed
 
 - **Quote Tweet Extraction**: Refined extraction logic to accurately differentiate between main tweet text and quoted tweet text, preventing messy or duplicated text in the output.
 - **Popup toggle switches**: Replaced basic checkboxes with modern, animated toggle switches with SVGs.
@@ -363,7 +363,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.0.0] - 2026-02-15
 
-### Initial Features
+### Added
 
 - **Core Extraction**: Tweets, threads, and X Articles/Notes.
 - **DOM Cleaning**: Strips follow buttons, engagement bars, and unwanted navigation automatically.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "xclipper",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "xclipper",
-      "version": "2.5.0",
+      "version": "2.5.1",
       "license": "PolyForm-Noncommercial-1.0.0",
       "devDependencies": {
         "@puppeteer/browsers": "^3.0.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xclipper",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "XClipper — free, source-available web clipper for X (Twitter). Download threads, posts, and articles as Markdown or PDF for Obsidian, research, and AI/RAG workflows. Works locally — no API, no accounts, no tracking.",
   "license": "PolyForm-Noncommercial-1.0.0",
   "private": true,

--- a/src/background/batch-state.ts
+++ b/src/background/batch-state.ts
@@ -58,6 +58,11 @@ export const BATCH_MAX_ITEMS = 200;
 export const EXPORTED_LEDGER_KEY = 'xclipper_batch_exported';
 export const LEDGER_CAP = 5000;
 
+// Fast Batch only: ids written as partial (rate-limited) stubs — un-ledgered so
+// a re-run retries them, and expanded FIRST next run so a stable feed order
+// can't starve the same tail forever (issue #81). Cleared by the same Reset.
+export const INCOMPLETE_LEDGER_KEY = 'xclipper_fast_incomplete';
+
 export function appendToLedger(ledger: string[], id: string): string[] {
   if (ledger.includes(id)) return ledger;
   const next = [...ledger, id];

--- a/src/background/fast-batch.ts
+++ b/src/background/fast-batch.ts
@@ -282,6 +282,13 @@ export interface FastBatchOptions {
 // went wrong"). Gentle + stop-on-rate-limit protects the session.
 const TWEET_DETAIL_CONCURRENCY = 3;
 
+// Subfolder for items whose thread/article expansion was cut short by X's rate
+// limit — they're written as root-only stubs, aren't ledgered, and a re-run
+// completes them. Quarantining them here (and out of the combined/manifest)
+// keeps them from masquerading as complete exports (issue #81). Named to signal
+// both the state and the fix.
+const INCOMPLETE_SUBFOLDER = '_incomplete_rerun_to_complete';
+
 // Phase-A trigger (no UI yet, like ADR 0002 batch): fetch the bookmarks
 // timeline via GraphQL, map each tweet to the AST, expand Articles/threads via
 // per-item TweetDetail, then postProcess + write through the SHARED sinks
@@ -469,9 +476,19 @@ async function runFastBatchExport(opts: FastBatchOptions = {}): Promise<FastBatc
   // and stay un-ledgered, so a re-run grabs them.
   const toWrite = cancelRequested ? selected.filter((s) => s.ledger) : selected;
   setProgress({ phase: 'Writing files…', total: toWrite.length, done: 0 });
+  // Reliable (fully-expanded) items go in the run folder root and drive the
+  // combined digest + data.json. Items whose expansion the rate limit cut short
+  // (needsExpand && !ledger) are quarantined as loose files under
+  // INCOMPLETE_SUBFOLDER — separate filename namespace, kept out of the ledger
+  // and out of the combined/manifest — so a re-run completes them (issue #81).
   const usedFilenames: string[] = [];
+  const stubFilenames: string[] = [];
   const items: StoredItem[] = [];
-  for (const { doc, ledger: ledgerIt } of toWrite) {
+  let incomplete = 0;
+  let processed = 0;
+  for (const s of toWrite) {
+    const { doc } = s;
+    const isStub = s.needsExpand && !s.ledger;
     const result = postProcess(docToExtracted(doc), {
       includeMetadata: settings.includeMetadata,
       downloadImages: resolveDownloadImages('download', settings.downloadImages),
@@ -480,15 +497,25 @@ async function runFastBatchExport(opts: FastBatchOptions = {}): Promise<FastBatc
       filenameTemplate: settings.filenameTemplate.trim(),
       frontmatterFields,
     });
-    const filename = uniqueFilename(usedFilenames, result.filename);
-    usedFilenames.push(filename.toLowerCase());
-    if (output !== 'combined') {
-      writePerItem(folder, format, filename, result.markdown, result.images, doc, settings);
+    if (isStub) {
+      const filename = uniqueFilename(stubFilenames, result.filename);
+      stubFilenames.push(filename.toLowerCase());
+      if (output !== 'combined') {
+        const stubFolder = `${folder}/${INCOMPLETE_SUBFOLDER}`;
+        writePerItem(stubFolder, format, filename, result.markdown, result.images, doc, settings);
+      }
+      incomplete++;
+    } else {
+      const filename = uniqueFilename(usedFilenames, result.filename);
+      usedFilenames.push(filename.toLowerCase());
+      if (output !== 'combined') {
+        writePerItem(folder, format, filename, result.markdown, result.images, doc, settings);
+      }
+      items.push({ url: doc.metadata.sourceUrl, filename, doc });
+      const id = doc.metadata.tweetId;
+      if (id && s.ledger) ledgerArr = appendToLedger(ledgerArr, id);
     }
-    items.push({ url: doc.metadata.sourceUrl, filename, doc });
-    const id = doc.metadata.tweetId;
-    if (id && ledgerIt) ledgerArr = appendToLedger(ledgerArr, id);
-    setProgress({ done: items.length });
+    setProgress({ done: ++processed });
   }
 
   if (items.length > 0) {
@@ -504,7 +531,11 @@ async function runFastBatchExport(opts: FastBatchOptions = {}): Promise<FastBatc
     void recordExport();
   }
   const cancelled = cancelRequested;
-  log(`${cancelled ? 'cancelled' : 'done'} — exported ${items.length} → ${folder}/ (${skipped} skipped; ${format}/${output})`);
+  log(
+    `${cancelled ? 'cancelled' : 'done'} — exported ${items.length}` +
+      `${incomplete ? `, ${incomplete} incomplete (rate-limited) → ${INCOMPLETE_SUBFOLDER}/` : ''}` +
+      ` → ${folder}/ (${skipped} skipped; ${format}/${output})`
+  );
   setProgress({
     status: cancelled ? 'cancelled' : 'done',
     phase: cancelled ? 'Cancelled' : 'Done',
@@ -513,7 +544,7 @@ async function runFastBatchExport(opts: FastBatchOptions = {}): Promise<FastBatc
     folder,
     rateLimited,
     total: toWrite.length,
-    done: items.length,
+    done: processed,
   });
   return { exported: items.length, skipped, folder };
 }

--- a/src/background/fast-batch.ts
+++ b/src/background/fast-batch.ts
@@ -41,6 +41,7 @@ import {
 import {
   BATCH_MAX_ITEMS,
   EXPORTED_LEDGER_KEY,
+  INCOMPLETE_LEDGER_KEY,
   appendToLedger,
   batchFolderName,
   uniqueFilename,
@@ -245,6 +246,12 @@ async function loadLedger(): Promise<string[]> {
   return Array.isArray(raw) ? raw.filter((v): v is string => typeof v === 'string') : [];
 }
 
+async function loadIncomplete(): Promise<string[]> {
+  const r = await chrome.storage.local.get(INCOMPLETE_LEDGER_KEY);
+  const raw = r[INCOMPLETE_LEDGER_KEY];
+  return Array.isArray(raw) ? raw.filter((v): v is string => typeof v === 'string') : [];
+}
+
 export interface FastBatchResult {
   exported: number;
   skipped: number;
@@ -288,6 +295,10 @@ const TWEET_DETAIL_CONCURRENCY = 3;
 // keeps them from masquerading as complete exports (issue #81). Named to signal
 // both the state and the fix.
 const INCOMPLETE_SUBFOLDER = '_incomplete_rerun_to_complete';
+
+// Cap on the persisted incomplete-id list; it drains as items complete, so this
+// only guards against a pathological run of rate limits growing it unbounded.
+const INCOMPLETE_CAP = 2000;
 
 // Phase-A trigger (no UI yet, like ADR 0002 batch): fetch the bookmarks
 // timeline via GraphQL, map each tweet to the AST, expand Articles/threads via
@@ -364,6 +375,8 @@ async function runFastBatchExport(opts: FastBatchOptions = {}): Promise<FastBatc
 
   const ledger = new Set(await loadLedger());
   let ledgerArr = [...ledger];
+  // Ids left incomplete by a previous rate-limited run — expanded first below.
+  const prevIncomplete = new Set(await loadIncomplete());
   let skipped = 0;
 
   // Start from the top of the feed — drop any mid-scroll cursor the captured
@@ -418,10 +431,13 @@ async function runFastBatchExport(opts: FastBatchOptions = {}): Promise<FastBatc
   }
 
   // 2) Expand via per-item TweetDetail: Articles always (full body), other
-  //    tweets when expandThreads. Articles go FIRST so the limited per-account
-  //    budget always covers them. On the first rate-limit signal we STOP (rather
-  //    than hammer X and degrade the user's session); stopped/rate-limited items
-  //    are NOT ledgered, so a later re-run fetches their full thread/article.
+  //    tweets when expandThreads. Ordering (highest priority first): items a
+  //    previous rate-limited run left incomplete, then Articles (their body only
+  //    exists via TweetDetail), then the rest — so the limited per-account budget
+  //    always clears the backlog before fresh items, and a stable feed order
+  //    can't starve the same tail forever (issue #81). On the first rate-limit
+  //    signal we STOP (rather than hammer X and degrade the user's session);
+  //    stopped/rate-limited items are NOT ledgered, so a re-run retries them.
   let rateLimited = false;
   const toExpand = selected.filter((s) => s.needsExpand);
   if (toExpand.length > 0 && !templates.TweetDetail) {
@@ -436,9 +452,13 @@ async function runFastBatchExport(opts: FastBatchOptions = {}): Promise<FastBatc
     return null;
   } else if (toExpand.length > 0) {
     setProgress({ phase: 'Expanding threads & articles…', total: toExpand.length, done: 0 });
-    const ordered = [...toExpand].sort(
-      (a, b) => Number(b.doc.metadata.type === 'article') - Number(a.doc.metadata.type === 'article')
-    );
+    // Lower rank = fetched first: previously-incomplete (0) < article (1) < rest (2).
+    const rank = (s: Item): number => {
+      const id = s.doc.metadata.tweetId;
+      if (id && prevIncomplete.has(id)) return 0;
+      return s.doc.metadata.type === 'article' ? 1 : 2;
+    };
+    const ordered = [...toExpand].sort((a, b) => rank(a) - rank(b));
     let expanded = 0;
     let unavailable = 0;
     let processed = 0;
@@ -484,10 +504,14 @@ async function runFastBatchExport(opts: FastBatchOptions = {}): Promise<FastBatc
   const usedFilenames: string[] = [];
   const stubFilenames: string[] = [];
   const items: StoredItem[] = [];
+  // Carry the incomplete-id memory forward: drop ids that completed this run,
+  // add ids still written as stubs — so next run expands the leftovers first.
+  const nextIncomplete = new Set(prevIncomplete);
   let incomplete = 0;
   let processed = 0;
   for (const s of toWrite) {
     const { doc } = s;
+    const id = doc.metadata.tweetId;
     const isStub = s.needsExpand && !s.ledger;
     const result = postProcess(docToExtracted(doc), {
       includeMetadata: settings.includeMetadata,
@@ -504,6 +528,7 @@ async function runFastBatchExport(opts: FastBatchOptions = {}): Promise<FastBatc
         const stubFolder = `${folder}/${INCOMPLETE_SUBFOLDER}`;
         writePerItem(stubFolder, format, filename, result.markdown, result.images, doc, settings);
       }
+      if (id) nextIncomplete.add(id);
       incomplete++;
     } else {
       const filename = uniqueFilename(usedFilenames, result.filename);
@@ -512,8 +537,8 @@ async function runFastBatchExport(opts: FastBatchOptions = {}): Promise<FastBatc
         writePerItem(folder, format, filename, result.markdown, result.images, doc, settings);
       }
       items.push({ url: doc.metadata.sourceUrl, filename, doc });
-      const id = doc.metadata.tweetId;
       if (id && s.ledger) ledgerArr = appendToLedger(ledgerArr, id);
+      if (id) nextIncomplete.delete(id);
     }
     setProgress({ done: ++processed });
   }
@@ -530,6 +555,10 @@ async function runFastBatchExport(opts: FastBatchOptions = {}): Promise<FastBatc
     await chrome.storage.local.set({ [EXPORTED_LEDGER_KEY]: ledgerArr });
     void recordExport();
   }
+  // Persisted regardless of items.length (an all-stub run still owes a re-run).
+  await chrome.storage.local.set({
+    [INCOMPLETE_LEDGER_KEY]: [...nextIncomplete].slice(-INCOMPLETE_CAP),
+  });
   const cancelled = cancelRequested;
   log(
     `${cancelled ? 'cancelled' : 'done'} — exported ${items.length}` +

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "__MSG_extensionName__",
   "short_name": "XClipper",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "__MSG_extensionDescription__",
   "default_locale": "en",
   "permissions": [

--- a/src/popup/batch-ui.ts
+++ b/src/popup/batch-ui.ts
@@ -19,7 +19,7 @@ import type {
 import { hostMatches } from '../shared/media';
 import { loadSettings } from '../shared/settings';
 // Pure module (no chrome.* at import time) — safe to share with the popup.
-import { EXPORTED_LEDGER_KEY, statusIdOf } from '../background/batch-state';
+import { EXPORTED_LEDGER_KEY, INCOMPLETE_LEDGER_KEY, statusIdOf } from '../background/batch-state';
 import {
   batchBarFill,
   batchDedupRow,
@@ -594,7 +594,7 @@ export async function initBatchUi(): Promise<void> {
     if (resuming) startJobPolling();
   });
   btnBatchReset.addEventListener('click', () => {
-    chrome.storage.local.remove(EXPORTED_LEDGER_KEY, () => void refreshIdleUi());
+    chrome.storage.local.remove([EXPORTED_LEDGER_KEY, INCOMPLETE_LEDGER_KEY], () => void refreshIdleUi());
   });
   btnBatchResetQueue.addEventListener('click', () => void resetQueue());
   (Object.keys(TAB_BUTTONS) as BatchTab[]).forEach((tab) => {


### PR DESCRIPTION
Closes #81.

## Problem

When a **Fast Batch** run hits X's TweetDetail rate limit mid-expansion, it stops issuing new fetches (correct) but still writes **every** collected item to the run folder — including items whose thread/article expansion never completed. These root-only **stubs** (`type: tweet`) landed **alongside** fully-expanded exports, indistinguishable, and (because they're deliberately un-ledgered so a re-run retries them) got re-exported into the next run's folder — producing the same post under the same filename in multiple folders with different content.

Worse, the expansion queue was ordered `article → rest` in stable feed order, so the same deep-tail posts fell past the ~150-call budget **every** run. A stub could be postponed indefinitely.

## Fix (2 commits)

1. **Quarantine incomplete exports** — stubs (`needsExpand && !ledger`) are written into an `_incomplete_rerun_to_complete/` subfolder with their own filename namespace, and kept out of the ledger, the combined digest, and `data.json`. Reliable items alone drive the run folder root + combined + manifest.

2. **Expand previously-incomplete posts first** — the stub ids are persisted (`xclipper_fast_incomplete`) and ranked ahead of Articles and fresh posts in the next run's expansion (`previously-incomplete → article → rest`), so the leftover budget always clears the backlog before touching new items. An id drops out once completed; **Reset dedup** clears it alongside the export ledger.

## Verification

`tsc --noEmit` · 194 tests · `npm run build` all green.

Validated end-to-end against three real consecutive runs:

- Each run quarantined its incomplete items (54 / 51 / 52) into the subfolder, out of `data.json`.
- **Every** previous run's stubs were processed the next run — `run1∩run2`, `run1∩run3`, `run2∩run3` stub overlap all **0**: no item was ever a stub twice (the starvation is gone; the backlog rotates).
- The promotions are real content, not renames — e.g. `bcherny-…749` went from a 16-line `type: tweet` stub to a 257-line `type: thread`; `claudeai-…721` 20 → 98 lines.

### Notes
- Single tweets look identical after expansion (nothing to add) — the fetch just confirms completeness, then they're ledgered and promoted. Expected.
- A few bookmarked *replies* change filename on expansion (re-attributed to the thread root) — pre-existing thread-expansion behavior, not introduced here; harmless since the stub folder is disposable.
- The rate-limit path in `fast-batch.ts` has no unit harness (only triggers under a live throttle), so it's compile/test/build-verified plus the real-run validation above.
