### PR TITLE
refactor: split three large files along real seams (no behavior change)

### DIFF
--- a/src/background/fast-batch.ts
+++ b/src/background/fast-batch.ts
@@ -47,27 +47,18 @@ import {
   batchFolderName,
   uniqueFilename,
 } from './batch-state';
+import {
+  authedFetchJson,
+  classify,
+  GraphqlError,
+  hasAccess,
+  requestFastBatchAccess,
+  restoreSession,
+  startCapturing,
+  templates,
+} from './x-session';
 
-const GRAPHQL_FILTER = '*://x.com/i/api/graphql/*';
-const FAST_BATCH_ORIGINS = ['*://x.com/*'];
 const log = (...args: unknown[]): void => console.log('[xclipper fast-batch]', ...args);
-
-interface XAuth {
-  authorization: string;
-  csrf: string;
-}
-
-// Last seen auth headers + the most recent timeline request URLs (each carries
-// the rotating query-id + `features`, so replaying the observed request is
-// robust to X changing them). Persisted to chrome.storage.session so they
-// survive the MV3 service worker being torn down between runs (otherwise a
-// re-run minutes later would wrongly ask the user to re-capture). Session
-// storage is in-memory + cleared on browser close, appropriate for the auth.
-const SESSION_AUTH_KEY = 'fastBatchAuth';
-const SESSION_TEMPLATES_KEY = 'fastBatchTemplates';
-let auth: XAuth | null = null;
-const templates: Record<string, string> = {};
-let listening = false;
 
 // Polled progress for the popup (Fast Batch has no per-item worker tab, so it
 // can't reuse the Standard batch job model). Cancel is cooperative — the run
@@ -85,112 +76,7 @@ const setProgress = (p: Partial<FastBatchProgress>): void => {
   progress = { ...progress, ...p };
 };
 
-function captureHeaders(
-  details: chrome.webRequest.OnBeforeSendHeadersDetails
-): chrome.webRequest.BlockingResponse | undefined {
-  const headers = details.requestHeaders ?? [];
-  const get = (name: string): string | undefined =>
-    headers.find((h) => h.name.toLowerCase() === name)?.value;
-  const authorization = get('authorization');
-  const csrf = get('x-csrf-token');
-  if (authorization && csrf && (auth?.authorization !== authorization || auth?.csrf !== csrf)) {
-    auth = { authorization, csrf };
-    void chrome.storage.session.set({ [SESSION_AUTH_KEY]: auth });
-  }
-
-  const op = details.url.match(/\/graphql\/[^/]+\/(Bookmarks|Likes|UserTweets|TweetDetail)\b/)?.[1];
-  if (op && templates[op] !== details.url) {
-    templates[op] = details.url;
-    void chrome.storage.session.set({ [SESSION_TEMPLATES_KEY]: { ...templates } });
-  }
-  return undefined; // observe-only; never block/modify
-}
-
-// Reload captured auth + request templates from session storage into memory
-// (after a service-worker restart). Awaited before a run so the precondition
-// check sees them, not just fired-and-forgotten at init.
-async function restoreSession(): Promise<void> {
-  const r = await chrome.storage.session.get([SESSION_AUTH_KEY, SESSION_TEMPLATES_KEY]);
-  if (!auth && r[SESSION_AUTH_KEY]) auth = r[SESSION_AUTH_KEY] as XAuth;
-  const saved = r[SESSION_TEMPLATES_KEY] as Record<string, string> | undefined;
-  if (saved) for (const k of Object.keys(saved)) templates[k] ??= saved[k];
-}
-
-function startCapturing(): void {
-  if (listening) return;
-  // extraHeaders so the auth/csrf headers are reliably readable in MV3.
-  chrome.webRequest.onBeforeSendHeaders.addListener(
-    captureHeaders,
-    { urls: [GRAPHQL_FILTER], types: ['xmlhttprequest'] },
-    ['requestHeaders', 'extraHeaders']
-  );
-  listening = true;
-  log('capturing X GraphQL auth headers');
-}
-
-async function hasAccess(): Promise<boolean> {
-  return chrome.permissions.contains({ permissions: ['webRequest'], origins: FAST_BATCH_ORIGINS });
-}
-
-// Request the opt-in permission (the consent UI will call this). Resolves true
-// once granted; registers the capture listener on success.
-export async function requestFastBatchAccess(): Promise<boolean> {
-  const granted =
-    (await hasAccess()) ||
-    (await chrome.permissions.request({ permissions: ['webRequest'], origins: FAST_BATCH_ORIGINS }));
-  if (granted) startCapturing();
-  return granted;
-}
-
-// Replay a captured GraphQL request with the observed session auth. Cookies ride
-// along via credentials:'include' + the x.com host permission; the csrf header
-// must match the ct0 cookie, which is why we reuse the captured one.
-class HttpError extends Error {
-  constructor(readonly status: number) {
-    super(`X GraphQL responded ${status}`);
-  }
-}
-
-async function authedFetchJson(url: string): Promise<unknown> {
-  if (!auth) {
-    throw new Error('No X auth captured yet — open x.com (e.g. /i/bookmarks) once, then retry');
-  }
-  const res = await fetch(url, {
-    method: 'GET',
-    headers: {
-      authorization: auth.authorization,
-      'x-csrf-token': auth.csrf,
-      'x-twitter-active-user': 'yes',
-      'x-twitter-auth-type': 'OAuth2Session',
-      'content-type': 'application/json',
-    },
-    credentials: 'include',
-  });
-  if (!res.ok) throw new HttpError(res.status);
-  return res.json();
-}
-
-// X returns rate-limit / "Something went wrong" as a GraphQL errors envelope
-// (HTTP 200) just as often as a 429 — both mean "back off".
-class GraphqlError extends Error {
-  constructor(messages: string[]) {
-    super(`X GraphQL error: ${messages.join('; ')}`);
-  }
-}
-
 const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
