### PR TITLE
feat(popup): add placeholder autocomplete to filename template field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ---
 ## [Unreleased]
 
+### Added
+
+- **Filename template placeholders now autocomplete as you type**: typing `{` in Settings → Filename template opens a filtered list of the available placeholders (`{date}`, `{datetime}`, `{handle}`, `{author}`, `{id}`, `{slug}`, `{type}`) — Arrow keys move, Enter, Tab or a click inserts the full `{name}`. Same typeahead the Obsidian **Tags** field already had. (#55)
+
 ---
 ## [2.7.0] - 2026-07-14
 

--- a/src/popup/dom.ts
+++ b/src/popup/dom.ts
@@ -96,3 +96,4 @@ export const btnTagsReset = document.getElementById('btn-obsidian-tags-reset') a
 export const tagsAutocomplete = document.getElementById('obsidian-tags-autocomplete') as HTMLDivElement;
 export const tagsFieldLabel = document.getElementById('obsidian-tags-label') as HTMLLabelElement;
 export const filenamePreview = document.getElementById('filename-preview') as HTMLElement;
+export const filenameAutocomplete = document.getElementById('filename-template-autocomplete') as HTMLDivElement;

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -486,7 +486,10 @@
                 </div>
               </span>
             </span>
-            <input type="text" id="txt-filename-template" class="field-input" autocomplete="off" spellcheck="false" placeholder="{handle}-{id}.md" data-i18n-placeholder="opt_filename_template_placeholder" />
+            <span class="field-with-popover">
+              <input type="text" id="txt-filename-template" class="field-input" autocomplete="off" spellcheck="false" placeholder="{handle}-{id}.md" data-i18n-placeholder="opt_filename_template_placeholder" />
+              <div id="filename-template-autocomplete" class="placeholder-autocomplete" role="listbox" hidden></div>
+            </span>
           </label>
           <div class="field-preview">
             <span class="field-preview-label" data-i18n="opt_filename_preview">Preview:</span>

--- a/src/popup/settings-form.ts
+++ b/src/popup/settings-form.ts
@@ -20,6 +20,7 @@ import {
   FRONTMATTER_FIELDS_OBSIDIAN,
   DEFAULT_TAGS_TEMPLATE,
   TAGS_PLACEHOLDERS,
+  FILENAME_PLACEHOLDERS,
 } from '../shared/post-process';
 import { attachPlaceholderAutocomplete } from './placeholder-autocomplete';
 import { updateFloodHint } from './fast-batch-ui';
@@ -49,6 +50,7 @@ import {
   tagsAutocomplete,
   tagsFieldLabel,
   filenamePreview,
+  filenameAutocomplete,
 } from './dom';
 
 // In-memory snapshot of field selections — the source of truth that gets
@@ -473,9 +475,30 @@ export function initSettingsForm(): void {
   txtDownloadFolder.addEventListener('blur', persistAll);
   txtObsidianFolder.addEventListener('change', persistAll);
   txtObsidianFolder.addEventListener('blur', persistAll);
-  txtFilenameTemplate.addEventListener('input', updateFilenamePreview);
+  // ─── Filename template: preview, autocomplete (`{` opens, filters as typed) ───
+  const filenameAutocompleteWidget = attachPlaceholderAutocomplete({
+    input: txtFilenameTemplate,
+    popover: filenameAutocomplete,
+    placeholders: FILENAME_PLACEHOLDERS,
+    onSelect: () => {
+      updateFilenamePreview();
+      persistAll();
+    },
+  });
+
+  txtFilenameTemplate.addEventListener('input', () => {
+    updateFilenamePreview();
+    filenameAutocompleteWidget.handleInput();
+  });
   txtFilenameTemplate.addEventListener('change', persistAll);
-  txtFilenameTemplate.addEventListener('blur', persistAll);
+  txtFilenameTemplate.addEventListener('blur', () => {
+    // Delay just enough to let an autocomplete click register before the popover
+    // is forced shut by the blur.
+    setTimeout(() => {
+      filenameAutocompleteWidget.close();
+      persistAll();
+    }, 120);
+  });
 
   // ─── ⓘ placeholder-list popovers (filename template, Obsidian tags) ───
   // Show the popover only while the cursor / keyboard focus is literally on the

--- a/tests/placeholder-autocomplete.test.ts
+++ b/tests/placeholder-autocomplete.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { attachPlaceholderAutocomplete } from '../src/popup/placeholder-autocomplete';
+import { FILENAME_PLACEHOLDERS } from '../src/shared/post-process';
+
+// Builds the field-with-popover DOM the filename-template and tags fields share,
+// wires the widget, and returns handles plus the widget's own input hook.
+function mount() {
+  document.body.innerHTML = `
+    <span class="field-with-popover">
+      <input type="text" id="inp" class="field-input" />
+      <div id="pop" class="placeholder-autocomplete" role="listbox" hidden></div>
+    </span>`;
+  const input = document.getElementById('inp') as HTMLInputElement;
+  const popover = document.getElementById('pop') as HTMLDivElement;
+  let selects = 0;
+  const widget = attachPlaceholderAutocomplete({
+    input,
+    popover,
+    placeholders: FILENAME_PLACEHOLDERS,
+    onSelect: () => {
+      selects += 1;
+    },
+  });
+  // Mirror settings-form.ts: the input listener drives handleInput().
+  input.addEventListener('input', () => widget.handleInput());
+  const type = (value: string): void => {
+    input.value = value;
+    input.setSelectionRange(value.length, value.length);
+    input.dispatchEvent(new Event('input'));
+  };
+  const options = (): string[] =>
+    [...popover.querySelectorAll('.placeholder-autocomplete-item')].map((b) => b.textContent ?? '');
+  return { input, popover, widget, type, options, selects: () => selects };
+}
+
+describe('placeholder autocomplete (filename template)', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('stays closed until a `{` trigger is typed', () => {
+    const { popover, type } = mount();
+    type('handle');
+    expect(popover.hidden).toBe(true);
+  });
+
+  it('opens with every filename placeholder when `{` is typed', () => {
+    const { popover, type, options } = mount();
+    type('{');
+    expect(popover.hidden).toBe(false);
+    expect(options()).toEqual(FILENAME_PLACEHOLDERS.map((p) => `{${p}}`));
+  });
+
+  it('filters the list by the fragment after `{`', () => {
+    const { type, options } = mount();
+    type('{da');
+    // `date` and `datetime` both start with "da"; nothing else does.
+    expect(options()).toEqual(['{date}', '{datetime}']);
+  });
+
+  it('closes once the placeholder is closed with `}`', () => {
+    const { popover, type } = mount();
+    type('{date}');
+    expect(popover.hidden).toBe(true);
+  });
+
+  it('inserts the chosen placeholder and fires onSelect on Enter', () => {
+    const { input, popover, type, selects } = mount();
+    type('{ha');
+    input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+    expect(input.value).toBe('{handle}');
+    expect(popover.hidden).toBe(true);
+    expect(selects()).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

Adds the `{` placeholder typeahead to the **Filename template** field, matching the existing autocomplete on the Obsidian tags field. Typing `{` opens a filtered list of the known placeholders (`date`, `datetime`, `handle`, `author`, `id`, `slug`, `type`); Arrow keys move, Enter/Tab/click insert `{name}` at the cursor.

The field already had substitution logic (`applyFilenameTemplate`/`buildFilename`) and the static ⓘ placeholder hint, so this only wires up the live typeahead — **no background or logic changes needed.**

## Changes

- **`src/popup/popup.html`** — wrapped the filename input in `.field-with-popover` and added the `#filename-template-autocomplete` popover, mirroring the tags field.
- **`src/popup/dom.ts`** — exported the new `filenameAutocomplete` element.
- **`src/popup/settings-form.ts`** — imported `FILENAME_PLACEHOLDERS`, attached `attachPlaceholderAutocomplete` to the filename input, and updated its `input`/`blur` handlers to drive the widget.
- **`tests/placeholder-autocomplete.test.ts`** — new jsdom test covering open-on-`{`, fragment filtering, close-on-`}`, and Enter-to-insert.

## Verification

- `tsc --noEmit` clean
- `npm run build` succeeds
- Full suite: **196 passed, 7 skipped** (5 new tests)
- Reused CSS uses descendant selectors, so wrapping the input doesn't affect layout.

Closes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)