### PR TITLE
fix(popup)+perf(batch): stop reset-button flicker and throttle batch downloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Reset buttons no longer flicker after a large export**: the popup refreshed the Reset queue / Reset history buttons by greying them first and re-enabling after an async storage read; right after a big export — while Chrome is still writing hundreds of downloaded files — that read is slow enough for the greyed state to paint every second, so the buttons blinked until the writes drained. Each refresh now assigns the buttons their final state exactly once.
 - **Fast Batch no longer re-exports edited or re-rooted posts every run**: some posts (edited tweets, and thread replies that re-root to the thread's first tweet on expansion) end up with a different canonical id than the one the bookmarks feed lists, so the dedup history — which only stored the canonical id — never matched them again and they re-exported on every run. Fast Batch now remembers both ids, so these posts are correctly skipped once exported.
 
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Chrome stays responsive while a batch writes thousands of files**: batch downloads were all fired at once, so a large export (e.g. a Super Fast run) janked the whole browser — downloads UI, history and disk writes all landed together — until the queue drained. Writes now keep at most 8 downloads in flight so disk speed sets the pace: the write phase takes a little longer, but Chrome stays usable and the progress bar tracks files actually written.
 - **Reset buttons no longer flicker after a large export**: the popup refreshed the Reset queue / Reset history buttons by greying them first and re-enabling after an async storage read; right after a big export — while Chrome is still writing hundreds of downloaded files — that read is slow enough for the greyed state to paint every second, so the buttons blinked until the writes drained. Each refresh now assigns the buttons their final state exactly once.
 - **Fast Batch no longer re-exports edited or re-rooted posts every run**: some posts (edited tweets, and thread replies that re-root to the thread's first tweet on expansion) end up with a different canonical id than the one the bookmarks feed lists, so the dedup history — which only stored the canonical id — never matched them again and they re-exported on every run. Fast Batch now remembers both ids, so these posts are correctly skipped once exported.
 

--- a/src/background/batch-sink.ts
+++ b/src/background/batch-sink.ts
@@ -95,10 +95,48 @@ export function buildCombined(format: BatchFormat, docs: Document[], opts: Forma
   }
 }
 
+// Download pacing: a big batch can fire thousands of downloads (a Super Fast
+// run alone writes 1000s of files, plus images). Unthrottled, they all hit
+// Chrome's browser process at once — data-URL decode, downloads-UI updates,
+// history-DB inserts, disk writes — and the whole browser janks until the
+// queue drains. A small in-flight cap lets disk/network set the pace while
+// Chrome stays responsive. Failures resolve rather than reject — a batch never
+// dies on one bad file, matching the old fire-and-forget behavior.
+const MAX_INFLIGHT_DOWNLOADS = 8;
+let inflight = 0;
+const waiting: (() => void)[] = [];
+
+function downloadThrottled(options: chrome.downloads.DownloadOptions): Promise<void> {
+  return new Promise((resolve) => {
+    const finish = (): void => {
+      inflight--;
+      resolve();
+      waiting.shift()?.();
+    };
+    const start = (): void => {
+      inflight++;
+      chrome.downloads.download(options, (id) => {
+        if (chrome.runtime.lastError || id === undefined) return finish();
+        const onChanged = (delta: chrome.downloads.DownloadDelta): void => {
+          const state = delta.state?.current;
+          if (delta.id === id && (state === 'complete' || state === 'interrupted')) {
+            chrome.downloads.onChanged.removeListener(onChanged);
+            finish();
+          }
+        };
+        chrome.downloads.onChanged.addListener(onChanged);
+      });
+    };
+    if (inflight < MAX_INFLIGHT_DOWNLOADS) start();
+    else waiting.push(start);
+  });
+}
+
 // Generic data-URL download into the job folder. Used for the Markdown items,
-// the alternate per-item formats, and the combined file.
-export function downloadData(folder: string, filename: string, content: string, mime: string): void {
-  chrome.downloads.download({
+// the alternate per-item formats, and the combined file. Resolves once the
+// file is written (or failed), so callers get backpressure.
+export async function downloadData(folder: string, filename: string, content: string, mime: string): Promise<void> {
+  await downloadThrottled({
     url: `data:${mime};charset=utf-8,` + encodeURIComponent(content),
     filename: sanitizeFilePath(`${folder}/${filename}`),
     saveAs: false,
@@ -108,27 +146,31 @@ export function downloadData(folder: string, filename: string, content: string, 
 // Folder sink (ADR 0002 #11): the item's Markdown plus any local images, all
 // under the job's downloads subfolder. Image paths already embed the item's own
 // media dir; Chrome uniquifies any residual conflict.
-export function downloadItem(
+export async function downloadItem(
   folder: string,
   filename: string,
   markdown: string,
   images?: { url: string; filename: string }[]
-): void {
+): Promise<void> {
+  const writes: Promise<void>[] = [];
   for (const img of images ?? []) {
     if (!img || typeof img.url !== 'string' || !isAllowedImageUrl(img.url)) continue;
-    chrome.downloads.download({
-      url: img.url,
-      filename: sanitizeFilePath(`${folder}/${img.filename}`),
-      saveAs: false,
-    });
+    writes.push(
+      downloadThrottled({
+        url: img.url,
+        filename: sanitizeFilePath(`${folder}/${img.filename}`),
+        saveAs: false,
+      })
+    );
   }
-  downloadData(folder, filename, markdown, 'text/markdown');
+  writes.push(downloadData(folder, filename, markdown, 'text/markdown'));
+  await Promise.all(writes);
 }
 
 // Write one item's file in the chosen format. Markdown is the postProcessed
 // output (+ local images); other formats are derived from the AST. Images only
 // attach to Markdown. CSV never reaches this (it's always combined).
-export function writePerItem(
+export async function writePerItem(
   folder: string,
   format: BatchFormat,
   filename: string,
@@ -136,20 +178,20 @@ export function writePerItem(
   images: { url: string; filename: string }[] | undefined,
   doc: Document | undefined,
   settings: Settings
-): void {
+): Promise<void> {
   if (format === 'md' || !doc) {
-    downloadItem(folder, filename, markdown, images);
+    await downloadItem(folder, filename, markdown, images);
     return;
   }
   const built = buildFormatExport(format as ExportFormat, docToExtracted(doc), formatOptionsFrom(settings));
   const outName = filename.replace(/\.md$/i, '') + '.' + built.ext;
-  downloadData(folder, outName, built.content, built.mime);
+  await downloadData(folder, outName, built.content, built.mime);
 }
 
 // JSON sink (ADR 0002 #11): one data.json per job with metadata, failures, and
 // every successful item's AST. Written for cancelled jobs too — partial is
 // honest since the matching files are already on disk.
-export function writeJsonManifest(folder: string, meta: JobMeta, items: StoredItem[]): void {
+export async function writeJsonManifest(folder: string, meta: JobMeta, items: StoredItem[]): Promise<void> {
   const manifest = {
     generator: 'xclipper-batch',
     jobId: meta.jobId,
@@ -159,7 +201,7 @@ export function writeJsonManifest(folder: string, meta: JobMeta, items: StoredIt
     failures: meta.failures,
     items,
   };
-  chrome.downloads.download({
+  await downloadThrottled({
     url: 'data:application/json;charset=utf-8,' + encodeURIComponent(JSON.stringify(manifest, null, 2)),
     filename: sanitizeFilePath(`${folder}/data.json`),
     saveAs: false,
@@ -169,15 +211,15 @@ export function writeJsonManifest(folder: string, meta: JobMeta, items: StoredIt
 // Combined sink: one file for the whole batch in the chosen format —
 // x-compilation-<date>.<ext>. Written when output is 'both'/'combined' (and
 // always for CSV, which has no per-item form).
-export function writeCombined(
+export async function writeCombined(
   folder: string,
   format: BatchFormat,
   docs: Document[],
   settings: Settings
-): void {
+): Promise<void> {
   const built = buildCombined(format, docs, formatOptionsFrom(settings));
   const d = new Date();
   const stamp =
     `${d.getFullYear()}${String(d.getMonth() + 1).padStart(2, '0')}` + String(d.getDate()).padStart(2, '0');
-  downloadData(folder, `x-compilation-${stamp}.${built.ext}`, built.content, built.mime);
+  await downloadData(folder, `x-compilation-${stamp}.${built.ext}`, built.content, built.mime);
 }

--- a/src/background/batch.ts
+++ b/src/background/batch.ts
@@ -294,7 +294,7 @@ async function handleItemResult(
   if (outcome.success && filename) {
     // 'combined' writes nothing per item — the one file is built at finalize.
     if (effectiveOutput(job) !== 'combined') {
-      writePerItem(
+      await writePerItem(
         advanced.folder,
         job.format ?? 'md',
         filename,
@@ -394,14 +394,14 @@ async function finalize(job: BatchJob): Promise<void> {
   try {
     const items = await takeStoredItems(job);
     if (items.length > 0) {
-      writeJsonManifest(
+      await writeJsonManifest(
         job.folder,
         { jobId: job.id, status: job.status, completed: job.completed, failures: job.failures },
         items
       );
       const out = effectiveOutput(job);
       if (out === 'both' || out === 'combined') {
-        writeCombined(job.folder, job.format ?? 'md', items.map((i) => i.doc), await loadSettings());
+        await writeCombined(job.folder, job.format ?? 'md', items.map((i) => i.doc), await loadSettings());
       }
     }
   } catch (err) {

--- a/src/background/fast-batch.ts
+++ b/src/background/fast-batch.ts
@@ -632,7 +632,7 @@ async function runFastBatchExport(opts: FastBatchOptions = {}): Promise<FastBatc
       stubFilenames.push(filename.toLowerCase());
       if (output !== 'combined') {
         const stubFolder = `${folder}/${INCOMPLETE_SUBFOLDER}`;
-        writePerItem(stubFolder, format, filename, result.markdown, result.images, doc, settings);
+        await writePerItem(stubFolder, format, filename, result.markdown, result.images, doc, settings);
       }
       if (feedId) nextIncomplete.add(feedId);
       incomplete++;
@@ -640,7 +640,7 @@ async function runFastBatchExport(opts: FastBatchOptions = {}): Promise<FastBatc
       const filename = uniqueFilename(usedFilenames, result.filename);
       usedFilenames.push(filename.toLowerCase());
       if (output !== 'combined') {
-        writePerItem(folder, format, filename, result.markdown, result.images, doc, settings);
+        await writePerItem(folder, format, filename, result.markdown, result.images, doc, settings);
       }
       items.push({ url: doc.metadata.sourceUrl, filename, doc });
       // Ledger BOTH ids the post can appear under, so the next run's feed dedups
@@ -656,13 +656,13 @@ async function runFastBatchExport(opts: FastBatchOptions = {}): Promise<FastBatc
   }
 
   if (items.length > 0) {
-    writeJsonManifest(
+    await writeJsonManifest(
       folder,
       { jobId: `fast-${now.getTime()}`, status: 'done', completed: items.length, failures: [] },
       items
     );
     if (output === 'both' || output === 'combined') {
-      writeCombined(folder, format, items.map((i) => i.doc), settings);
+      await writeCombined(folder, format, items.map((i) => i.doc), settings);
     }
     await chrome.storage.local.set({ [EXPORTED_LEDGER_KEY]: ledgerArr });
     void recordExport();

--- a/src/popup/batch-ui.ts
+++ b/src/popup/batch-ui.ts
@@ -165,14 +165,21 @@ function setButton(label: string, enabled: boolean, tooltip: string): void {
 // Refresh the action button for the active tab. Counts only apply when the
 // current page matches the tab's source; otherwise the button points the
 // user at the right page.
+// Early-return branches of refreshIdleUi: no dedup info applies — hide the row
+// and grey both reset buttons together. Each branch assigns the buttons' FINAL
+// state exactly once (here, or after the main paths' awaits); a transient
+// "default disabled" at the top would get painted whenever the awaited storage
+// read is slow — e.g. right after a big export, while Chrome is still flushing
+// hundreds of downloads — making the buttons flicker every poll tick (#87).
+function hideDedupAndResets(): void {
+  batchDedupRow.classList.add('hidden');
+  btnBatchResetQueue.disabled = true;
+  btnBatchReset.disabled = true;
+}
+
 async function refreshIdleUi(): Promise<void> {
   appendable = false;
   openTarget = undefined;
-  // Reset buttons are always shown (stacked beside Export); default them to
-  // disabled so early-return branches leave them greyed, and the main/fast
-  // paths re-enable as appropriate below.
-  btnBatchResetQueue.disabled = true;
-  btnBatchReset.disabled = true;
 
   // Fast Batch (armed via the red toggle) overrides per-page gating: it fetches
   // bookmarks through the GraphQL session, so it doesn't need the bookmarks page
@@ -180,7 +187,7 @@ async function refreshIdleUi(): Promise<void> {
   if (getFastMode()) {
     // Selection and Timeline aren't Fast-compatible (no GET-paginated feed).
     if (activeTab === 'selection' || activeTab === 'timeline') {
-      batchDedupRow.classList.add('hidden');
+      hideDedupAndResets();
       setButton(
         activeTab === 'timeline'
           ? t('btn_batch_timeline', 'Export timeline')
@@ -226,7 +233,7 @@ async function refreshIdleUi(): Promise<void> {
   // (the same situation Single export reports). Every batch source needs it,
   // so surface the same "reload the page" hint rather than a misleading state.
   if (unreachable && pageIsX) {
-    batchDedupRow.classList.add('hidden');
+    hideDedupAndResets();
     const label =
       activeTab === 'bookmarks' ? t('btn_batch', 'Export bookmarks')
         : activeTab === 'profile' ? t('btn_batch_profile', 'Export posts')
@@ -241,7 +248,7 @@ async function refreshIdleUi(): Promise<void> {
   }
 
   if (activeTab === 'selection') {
-    batchDedupRow.classList.add('hidden');
+    hideDedupAndResets();
     setButton(
       t('btn_batch_select', 'Select tweets…'),
       pageIsX,
@@ -253,7 +260,7 @@ async function refreshIdleUi(): Promise<void> {
   }
 
   if (activeTab === 'bookmarks' && source !== 'bookmarks') {
-    batchDedupRow.classList.add('hidden');
+    hideDedupAndResets();
     openTarget = OPEN_URLS.bookmarks;
     setButton(
       t('btn_batch_go_bookmarks', 'Open Bookmarks'),
@@ -263,7 +270,7 @@ async function refreshIdleUi(): Promise<void> {
     return;
   }
   if (activeTab === 'profile' && source !== 'profile') {
-    batchDedupRow.classList.add('hidden');
+    hideDedupAndResets();
     setButton(
       t('btn_batch_profile', 'Export posts'),
       false,
@@ -272,7 +279,7 @@ async function refreshIdleUi(): Promise<void> {
     return;
   }
   if (activeTab === 'likes' && source !== 'likes') {
-    batchDedupRow.classList.add('hidden');
+    hideDedupAndResets();
     setButton(
       t('btn_batch_likes', 'Export likes'),
       false,
@@ -281,7 +288,7 @@ async function refreshIdleUi(): Promise<void> {
     return;
   }
   if (activeTab === 'timeline' && source !== 'timeline') {
-    batchDedupRow.classList.add('hidden');
+    hideDedupAndResets();
     openTarget = OPEN_URLS.timeline;
     setButton(
       t('btn_batch_go_timeline', 'Open Timeline'),


### PR DESCRIPTION
Closes #87.

Two fixes for the same root cause: a large batch (e.g. a 1750-item Super Fast export, #85) fired every `chrome.downloads.download` at once, slamming Chrome's browser process — data-URL decode, downloads-UI updates, history-DB inserts, disk writes — until the queue drained. Symptom one: the whole browser janked during the write phase. Symptom two: the popup's per-second `refreshIdleUi()` poll painted its transient "disabled" default while its storage read crawled under that I/O load, blinking the Reset buttons.

## Commit 1 — `fix(popup)`: reset buttons never move backwards mid-refresh

`refreshIdleUi()` preemptively greyed both reset buttons, then `await`ed a `chrome.storage.local` read before assigning the real state. Replaced the preemptive default with `hideDedupAndResets()` — every early-return branch (each already hid the dedup row) greys the buttons explicitly, and both main paths assign them exactly once, after their awaits, with the final value. Fixes the flicker regardless of storage latency, in Fast and Standard modes alike.

## Commit 2 — `perf(batch)`: throttle the download firehose

`downloadThrottled()` in `batch-sink.ts` caps in-flight downloads at 8 and resolves on each download's completion (failures resolve rather than reject, matching the old fire-and-forget tolerance). All sinks (`downloadData`, `downloadItem`, `writePerItem`, `writeJsonManifest`, `writeCombined`) now await it, so **both** batch paths get backpressure: the write phase paces itself to disk/network speed, Chrome stays usable throughout, and Fast Batch's "Writing files" progress reflects files actually on disk instead of a burst of enqueues. This also removes the I/O storm that made commit 1's flicker visible.

## Verification

- `npm run typecheck`, `npm test` (194 passed), `npm run build` — all green after each commit.
- Manual: run a large Super Fast export and use Chrome during the write phase — browser stays responsive, progress advances with real writes, reset buttons hold a steady state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)