-
-type ErrorKind = 'rate-limit' | 'transient' | 'permanent';
-
-// 429 and GraphQL error envelopes mean the account is being throttled — stop
-// spending the TweetDetail budget. 5xx / network blips are transient (retry). A
-// 4xx (deleted/protected tweet) or a mapping miss is permanent (keep the root).
-function classify(err: unknown): ErrorKind {
-  if (err instanceof HttpError) return err.status === 429 ? 'rate-limit' : err.status >= 500 ? 'transient' : 'permanent';
-  if (err instanceof GraphqlError) return 'rate-limit';
-  if (err instanceof TypeError) return 'transient'; // fetch network failure
-  return 'permanent';
-}
 
 const MAX_RETRIES = 2;
 const RETRY_BASE_MS = 1200;

--- a/src/background/x-session.ts
+++ b/src/background/x-session.ts
@@ -1,0 +1,134 @@
+// X session auth + authed transport for Fast Batch (ADR 0003). We never ask for
+// a password or a paid API key: with the opt-in `webRequest` permission granted,
+// we observe the auth headers the browser ALREADY sends on the user's own x.com
+// GraphQL requests, remember the request templates, and replay them ourselves.
+//
+// This is the impure edge (webRequest, fetch, permissions, storage); fast-batch
+// orchestrates on top of it. `templates` is exported live — captureHeaders keeps
+// it current and the orchestrator reads it to know which requests it can replay.
+
+const GRAPHQL_FILTER = '*://x.com/i/api/graphql/*';
+const FAST_BATCH_ORIGINS = ['*://x.com/*'];
+const log = (...args: unknown[]): void => console.log('[xclipper fast-batch]', ...args);
+
+interface XAuth {
+  authorization: string;
+  csrf: string;
+}
+
+// Last seen auth headers + the most recent timeline request URLs (each carries
+// the rotating query-id + `features`, so replaying the observed request is
+// robust to X changing them). Persisted to chrome.storage.session so they
+// survive the MV3 service worker being torn down between runs (otherwise a
+// re-run minutes later would wrongly ask the user to re-capture). Session
+// storage is in-memory + cleared on browser close, appropriate for the auth.
+const SESSION_AUTH_KEY = 'fastBatchAuth';
+const SESSION_TEMPLATES_KEY = 'fastBatchTemplates';
+let auth: XAuth | null = null;
+export const templates: Record<string, string> = {};
+let listening = false;
+
+function captureHeaders(
+  details: chrome.webRequest.OnBeforeSendHeadersDetails
+): chrome.webRequest.BlockingResponse | undefined {
+  const headers = details.requestHeaders ?? [];
+  const get = (name: string): string | undefined =>
+    headers.find((h) => h.name.toLowerCase() === name)?.value;
+  const authorization = get('authorization');
+  const csrf = get('x-csrf-token');
+  if (authorization && csrf && (auth?.authorization !== authorization || auth?.csrf !== csrf)) {
+    auth = { authorization, csrf };
+    void chrome.storage.session.set({ [SESSION_AUTH_KEY]: auth });
+  }
+
+  const op = details.url.match(/\/graphql\/[^/]+\/(Bookmarks|Likes|UserTweets|TweetDetail)\b/)?.[1];
+  if (op && templates[op] !== details.url) {
+    templates[op] = details.url;
+    void chrome.storage.session.set({ [SESSION_TEMPLATES_KEY]: { ...templates } });
+  }
+  return undefined; // observe-only; never block/modify
+}
+
+// Reload captured auth + request templates from session storage into memory
+// (after a service-worker restart). Awaited before a run so the precondition
+// check sees them, not just fired-and-forgotten at init.
+export async function restoreSession(): Promise<void> {
+  const r = await chrome.storage.session.get([SESSION_AUTH_KEY, SESSION_TEMPLATES_KEY]);
+  if (!auth && r[SESSION_AUTH_KEY]) auth = r[SESSION_AUTH_KEY] as XAuth;
+  const saved = r[SESSION_TEMPLATES_KEY] as Record<string, string> | undefined;
+  if (saved) for (const k of Object.keys(saved)) templates[k] ??= saved[k];
+}
+
+export function startCapturing(): void {
+  if (listening) return;
+  // extraHeaders so the auth/csrf headers are reliably readable in MV3.
+  chrome.webRequest.onBeforeSendHeaders.addListener(
+    captureHeaders,
+    { urls: [GRAPHQL_FILTER], types: ['xmlhttprequest'] },
+    ['requestHeaders', 'extraHeaders']
+  );
+  listening = true;
+  log('capturing X GraphQL auth headers');
+}
+
+export async function hasAccess(): Promise<boolean> {
+  return chrome.permissions.contains({ permissions: ['webRequest'], origins: FAST_BATCH_ORIGINS });
+}
+
+// Request the opt-in permission (the consent UI will call this). Resolves true
+// once granted; registers the capture listener on success.
+export async function requestFastBatchAccess(): Promise<boolean> {
+  const granted =
+    (await hasAccess()) ||
+    (await chrome.permissions.request({ permissions: ['webRequest'], origins: FAST_BATCH_ORIGINS }));
+  if (granted) startCapturing();
+  return granted;
+}
+
+// Replay a captured GraphQL request with the observed session auth. Cookies ride
+// along via credentials:'include' + the x.com host permission; the csrf header
+// must match the ct0 cookie, which is why we reuse the captured one.
+class HttpError extends Error {
+  constructor(readonly status: number) {
+    super(`X GraphQL responded ${status}`);
+  }
+}
+
+export async function authedFetchJson(url: string): Promise<unknown> {
+  if (!auth) {
+    throw new Error('No X auth captured yet — open x.com (e.g. /i/bookmarks) once, then retry');
+  }
+  const res = await fetch(url, {
+    method: 'GET',
+    headers: {
+      authorization: auth.authorization,
+      'x-csrf-token': auth.csrf,
+      'x-twitter-active-user': 'yes',
+      'x-twitter-auth-type': 'OAuth2Session',
+      'content-type': 'application/json',
+    },
+    credentials: 'include',
+  });
+  if (!res.ok) throw new HttpError(res.status);
+  return res.json();
+}
+
+// X returns rate-limit / "Something went wrong" as a GraphQL errors envelope
+// (HTTP 200) just as often as a 429 — both mean "back off".
+export class GraphqlError extends Error {
+  constructor(messages: string[]) {
+    super(`X GraphQL error: ${messages.join('; ')}`);
+  }
+}
+
+export type ErrorKind = 'rate-limit' | 'transient' | 'permanent';
+
+// 429 and GraphQL error envelopes mean the account is being throttled — stop
+// spending the TweetDetail budget. 5xx / network blips are transient (retry). A
+// 4xx (deleted/protected tweet) or a mapping miss is permanent (keep the root).
+export function classify(err: unknown): ErrorKind {
+  if (err instanceof HttpError) return err.status === 429 ? 'rate-limit' : err.status >= 500 ? 'transient' : 'permanent';
+  if (err instanceof GraphqlError) return 'rate-limit';
+  if (err instanceof TypeError) return 'transient'; // fetch network failure
+  return 'permanent';
+}

--- a/src/content/injector.ts
+++ b/src/content/injector.ts
@@ -2,6 +2,9 @@
 // action bar. Clicking opens the tweet's permalink in a new tab with the
 // `#xclipper=1` marker, which the main content script's bootstrap handles.
 
+import { getStatusUrl, normalizeStatusUrl } from './status-url';
+import { decorateSelection, enterSelection, exitSelection } from './selection';
+
 const BUTTON_ATTR = 'data-xclipper-injected';
 let decorated = new WeakSet<Element>();
 
@@ -84,36 +87,6 @@ function buildIcon(): SVGElement {
   svg.appendChild(path);
 
   return svg;
-}
-
-function normalizeStatusUrl(url: string): string | null {
-  const m = url.match(/^(https?:\/\/(?:www\.)?x\.com\/[^/]+\/status\/\d+)/);
-  return m ? m[1] : null;
-}
-
-function getStatusUrl(article: Element): string | null {
-  // On a /status/<id> permalink page, the URL bar is authoritative for the
-  // *outer* tweet. The article DOM may contain a quoted tweet whose own
-  // <time> link appears earlier in DOM order than the main tweet's — picking
-  // the first time-link there would return the quoted tweet's URL.
-  // So if the article element references the page's status id anywhere, trust
-  // the URL bar instead of walking the DOM.
-  if (window.location.pathname.includes('/status/')) {
-    const pageUrl = normalizeStatusUrl(window.location.href);
-    const id = pageUrl?.match(/status\/(\d+)/)?.[1];
-    if (pageUrl && id && article.querySelector(`a[href*="/status/${id}"]`)) {
-      return pageUrl;
-    }
-  }
-
-  const timeLink = article.querySelector('a[href*="/status/"] time');
-  const a = timeLink?.closest('a') as HTMLAnchorElement | null;
-  if (a?.href) {
-    const norm = normalizeStatusUrl(a.href);
-    if (norm) return norm;
-  }
-  const anyStatus = article.querySelector('a[href*="/status/"]') as HTMLAnchorElement | null;
-  return anyStatus?.href ? normalizeStatusUrl(anyStatus.href) : null;
 }
 
 function openWithMarker(
@@ -376,190 +349,8 @@ function harvestTimeline(): HarvestSource {
   return source;
 }
 
-// ─── Selection mode (ADR 0002, Phase C) ──────────────────────────────
-// Toggled from the popup on any timeline: overlay a check mark on each tweet
-// cell and a floating bar with the count + Export. Selection is keyed by
-// permalink, so it survives X's cell virtualization; checks are re-painted
-// by the mutation observer as cells re-mount.
-
-const SELECT_MARK_ATTR = 'data-xclipper-select';
-const SELECTED_ATTR = 'data-xclipper-selected';
-const ACCENT = 'rgb(14,165,233)';
-
-let selectionMode = false;
-const selectedUrls = new Set<string>();
-let selectionBar: HTMLElement | null = null;
-let selectionCountEl: HTMLElement | null = null;
-
-function syncMark(mark: HTMLElement, selected: boolean): void {
-  mark.textContent = selected ? '✓' : '';
-  mark.style.background = selected ? ACCENT : 'rgba(15,20,25,0.55)';
-  mark.style.borderColor = selected ? ACCENT : '#fff';
-}
-
-function decorateSelection(): void {
-  if (!selectionMode) return;
-  for (const article of document.querySelectorAll('article[role="article"]')) {
-    const url = getStatusUrl(article);
-    if (!url) continue;
-    let mark = article.querySelector(`[${SELECT_MARK_ATTR}]`) as HTMLElement | null;
-    if (!mark) {
-      const host = article as HTMLElement;
-      if (getComputedStyle(host).position === 'static') host.style.position = 'relative';
-      mark = document.createElement('div');
-      mark.setAttribute(SELECT_MARK_ATTR, '1');
-      mark.style.cssText = [
-        'position:absolute',
-        'top:10px',
-        'right:10px',
-        'width:22px',
-        'height:22px',
-        'border-radius:9999px',
-        'border:2px solid #fff',
-        'box-shadow:0 1px 4px rgba(0,0,0,0.4)',
-        'color:#fff',
-        'font:700 14px/18px system-ui,sans-serif',
-        'text-align:center',
-        'cursor:pointer',
-        'z-index:10',
-        'user-select:none',
-      ].join(';');
-      mark.addEventListener('click', (e) => {
-        e.stopPropagation();
-        e.preventDefault();
-        const fresh = getStatusUrl(article) || url;
-        if (selectedUrls.has(fresh)) {
-          selectedUrls.delete(fresh);
-          article.removeAttribute(SELECTED_ATTR);
-        } else {
-          selectedUrls.add(fresh);
-          article.setAttribute(SELECTED_ATTR, '1');
-        }
-        syncMark(mark as HTMLElement, selectedUrls.has(fresh));
-        updateSelectionBar();
-      });
-      article.appendChild(mark);
-    }
-    // Cells get recycled by the virtualizer — re-sync visuals from state.
-    const isSelected = selectedUrls.has(url);
-    syncMark(mark, isSelected);
-    if (isSelected) article.setAttribute(SELECTED_ATTR, '1');
-    else article.removeAttribute(SELECTED_ATTR);
-  }
-}
-
-function updateSelectionBar(): void {
-  if (!selectionCountEl) return;
-  // Lead with an instruction so it's obvious what mode this is; switch to the
-  // running count once the user starts picking tweets.
-  selectionCountEl.textContent =
-    selectedUrls.size === 0
-      ? chrome.i18n.getMessage('batch_bar_hint') || 'Tap tweets to select'
-      : `${selectedUrls.size} ${chrome.i18n.getMessage('batch_bar_selected') || 'selected'}`;
-}
-
-function barButton(label: string, solid: boolean, onClick: () => void): HTMLElement {
-  const b = document.createElement('button');
-  b.type = 'button';
-  b.textContent = label;
-  b.style.cssText = [
-    'font:600 14px/1 system-ui,sans-serif',
-    'padding:10px 18px',
-    'border-radius:10px',
-    'cursor:pointer',
-    'white-space:nowrap',
-    solid ? `background:${ACCENT};border:1px solid ${ACCENT};color:#fff`
-          : 'background:transparent;border:1px solid rgba(255,255,255,0.5);color:#fff',
-  ].join(';');
-  b.addEventListener('click', (e) => {
-    e.stopPropagation();
-    onClick();
-  });
-  return b;
-}
-
-function enterSelection(): void {
-  if (selectionMode) return;
-  selectionMode = true;
-
-  selectionBar = document.createElement('div');
-  selectionBar.style.cssText = [
-    'position:fixed',
-    'bottom:28px',
-    'left:50%',
-    // Size to content (and cap to the viewport) so the centered bar never
-    // wraps to two lines — a fixed box at left:50% otherwise shrink-fits to
-    // only half the viewport width.
-    'width:max-content',
-    'max-width:calc(100vw - 24px)',
-    // Start a touch lower and transparent so the bar slides up into view
-    // (revealed via requestAnimationFrame below) instead of appearing
-    // silently where a scrolling user wouldn't notice it.
-    'transform:translateX(-50%) translateY(16px)',
-    'opacity:0',
-    'transition:opacity .22s ease, transform .22s ease',
-    'display:flex',
-    'align-items:center',
-    'gap:14px',
-    'background:rgba(15,20,25,0.97)',
-    'color:#fff',
-    'padding:14px 20px',
-    'border-radius:14px',
-    // Accent ring + deep shadow so it stands clear of the timeline.
-    `box-shadow:0 8px 28px rgba(0,0,0,0.45), 0 0 0 1px ${ACCENT}`,
-    'z-index:2147483647',
-    'font:600 15px/1.2 system-ui,sans-serif',
-  ].join(';');
-
-  selectionCountEl = document.createElement('span');
-  selectionBar.appendChild(selectionCountEl);
-  selectionBar.appendChild(
-    barButton(chrome.i18n.getMessage('batch_bar_export') || 'Export', true, () => {
-      if (selectedUrls.size === 0) return;
-      try {
-        chrome.runtime.sendMessage(
-          { action: 'BATCH_START', urls: Array.from(selectedUrls), origin: 'selection' },
-          (resp) => {
-            void chrome.runtime.lastError;
-            if (resp?.success) {
-              if (selectionCountEl) {
-                selectionCountEl.textContent =
-                  chrome.i18n.getMessage('batch_started') || 'Batch started';
-              }
-              setTimeout(exitSelection, 1200);
-            } else if (selectionCountEl) {
-              selectionCountEl.textContent = resp?.error || 'Could not start the batch.';
-            }
-          }
-        );
-      } catch {
-        /* extension context gone */
-      }
-    })
-  );
-  selectionBar.appendChild(barButton('✕', false, exitSelection));
-  document.body.appendChild(selectionBar);
-
-  updateSelectionBar();
-  decorateSelection();
-
-  // Next frame: animate from the hidden initial state into view.
-  requestAnimationFrame(() => {
-    if (!selectionBar) return;
-    selectionBar.style.opacity = '1';
-    selectionBar.style.transform = 'translateX(-50%) translateY(0)';
-  });
-}
-
-function exitSelection(): void {
-  selectionMode = false;
-  selectedUrls.clear();
-  document.querySelectorAll(`[${SELECT_MARK_ATTR}]`).forEach((m) => m.remove());
-  document.querySelectorAll(`[${SELECTED_ATTR}]`).forEach((a) => a.removeAttribute(SELECTED_ATTR));
-  selectionBar?.remove();
-  selectionBar = null;
-  selectionCountEl = null;
-}
+// Selection mode lives in ./selection (enter/exit/decorate); the injector just
+// wires it to the popup message + the mutation observer below.
 
 try {
   chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {

--- a/src/content/selection.ts
+++ b/src/content/selection.ts
@@ -1,0 +1,186 @@
+// Selection mode (ADR 0002, Phase C). Toggled from the popup on any timeline:
+// overlay a check mark on each tweet cell and a floating bar with the count +
+// Export. Selection is keyed by permalink, so it survives X's cell
+// virtualization; checks are re-painted by decorateSelection() (called from the
+// injector's mutation observer) as cells re-mount.
+
+import { getStatusUrl } from './status-url';
+
+const SELECT_MARK_ATTR = 'data-xclipper-select';
+const SELECTED_ATTR = 'data-xclipper-selected';
+const ACCENT = 'rgb(14,165,233)';
+
+let selectionMode = false;
+const selectedUrls = new Set<string>();
+let selectionBar: HTMLElement | null = null;
+let selectionCountEl: HTMLElement | null = null;
+
+function syncMark(mark: HTMLElement, selected: boolean): void {
+  mark.textContent = selected ? '✓' : '';
+  mark.style.background = selected ? ACCENT : 'rgba(15,20,25,0.55)';
+  mark.style.borderColor = selected ? ACCENT : '#fff';
+}
+
+export function decorateSelection(): void {
+  if (!selectionMode) return;
+  for (const article of document.querySelectorAll('article[role="article"]')) {
+    const url = getStatusUrl(article);
+    if (!url) continue;
+    let mark = article.querySelector(`[${SELECT_MARK_ATTR}]`) as HTMLElement | null;
+    if (!mark) {
+      const host = article as HTMLElement;
+      if (getComputedStyle(host).position === 'static') host.style.position = 'relative';
+      mark = document.createElement('div');
+      mark.setAttribute(SELECT_MARK_ATTR, '1');
+      mark.style.cssText = [
+        'position:absolute',
+        'top:10px',
+        'right:10px',
+        'width:22px',
+        'height:22px',
+        'border-radius:9999px',
+        'border:2px solid #fff',
+        'box-shadow:0 1px 4px rgba(0,0,0,0.4)',
+        'color:#fff',
+        'font:700 14px/18px system-ui,sans-serif',
+        'text-align:center',
+        'cursor:pointer',
+        'z-index:10',
+        'user-select:none',
+      ].join(';');
+      mark.addEventListener('click', (e) => {
+        e.stopPropagation();
+        e.preventDefault();
+        const fresh = getStatusUrl(article) || url;
+        if (selectedUrls.has(fresh)) {
+          selectedUrls.delete(fresh);
+          article.removeAttribute(SELECTED_ATTR);
+        } else {
+          selectedUrls.add(fresh);
+          article.setAttribute(SELECTED_ATTR, '1');
+        }
+        syncMark(mark as HTMLElement, selectedUrls.has(fresh));
+        updateSelectionBar();
+      });
+      article.appendChild(mark);
+    }
+    // Cells get recycled by the virtualizer — re-sync visuals from state.
+    const isSelected = selectedUrls.has(url);
+    syncMark(mark, isSelected);
+    if (isSelected) article.setAttribute(SELECTED_ATTR, '1');
+    else article.removeAttribute(SELECTED_ATTR);
+  }
+}
+
+function updateSelectionBar(): void {
+  if (!selectionCountEl) return;
+  // Lead with an instruction so it's obvious what mode this is; switch to the
+  // running count once the user starts picking tweets.
+  selectionCountEl.textContent =
+    selectedUrls.size === 0
+      ? chrome.i18n.getMessage('batch_bar_hint') || 'Tap tweets to select'
+      : `${selectedUrls.size} ${chrome.i18n.getMessage('batch_bar_selected') || 'selected'}`;
+}
+
+function barButton(label: string, solid: boolean, onClick: () => void): HTMLElement {
+  const b = document.createElement('button');
+  b.type = 'button';
+  b.textContent = label;
+  b.style.cssText = [
+    'font:600 14px/1 system-ui,sans-serif',
+    'padding:10px 18px',
+    'border-radius:10px',
+    'cursor:pointer',
+    'white-space:nowrap',
+    solid ? `background:${ACCENT};border:1px solid ${ACCENT};color:#fff`
+          : 'background:transparent;border:1px solid rgba(255,255,255,0.5);color:#fff',
+  ].join(';');
+  b.addEventListener('click', (e) => {
+    e.stopPropagation();
+    onClick();
+  });
+  return b;
+}
+
+export function enterSelection(): void {
+  if (selectionMode) return;
+  selectionMode = true;
+
+  selectionBar = document.createElement('div');
+  selectionBar.style.cssText = [
+    'position:fixed',
+    'bottom:28px',
+    'left:50%',
+    // Size to content (and cap to the viewport) so the centered bar never
+    // wraps to two lines — a fixed box at left:50% otherwise shrink-fits to
+    // only half the viewport width.
+    'width:max-content',
+    'max-width:calc(100vw - 24px)',
+    // Start a touch lower and transparent so the bar slides up into view
+    // (revealed via requestAnimationFrame below) instead of appearing
+    // silently where a scrolling user wouldn't notice it.
+    'transform:translateX(-50%) translateY(16px)',
+    'opacity:0',
+    'transition:opacity .22s ease, transform .22s ease',
+    'display:flex',
+    'align-items:center',
+    'gap:14px',
+    'background:rgba(15,20,25,0.97)',
+    'color:#fff',
+    'padding:14px 20px',
+    'border-radius:14px',
+    // Accent ring + deep shadow so it stands clear of the timeline.
+    `box-shadow:0 8px 28px rgba(0,0,0,0.45), 0 0 0 1px ${ACCENT}`,
+    'z-index:2147483647',
+    'font:600 15px/1.2 system-ui,sans-serif',
+  ].join(';');
+
+  selectionCountEl = document.createElement('span');
+  selectionBar.appendChild(selectionCountEl);
+  selectionBar.appendChild(
+    barButton(chrome.i18n.getMessage('batch_bar_export') || 'Export', true, () => {
+      if (selectedUrls.size === 0) return;
+      try {
+        chrome.runtime.sendMessage(
+          { action: 'BATCH_START', urls: Array.from(selectedUrls), origin: 'selection' },
+          (resp) => {
+            void chrome.runtime.lastError;
+            if (resp?.success) {
+              if (selectionCountEl) {
+                selectionCountEl.textContent =
+                  chrome.i18n.getMessage('batch_started') || 'Batch started';
+              }
+              setTimeout(exitSelection, 1200);
+            } else if (selectionCountEl) {
+              selectionCountEl.textContent = resp?.error || 'Could not start the batch.';
+            }
+          }
+        );
+      } catch {
+        /* extension context gone */
+      }
+    })
+  );
+  selectionBar.appendChild(barButton('✕', false, exitSelection));
+  document.body.appendChild(selectionBar);
+
+  updateSelectionBar();
+  decorateSelection();
+
+  // Next frame: animate from the hidden initial state into view.
+  requestAnimationFrame(() => {
+    if (!selectionBar) return;
+    selectionBar.style.opacity = '1';
+    selectionBar.style.transform = 'translateX(-50%) translateY(0)';
+  });
+}
+
+export function exitSelection(): void {
+  selectionMode = false;
+  selectedUrls.clear();
+  document.querySelectorAll(`[${SELECT_MARK_ATTR}]`).forEach((m) => m.remove());
+  document.querySelectorAll(`[${SELECTED_ATTR}]`).forEach((a) => a.removeAttribute(SELECTED_ATTR));
+  selectionBar?.remove();
+  selectionBar = null;
+  selectionCountEl = null;
+}

--- a/src/content/status-url.ts
+++ b/src/content/status-url.ts
@@ -1,0 +1,34 @@
+// Canonicalize an x.com status permalink and locate one on a tweet <article>.
+// A shared content-script leaf: the injector (button placement, harvest, context
+// menu) and selection mode both need it, so it lives here to keep either from
+// importing the other.
+
+export function normalizeStatusUrl(url: string): string | null {
+  const m = url.match(/^(https?:\/\/(?:www\.)?x\.com\/[^/]+\/status\/\d+)/);
+  return m ? m[1] : null;
+}
+
+export function getStatusUrl(article: Element): string | null {
+  // On a /status/<id> permalink page, the URL bar is authoritative for the
+  // *outer* tweet. The article DOM may contain a quoted tweet whose own
+  // <time> link appears earlier in DOM order than the main tweet's — picking
+  // the first time-link there would return the quoted tweet's URL.
+  // So if the article element references the page's status id anywhere, trust
+  // the URL bar instead of walking the DOM.
+  if (window.location.pathname.includes('/status/')) {
+    const pageUrl = normalizeStatusUrl(window.location.href);
+    const id = pageUrl?.match(/status\/(\d+)/)?.[1];
+    if (pageUrl && id && article.querySelector(`a[href*="/status/${id}"]`)) {
+      return pageUrl;
+    }
+  }
+
+  const timeLink = article.querySelector('a[href*="/status/"] time');
+  const a = timeLink?.closest('a') as HTMLAnchorElement | null;
+  if (a?.href) {
+    const norm = normalizeStatusUrl(a.href);
+    if (norm) return norm;
+  }
+  const anyStatus = article.querySelector('a[href*="/status/"]') as HTMLAnchorElement | null;
+  return anyStatus?.href ? normalizeStatusUrl(anyStatus.href) : null;
+}

--- a/src/popup/batch-ui.ts
+++ b/src/popup/batch-ui.ts
@@ -180,53 +180,62 @@ function hideDedupAndResets(): void {
 async function refreshIdleUi(): Promise<void> {
   appendable = false;
   openTarget = undefined;
-
   // Fast Batch (armed via the red toggle) overrides per-page gating: it fetches
-  // bookmarks through the GraphQL session, so it doesn't need the bookmarks page
-  // loaded. Phase 1 is bookmarks-only — other tabs point back to Bookmarks.
+  // through the GraphQL session, so it doesn't need the source page loaded.
   if (getFastMode()) {
-    // Selection and Timeline aren't Fast-compatible (no GET-paginated feed).
-    if (activeTab === 'selection' || activeTab === 'timeline') {
-      hideDedupAndResets();
-      setButton(
-        activeTab === 'timeline'
-          ? t('btn_batch_timeline', 'Export timeline')
-          : t('btn_batch_select', 'Select tweets…'),
-        false,
-        activeTab === 'timeline'
-          ? t('btn_batch_fast_no_timeline', "Timeline isn't available in Fast — turn Fast off to export your home feed.")
-          : t('btn_batch_fast_no_selection', "Selection isn't available in Fast — turn Fast off to pick tweets by hand.")
-      );
-      return;
-    }
-    // bookmarks / profile / likes — Fast paginates from the top via cursor (no
-    // harvested collection), so "Reset queue" is always greyed; "Reset history"
-    // greys when the ledger is empty. The row stays visible so layout is stable.
-    const ledger = await loadLedgerSet();
-    btnBatchResetQueue.disabled = true;
-    btnBatchReset.disabled = ledger.size === 0;
-    batchDedupText.textContent =
-      ledger.size > 0 ? `${ledger.size} ${t('batch_already_exported', 'already exported')}` : '';
-    batchDedupRow.classList.remove('hidden');
-    let label: string;
-    let hint: string;
-    if (activeTab === 'profile') {
-      // Handle from the URL, not the injector — Fast doesn't need the page.
-      const handle = handleFromUrl(pageUrl);
-      label = `${t('btn_batch_profile', 'Export posts')}${handle ? ` @${handle}` : ''}`;
-      hint = t('btn_batch_fast_profile_hint', "Fetch this profile's own posts through your X session — much faster. Reposts are skipped.");
-    } else if (activeTab === 'likes') {
-      label = t('btn_batch_likes', 'Export likes');
-      hint = t('btn_batch_fast_likes_hint', 'Fetch your liked posts through your X session — much faster. Expands threads & articles.');
-    } else {
-      label = t('btn_batch', 'Export bookmarks');
-      hint = t('btn_batch_fast_hint', 'Fetch all your bookmarks through your X session — much faster. Expands threads & articles; stops politely if X rate-limits.');
-    }
-    setButton(label, !isFastActive(), hint);
-    void updateFastSteps(activeTab); // refresh the Page/Tweet readiness lights
+    await refreshFastIdle();
     return;
   }
+  await refreshStandardIdle();
+}
 
+// Fast-mode idle state. Phase 1 is bookmarks / profile / likes only — Selection
+// and Timeline have no GET-paginated feed, so they point back with a "turn Fast
+// off" hint. The dedup row stays visible so layout is stable.
+async function refreshFastIdle(): Promise<void> {
+  if (activeTab === 'selection' || activeTab === 'timeline') {
+    hideDedupAndResets();
+    setButton(
+      activeTab === 'timeline'
+        ? t('btn_batch_timeline', 'Export timeline')
+        : t('btn_batch_select', 'Select tweets…'),
+      false,
+      activeTab === 'timeline'
+        ? t('btn_batch_fast_no_timeline', "Timeline isn't available in Fast — turn Fast off to export your home feed.")
+        : t('btn_batch_fast_no_selection', "Selection isn't available in Fast — turn Fast off to pick tweets by hand.")
+    );
+    return;
+  }
+  // bookmarks / profile / likes — Fast paginates from the top via cursor (no
+  // harvested collection), so "Reset queue" is always greyed; "Reset history"
+  // greys when the ledger is empty.
+  const ledger = await loadLedgerSet();
+  btnBatchResetQueue.disabled = true;
+  btnBatchReset.disabled = ledger.size === 0;
+  batchDedupText.textContent =
+    ledger.size > 0 ? `${ledger.size} ${t('batch_already_exported', 'already exported')}` : '';
+  batchDedupRow.classList.remove('hidden');
+  let label: string;
+  let hint: string;
+  if (activeTab === 'profile') {
+    // Handle from the URL, not the injector — Fast doesn't need the page.
+    const handle = handleFromUrl(pageUrl);
+    label = `${t('btn_batch_profile', 'Export posts')}${handle ? ` @${handle}` : ''}`;
+    hint = t('btn_batch_fast_profile_hint', "Fetch this profile's own posts through your X session — much faster. Reposts are skipped.");
+  } else if (activeTab === 'likes') {
+    label = t('btn_batch_likes', 'Export likes');
+    hint = t('btn_batch_fast_likes_hint', 'Fetch your liked posts through your X session — much faster. Expands threads & articles.');
+  } else {
+    label = t('btn_batch', 'Export bookmarks');
+    hint = t('btn_batch_fast_hint', 'Fetch all your bookmarks through your X session — much faster. Expands threads & articles; stops politely if X rate-limits.');
+  }
+  setButton(label, !isFastActive(), hint);
+  void updateFastSteps(activeTab); // refresh the Page/Tweet readiness lights
+}
+
+// Standard (worker-tab) idle state: harvest the current page, then either gate
+// with a "where to go" hint or render the export/append button.
+async function refreshStandardIdle(): Promise<void> {
   const { source, handle, urls, unreachable } = await harvest();
 
   // After an extension reload the page still runs the old/no content script
@@ -259,6 +268,15 @@ async function refreshIdleUi(): Promise<void> {
     return;
   }
 
+  if (gateWrongSource(source)) return;
+
+  await renderOnSourceButton(urls, handle);
+}
+
+// When the active tab's source doesn't match the current page, show a greyed
+// button — or an "Open <page>" for the sources with a canonical URL. Returns
+// true when it rendered such a gate, so the caller stops.
+function gateWrongSource(source: HarvestResult['source']): boolean {
   if (activeTab === 'bookmarks' && source !== 'bookmarks') {
     hideDedupAndResets();
     openTarget = OPEN_URLS.bookmarks;
@@ -267,7 +285,7 @@ async function refreshIdleUi(): Promise<void> {
       true,
       t('btn_batch_open_bookmarks', 'Open your Bookmarks page, then scroll to load posts and export.')
     );
-    return;
+    return true;
   }
   if (activeTab === 'profile' && source !== 'profile') {
     hideDedupAndResets();
@@ -276,7 +294,7 @@ async function refreshIdleUi(): Promise<void> {
       false,
       t('btn_batch_open_profile', 'Open a profile page on x.com to export its posts. Reposts are skipped.')
     );
-    return;
+    return true;
   }
   if (activeTab === 'likes' && source !== 'likes') {
     hideDedupAndResets();
@@ -285,7 +303,7 @@ async function refreshIdleUi(): Promise<void> {
       false,
       t('btn_batch_open_likes', 'Open your Likes page on x.com to export the posts you have liked.')
     );
-    return;
+    return true;
   }
   if (activeTab === 'timeline' && source !== 'timeline') {
     hideDedupAndResets();
@@ -295,20 +313,22 @@ async function refreshIdleUi(): Promise<void> {
       true,
       t('btn_batch_open_timeline', 'Open your home timeline, then scroll to load posts and export.')
     );
-    return;
+    return true;
   }
+  return false;
+}
 
-  // On the running job's own source the button appends loaded items to its
-  // queue instead of starting a new job — bookmarks always; a profile only
-  // when it's the same handle (a different profile stays disabled).
+// On the active tab's own source: the button exports the loaded items, or APPENDS
+// them to a running same-source job (bookmarks always; a profile only when it's
+// the same handle). "N new" excludes the exported ledger and, while appending,
+// whatever the queue already holds.
+async function renderOnSourceButton(urls: string[], handle: string | undefined): Promise<void> {
   const onSameSourceJob =
     jobIsActive &&
     lastJob?.origin === activeTab &&
     (activeTab !== 'profile' || (lastJob?.handle ?? '') === (handle ?? ''));
   appendable = onSameSourceJob;
 
-  // While appending, also exclude what's already in the queue (not just the
-  // exported ledger), so the count reflects only items the queue lacks.
   const queued = onSameSourceJob ? new Set(lastJob?.queuedIds ?? []) : undefined;
   const ledger = await loadLedgerSet();
   const fresh = urls.filter((u) => {


### PR DESCRIPTION
Pure structural cleanup ahead of the Batch/popup redesign — each change moves code along a genuine seam, with logic preserved byte-for-byte. No behavior change; `tsc`, `npm test` (194), and `npm run build` are green after every commit.

### 1. `refactor(popup): split refreshIdleUi into named phases`
The 170-line `refreshIdleUi` becomes a small dispatcher over four focused functions:
- `refreshFastIdle` — Fast-mode idle state
- `refreshStandardIdle` — harvest + gate/render
- `gateWrongSource` — the repetitive "Open Bookmarks/Timeline/…" wrong-source gates
- `renderOnSourceButton` — the export/append button + reset-button state

(File nudges up ~20 lines from the added signatures/comments — the win is that no function is a 170-line monster anymore, which matters for the upcoming redesign.)

### 2. `refactor(content): extract selection mode and status-url helpers`
Selection mode (~180 lines) moves out of `injector.ts` into `content/selection.ts`, and the shared permalink helpers (`normalizeStatusUrl`/`getStatusUrl`) into a `content/status-url.ts` leaf both import. Clean DAG, no cycle: `injector → selection → status-url`, `injector → status-url`. esbuild inlines both back into the injector IIFE (bundle size unchanged). `injector.ts`: 640 → 431 lines.

### 3. `refactor(background): extract X session auth/transport from fast-batch`
The webRequest auth capture, session-storage persistence, permission request, authed GraphQL fetch, and error classification (~130 lines) move into `background/x-session.ts`. `fast-batch.ts` imports that surface and reads the live `templates` map; its orchestration stays put. `fast-batch.ts`: 831 → 717 lines.

## Verification
- `tsc --noEmit`, `npm test` (194/194), `npm run build` — all green.
- Bundle-checked: selection + status-url inlined into `injector.js`; auth into `background.js`; sizes unchanged.
- **Not exercised live** (needs the extension loaded against a logged-in X session): these are content-script / service-worker paths with no unit coverage. They're strict moves (logic and console output unchanged), so risk is low, but the selection overlay and a Fast Batch run are worth a smoke-test on load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)