### PR TITLE
fix(article): restore markdown emphasis, extract tables, and align Fast Batch output (2.7.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **Filename template placeholders now autocomplete as you type**: typing `{` in Settings → Filename template opens a filtered list of the available placeholders (`{date}`, `{datetime}`, `{handle}`, `{author}`, `{id}`, `{slug}`, `{type}`) — Arrow keys move, Enter, Tab or a click inserts the full `{name}`. Same typeahead the Obsidian **Tags** field already had. (#55)
+- **Tables in X Articles now export as tables**: an article table used to collapse into one unreadable run of concatenated cells (`LoopYou hand offUse it when…`). It now exports as a proper Markdown table — header row, columns and all — and as a real bordered table in PDF. Cells keep their bold, italic and links; a literal `|` is escaped and a line break inside a cell becomes a space so the row survives.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,16 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
-## [Unreleased]
+## [2.7.1] - 2026-08-02
 
 ### Added
 
 - **Filename template placeholders now autocomplete as you type**: typing `{` in Settings → Filename template opens a filtered list of the available placeholders (`{date}`, `{datetime}`, `{handle}`, `{author}`, `{id}`, `{slug}`, `{type}`) — Arrow keys move, Enter, Tab or a click inserts the full `{name}`. Same typeahead the Obsidian **Tags** field already had. (#55)
-- **Tables in X Articles now export as tables**: an article table used to collapse into one unreadable run of concatenated cells (`LoopYou hand offUse it when…`). It now exports as a proper Markdown table — header row, columns and all — and as a real bordered table in PDF. Cells keep their bold, italic and links; a literal `|` is escaped and a line break inside a cell becomes a space so the row survives.
-- **Fast Batch no longer drops code blocks and tables from articles**: in Auto and Super mode, every code block and table in an X Article was silently missing from the export — X sends those two as raw markdown rather than as structured content, and they were skipped. Both now come through, matching a normal export.
 
 ### Fixed
 
+- **Tables in X Articles now export as tables**: an article table used to collapse into one unreadable run of concatenated cells (`LoopYou hand offUse it when…`). It now exports as a proper Markdown table — header row, columns and all — and as a real bordered table in PDF. Cells keep their bold, italic and links; a literal `|` is escaped and a line break inside a cell becomes a space so the row survives.
+- **Fast Batch no longer drops code blocks and tables from articles**: in Auto and Super mode, every code block and table in an X Article was silently missing from the export — X sends those two as raw markdown rather than as structured content, and they were skipped. Both now come through, matching a normal export.
 - **Bold and italic no longer break when the author styled a trailing space**: X Article authors routinely bold a label together with the space after it, which produced `**Best used for: **Shorter tasks` — markdown ignores a closing `**` that follows whitespace, so the asterisks showed up literally instead of rendering bold. The space now moves outside the markers (`**Best used for:** Shorter tasks`). Same fix for italic, for both the normal and Fast Batch export paths. (Originally fixed in 1.2.0 and lost in the Content AST rewrite.)
 - **Fast Batch headings no longer come out bold**: X's article editor marks every heading's text bold, so Auto and Super exported `## **Getting started**` — asterisks around a line the `##` already makes a heading. The wrapper is dropped; bold on *part* of a heading is the author's own emphasis and stays.
 - **Fast Batch image links now match a normal export**: Auto and Super wrote the canonical image URL (`…/HMkRVmsaEAA3Dl5.jpg`) while a normal export wrote the sized variant (`…?format=jpg&name=large`), so the same post exported two ways produced two different files. Both now use the sized form.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **Bold and italic no longer break when the author styled a trailing space**: X Article authors routinely bold a label together with the space after it, which produced `**Best used for: **Shorter tasks` — markdown ignores a closing `**` that follows whitespace, so the asterisks showed up literally instead of rendering bold. The space now moves outside the markers (`**Best used for:** Shorter tasks`). Same fix for italic, for both the normal and Fast Batch export paths. (Originally fixed in 1.2.0 and lost in the Content AST rewrite.)
+- **Fast Batch headings no longer come out bold**: X's article editor marks every heading's text bold, so Auto and Super exported `## **Getting started**` — asterisks around a line the `##` already makes a heading. The wrapper is dropped; bold on *part* of a heading is the author's own emphasis and stays.
+- **Fast Batch image links now match a normal export**: Auto and Super wrote the canonical image URL (`…/HMkRVmsaEAA3Dl5.jpg`) while a normal export wrote the sized variant (`…?format=jpg&name=large`), so the same post exported two ways produced two different files. Both now use the sized form.
 - **Stray asterisks from empty bold runs removed**: X ends some article paragraphs with a bold zero-width joiner, which exported as a bare `****` — four asterisks with nothing visible between them. Emphasis that contains nothing but invisible characters now renders without the markers.
 
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Filename template placeholders now autocomplete as you type**: typing `{` in Settings → Filename template opens a filtered list of the available placeholders (`{date}`, `{datetime}`, `{handle}`, `{author}`, `{id}`, `{slug}`, `{type}`) — Arrow keys move, Enter, Tab or a click inserts the full `{name}`. Same typeahead the Obsidian **Tags** field already had. (#55)
 
+### Fixed
+
+- **Bold and italic no longer break when the author styled a trailing space**: X Article authors routinely bold a label together with the space after it, which produced `**Best used for: **Shorter tasks` — markdown ignores a closing `**` that follows whitespace, so the asterisks showed up literally instead of rendering bold. The space now moves outside the markers (`**Best used for:** Shorter tasks`). Same fix for italic, for both the normal and Fast Batch export paths. (Originally fixed in 1.2.0 and lost in the Content AST rewrite.)
+- **Stray asterisks from empty bold runs removed**: X ends some article paragraphs with a bold zero-width joiner, which exported as a bare `****` — four asterisks with nothing visible between them. Emphasis that contains nothing but invisible characters now renders without the markers.
+
 ---
 ## [2.7.0] - 2026-07-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Filename template placeholders now autocomplete as you type**: typing `{` in Settings → Filename template opens a filtered list of the available placeholders (`{date}`, `{datetime}`, `{handle}`, `{author}`, `{id}`, `{slug}`, `{type}`) — Arrow keys move, Enter, Tab or a click inserts the full `{name}`. Same typeahead the Obsidian **Tags** field already had. (#55)
 - **Tables in X Articles now export as tables**: an article table used to collapse into one unreadable run of concatenated cells (`LoopYou hand offUse it when…`). It now exports as a proper Markdown table — header row, columns and all — and as a real bordered table in PDF. Cells keep their bold, italic and links; a literal `|` is escaped and a line break inside a cell becomes a space so the row survives.
+- **Fast Batch no longer drops code blocks and tables from articles**: in Auto and Super mode, every code block and table in an X Article was silently missing from the export — X sends those two as raw markdown rather than as structured content, and they were skipped. Both now come through, matching a normal export.
 
 ### Fixed
 

--- a/docs/ast-schema.md
+++ b/docs/ast-schema.md
@@ -158,6 +158,19 @@ interface ThematicBreakNode { type: 'thematicBreak'; }
 - `CodeBlockNode.lang` is the fenced language hint when present.
 - `VideoNode.sourceUrl` is the playable media URL; `posterUrl` is the still-frame thumbnail. PDF and other static formats render the poster with a link to the source.
 
+### TableNode / TableRowNode / TableCellNode
+
+```ts
+interface TableNode     { type: 'table'; header?: TableRowNode; children: TableRowNode[]; }
+interface TableRowNode  { type: 'tableRow'; children: TableCellNode[]; }
+interface TableCellNode { type: 'tableCell'; children: InlineNode[]; }
+```
+
+- X Article tables. The `<th>` row becomes `header`; `children` holds the data rows only.
+- `header` is optional because a table can start straight into data rows. Markdown tables require a header, so `renderMarkdown` emits an empty one rather than promoting a data row and losing a line of content.
+- Cells hold inline content, not blocks — nothing in X's article editor can put a paragraph or a list inside a cell.
+- A cell renders to one markdown line: hard breaks collapse to spaces and literal `|` is escaped, since neither survives a GFM row.
+
 ## Inline nodes
 
 The inline taxonomy is intentionally minimal in v1. New inline types should be added only when an extraction case forces them (see the ADR's "minimum survivable" framing).

--- a/package-lock.json
+++ b/package-lock.json
@@ -2310,9 +2310,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.15",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
-      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -2380,9 +2380,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.16",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
-      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
       "dev": true,
       "funding": [
         {
@@ -2400,7 +2400,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "xclipper",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "xclipper",
-      "version": "2.7.0",
+      "version": "2.7.1",
       "license": "PolyForm-Noncommercial-1.0.0",
       "devDependencies": {
         "@puppeteer/browsers": "^3.0.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xclipper",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "description": "XClipper — free, source-available web clipper for X (Twitter). Download threads, posts, and articles as Markdown or PDF for Obsidian, research, and AI/RAG workflows. Works locally — no API, no accounts, no tracking.",
   "license": "PolyForm-Noncommercial-1.0.0",
   "private": true,

--- a/src/ast/render-markdown.ts
+++ b/src/ast/render-markdown.ts
@@ -10,6 +10,8 @@ import type {
   PollNode,
   LinkCardNode,
   ArticleCardNode,
+  TableNode,
+  TableCellNode,
 } from './types';
 
 // AST → markdown body, matching the shape produced by the legacy Turndown
@@ -315,6 +317,8 @@ function renderArticleBlock(block: Block): string {
       return `![${block.alt ?? 'Image'}](${block.url})`;
     case 'thematicBreak':
       return '---';
+    case 'table':
+      return renderTable(block);
     case 'blockquote':
       return block.children
         .map(renderArticleBlock)
@@ -331,4 +335,33 @@ function renderArticleBlock(block: Block): string {
     default:
       return '';
   }
+}
+
+// GFM table. The header row is required by the syntax, so a headerless table
+// gets an empty one — losing the borders is better than losing the rows.
+function renderTable(table: TableNode): string {
+  const width = Math.max(
+    table.header?.children.length ?? 0,
+    ...table.children.map((r) => r.children.length),
+    1
+  );
+  const row = (cells: string[]): string => {
+    const padded = [...cells, ...Array(width - cells.length).fill('')];
+    return `| ${padded.join(' | ')} |`;
+  };
+  const lines = [
+    row((table.header?.children ?? []).map(renderTableCell)),
+    row(Array(width).fill('---')),
+    ...table.children.map((r) => row(r.children.map(renderTableCell))),
+  ];
+  return lines.join('\n');
+}
+
+// A cell is a single line: hard breaks become spaces, and a literal pipe
+// would otherwise end the cell early.
+function renderTableCell(cell: TableCellNode): string {
+  return renderInlineForArticle(cell.children)
+    .replace(/\s*\n\s*/g, ' ')
+    .replace(/\|/g, '\\|')
+    .trim();
 }

--- a/src/ast/render-markdown.ts
+++ b/src/ast/render-markdown.ts
@@ -358,10 +358,13 @@ function renderTable(table: TableNode): string {
 }
 
 // A cell is a single line: hard breaks become spaces, and a literal pipe
-// would otherwise end the cell early.
+// would otherwise end the cell early. Backslashes are escaped first — escaping
+// only the pipe turns the author's `\` + `|` into `\\|`, which markdown reads
+// as an escaped backslash followed by a live pipe, splitting the row.
 function renderTableCell(cell: TableCellNode): string {
   return renderInlineForArticle(cell.children)
     .replace(/\s*\n\s*/g, ' ')
+    .replace(/\\/g, '\\\\')
     .replace(/\|/g, '\\|')
     .trim();
 }

--- a/src/ast/render-markdown.ts
+++ b/src/ast/render-markdown.ts
@@ -257,12 +257,28 @@ function renderInline(node: InlineNode, ctx: InlineContext): string {
       return `[${display}](${node.url})`;
     }
     case 'strong':
-      return `**${renderInlineNodes(node.children, ctx)}**`;
+      return wrapEmphasis(renderInlineNodes(node.children, ctx), '**');
     case 'emphasis':
-      return `*${renderInlineNodes(node.children, ctx)}*`;
+      return wrapEmphasis(renderInlineNodes(node.children, ctx), '*');
     case 'inlineCode':
       return `\`${node.value}\``;
   }
+}
+
+// X authors routinely style the trailing space of a run ("Best used for: "),
+// so the AST faithfully carries whitespace inside the emphasis. Markdown can't:
+// a closing delimiter preceded by whitespace isn't a delimiter at all, so
+// `**Best used for: **` renders as literal asterisks. Hoist edge whitespace
+// outside the markers; drop the markers when there's nothing visible left to
+// emphasize — X ends some article paragraphs with a bold zero-width joiner,
+// and a bold joiner is just two pairs of asterisks on screen. The invisible
+// characters themselves are kept: the AST says the author typed them.
+function wrapEmphasis(inner: string, marker: string): string {
+  const lead = inner.match(/^\s*/)![0];
+  const trail = inner.slice(lead.length).match(/\s*$/)![0];
+  const core = inner.slice(lead.length, inner.length - trail.length);
+  const visible = core.replace(/[\u200b-\u200d\u2060\ufeff]/g, '');
+  return visible ? `${lead}${marker}${core}${marker}${trail}` : inner;
 }
 
 // ─── Article body ───────────────────────────────────────────────────

--- a/src/ast/render-pdf-html.ts
+++ b/src/ast/render-pdf-html.ts
@@ -10,6 +10,8 @@ import type {
   PollNode,
   LinkCardNode,
   ArticleCardNode,
+  TableNode,
+  TableRowNode,
 } from './types';
 
 export interface RenderPdfHtmlOptions {
@@ -241,6 +243,8 @@ function renderArticleBlock(block: Block): string {
       return `<figure class="article-image"><img src="${escapeAttr(block.posterUrl)}" alt="${escapeAttr(block.alt || '')}"></figure>`;
     case 'thematicBreak':
       return '<hr>';
+    case 'table':
+      return renderTable(block);
     case 'articleCard':
       return renderArticleCard(block);
     case 'tweet':
@@ -248,6 +252,14 @@ function renderArticleBlock(block: Block): string {
     default:
       return '';
   }
+}
+
+function renderTable(table: TableNode): string {
+  const cells = (row: TableRowNode, tag: 'th' | 'td'): string =>
+    row.children.map((c) => `<${tag}>${renderInlines(c.children)}</${tag}>`).join('');
+  const head = table.header ? `<thead><tr>${cells(table.header, 'th')}</tr></thead>` : '';
+  const body = table.children.map((r) => `<tr>${cells(r, 'td')}</tr>`).join('');
+  return `<table>${head}<tbody>${body}</tbody></table>`;
 }
 
 function renderList(list: { ordered: boolean; children: { type: 'listItem'; children: Block[] }[] }): string {
@@ -366,6 +378,9 @@ const STYLES = `
 .article-body figure img{display:block;width:100%;border-radius:8px}
 .article-body figcaption{font-size:13px;color:#536471;text-align:center;margin-top:6px}
 .article-body hr{border:none;border-top:1px solid #eff3f4;margin:24px 0}
+.article-body table{border-collapse:collapse;width:100%;margin:0 0 16px;font-size:15px}
+.article-body th,.article-body td{border:1px solid #cfd9de;padding:8px 10px;text-align:left;vertical-align:top}
+.article-body th{background:#eff3f4;font-weight:700}
 .xclipper-root strong{font-weight:700}
 .xclipper-root em{font-style:italic}
 .xclipper-root img{max-width:100%;height:auto}

--- a/src/ast/types.ts
+++ b/src/ast/types.ts
@@ -29,6 +29,7 @@ export type Block =
   | BlockquoteNode
   | ImageNode
   | VideoNode
+  | TableNode
   | PollNode
   | LinkCardNode
   | ArticleCardNode
@@ -104,6 +105,25 @@ export interface VideoNode {
   posterUrl: string;
   sourceUrl: string;
   alt?: string;
+}
+
+// X Article tables. `header` is the `<th>` row when the source has one —
+// markdown tables require a header row, so renderers emit an empty one when
+// it's absent rather than promoting a data row and losing a line of content.
+export interface TableNode {
+  type: 'table';
+  header?: TableRowNode;
+  children: TableRowNode[];
+}
+
+export interface TableRowNode {
+  type: 'tableRow';
+  children: TableCellNode[];
+}
+
+export interface TableCellNode {
+  type: 'tableCell';
+  children: InlineNode[];
 }
 
 export interface PollNode {

--- a/src/content/dom-to-ast/article-body.ts
+++ b/src/content/dom-to-ast/article-body.ts
@@ -10,6 +10,8 @@ import type {
   CodeBlockNode,
   ParagraphNode,
   ThematicBreakNode,
+  TableNode,
+  TableRowNode,
 } from '../../ast/types';
 import { SELECTORS, extractAuthor, extractDate, extractTweetId } from '../dom';
 import { extractEngagementMetadata } from '../tweet';
@@ -104,6 +106,15 @@ function articleBlockToNodes(block: HTMLElement): Block[] {
     return [{ type: 'thematicBreak' } satisfies ThematicBreakNode];
   }
 
+  // Table — like code blocks and separators, X wraps it in a non-editable
+  // <section> block. Without this branch it falls through to the paragraph
+  // fallback, which concatenates every cell into one unreadable run.
+  const tableEl = block.querySelector('table') || (block.tagName === 'TABLE' ? block : null);
+  if (tableEl) {
+    const table = tableToNode(tableEl);
+    return table ? [table] : [];
+  }
+
   const hasH1 = block.classList.contains('longform-header-one')
     || !!block.querySelector('.longform-header-one');
   if (hasH1) {
@@ -188,6 +199,27 @@ function articleBlockToNodes(block: HTMLElement): Block[] {
   const inline = extractArticleInline(block);
   if (inline.length === 0) return [];
   return [{ type: 'paragraph', children: inline } satisfies ParagraphNode];
+}
+
+function tableToNode(tableEl: Element): TableNode | undefined {
+  let header: TableRowNode | undefined;
+  const rows: TableRowNode[] = [];
+
+  for (const tr of tableEl.querySelectorAll('tr')) {
+    const cells = Array.from(tr.children).filter((c) => c.tagName === 'TH' || c.tagName === 'TD');
+    if (cells.length === 0) continue;
+    const row: TableRowNode = {
+      type: 'tableRow',
+      children: cells.map((c) => ({ type: 'tableCell', children: extractArticleInline(c) })),
+    };
+    // X marks the header row with <th>; a table can also start straight into
+    // data rows, in which case the renderers supply an empty header.
+    if (!header && cells.every((c) => c.tagName === 'TH')) header = row;
+    else rows.push(row);
+  }
+
+  if (!header && rows.length === 0) return undefined;
+  return { type: 'table', ...(header ? { header } : {}), children: rows };
 }
 
 function blockHasOnlyImage(block: HTMLElement): boolean {

--- a/src/graphql/json-to-ast.ts
+++ b/src/graphql/json-to-ast.ts
@@ -196,7 +196,7 @@ function articleDocument(t: RawTweet, article: RawArticle, sourceUrl?: string): 
 
   const body: ArticleNode = { type: 'article', children };
   const cover = article.cover_media?.media_info?.original_img_url;
-  if (cover) body.banner = { type: 'image', url: cover };
+  if (cover) body.banner = { type: 'image', url: normalizeMediaUrl(cover) };
 
   const eng = engagement(t);
   return {
@@ -287,7 +287,7 @@ function draftToBlocks(cs: RawContentState, mediaEntities: RawMediaEntity[]): Bl
     }
 
     if (type === 'header-one' || type === 'header-two' || type === 'header-three') {
-      const inline = draftInline(b, entities);
+      const inline = unwrapWholeStrong(draftInline(b, entities));
       if (inline.length === 0) continue;
       const depth = type === 'header-one' ? 1 : type === 'header-two' ? 2 : 3;
       out.push({ type: 'heading', depth, children: inline } satisfies HeadingNode);
@@ -300,6 +300,25 @@ function draftToBlocks(cs: RawContentState, mediaEntities: RawMediaEntity[]): Bl
   }
   flush();
   return out;
+}
+
+// X's article editor marks every heading's text Bold, so a heading maps to a
+// single strong spanning the whole line — `## **Getting started**`, where the
+// `##` already says it. Drop that wrapper; bold on *part* of a heading is the
+// author's own emphasis and stays. (The DOM extractor takes heading text
+// plain, so this is also what keeps the two paths in step.)
+function unwrapWholeStrong(nodes: InlineNode[]): InlineNode[] {
+  const only = nodes.length === 1 ? nodes[0] : undefined;
+  return only?.type === 'strong' ? only.children : nodes;
+}
+
+// X's GraphQL returns the canonical media URL (…/HMkRVmsaEAA3Dl5.jpg) while
+// the DOM extractor emits the sized variant it finds on the page. Same image;
+// normalize to the DOM's form so both acquisition paths render identical
+// markdown for the same post.
+function normalizeMediaUrl(url: string): string {
+  const m = url.match(/^(https:\/\/pbs\.twimg\.com\/media\/[^./?#]+)\.(jpg|jpeg|png|webp)$/i);
+  return m ? `${m[1]}?format=${m[2].toLowerCase()}&name=large` : url;
 }
 
 // An atomic block carries a single entity: a DIVIDER (→ horizontal rule),
@@ -319,7 +338,7 @@ function atomicBlock(
   const mediaId = ent.data?.mediaItems?.[0]?.mediaId;
   if (!mediaId) return undefined;
   const url = mediaById.get(mediaId)?.media_info?.original_img_url;
-  return url ? { type: 'image', url } : undefined;
+  return url ? { type: 'image', url: normalizeMediaUrl(url) } : undefined;
 }
 
 // Code blocks and tables are the one part of an article X does NOT hand over
@@ -555,14 +574,16 @@ function media(items: RawMedia[]): MediaItem[] {
   for (const m of items) {
     const alt = m.ext_alt_text || undefined;
     if (m.type === 'photo') {
-      if (m.media_url_https) out.push({ kind: 'image', url: m.media_url_https, ...(alt ? { alt } : {}) });
+      if (m.media_url_https) {
+        out.push({ kind: 'image', url: normalizeMediaUrl(m.media_url_https), ...(alt ? { alt } : {}) });
+      }
     } else if (m.type === 'video' || m.type === 'animated_gif') {
       const src = bestVariant(m.video_info?.variants ?? []);
       if (src) {
         out.push({
           kind: m.type === 'animated_gif' ? 'gif' : 'video',
           url: src,
-          ...(m.media_url_https ? { posterUrl: m.media_url_https } : {}),
+          ...(m.media_url_https ? { posterUrl: normalizeMediaUrl(m.media_url_https) } : {}),
           ...(alt ? { alt } : {}),
         });
       }

--- a/src/graphql/json-to-ast.ts
+++ b/src/graphql/json-to-ast.ts
@@ -26,6 +26,8 @@ import type {
   ListNode,
   MediaItem,
   PollNode,
+  TableNode,
+  TableRowNode,
   TweetNode,
 } from '../ast/types';
 
@@ -136,8 +138,8 @@ interface RawDraftBlock {
   entityRanges?: RawEntityRange[];
 }
 interface RawEntityValue {
-  type?: string; // 'LINK' | 'MEDIA'
-  data?: { url?: string; mediaItems?: { mediaId?: string }[] };
+  type?: string; // 'LINK' | 'MEDIA' | 'DIVIDER' | 'MARKDOWN'
+  data?: { url?: string; mediaItems?: { mediaId?: string }[]; markdown?: string };
 }
 interface RawContentState {
   blocks?: RawDraftBlock[];
@@ -300,8 +302,9 @@ function draftToBlocks(cs: RawContentState, mediaEntities: RawMediaEntity[]): Bl
   return out;
 }
 
-// An atomic block carries a single entity: a DIVIDER (→ horizontal rule) or
-// MEDIA (→ image, resolved via media_entities by mediaId).
+// An atomic block carries a single entity: a DIVIDER (→ horizontal rule),
+// MEDIA (→ image, resolved via media_entities by mediaId) or MARKDOWN
+// (→ code block or table).
 function atomicBlock(
   b: RawDraftBlock,
   entities: Map<string, RawEntityValue>,
@@ -311,11 +314,107 @@ function atomicBlock(
   if (!range || range.key == null) return undefined;
   const ent = entities.get(String(range.key));
   if (ent?.type === 'DIVIDER') return { type: 'thematicBreak' };
+  if (ent?.type === 'MARKDOWN') return markdownEntityBlock(ent.data?.markdown);
   if (ent?.type !== 'MEDIA') return undefined;
   const mediaId = ent.data?.mediaItems?.[0]?.mediaId;
   if (!mediaId) return undefined;
   const url = mediaById.get(mediaId)?.media_info?.original_img_url;
   return url ? { type: 'image', url } : undefined;
+}
+
+// Code blocks and tables are the one part of an article X does NOT hand over
+// as structured Draft.js: the entity holds raw markdown source. Parse the two
+// shapes X emits so this path lands on the same AST as the DOM extractor —
+// otherwise every code block and table in a Fast Batch export is dropped.
+function markdownEntityBlock(markdown?: string): Block | undefined {
+  const src = (markdown ?? '').trim();
+  if (!src) return undefined;
+
+  const fence = src.match(/^```([^\n]*)\n([\s\S]*?)\n?```$/);
+  if (fence) {
+    const lang = fence[1].trim();
+    const value = fence[2].replace(/\s+$/, '');
+    return { type: 'code', value, ...(lang ? { lang } : {}) };
+  }
+
+  if (src.startsWith('|')) return markdownTable(src);
+  return undefined;
+}
+
+function markdownTable(src: string): TableNode | undefined {
+  const rows = src
+    .split('\n')
+    .map((l) => l.trim())
+    .filter(Boolean)
+    .map(splitTableRow)
+    .filter((r): r is string[] => r !== undefined);
+  if (rows.length === 0) return undefined;
+
+  const isDelimiter = (cells: string[]): boolean =>
+    cells.length > 0 && cells.every((c) => /^:?-{1,}:?$/.test(c));
+  const toRow = (cells: string[]): TableRowNode => ({
+    type: 'tableRow',
+    children: cells.map((c) => ({ type: 'tableCell', children: parseInlineMarkdown(c) })),
+  });
+
+  // `| a | b |` / `| --- | --- |` / data rows. The delimiter row is what makes
+  // the row above it a header; without one every row is data.
+  const header = isDelimiter(rows[1] ?? []) ? toRow(rows[0]) : undefined;
+  const body = rows.filter((cells, i) => !isDelimiter(cells) && !(header && i === 0));
+  if (!header && body.length === 0) return undefined;
+  return { type: 'table', ...(header ? { header } : {}), children: body.map(toRow) };
+}
+
+function splitTableRow(line: string): string[] | undefined {
+  if (!line.startsWith('|')) return undefined;
+  const cells: string[] = [];
+  let cur = '';
+  for (let i = 1; i < line.length; i++) {
+    if (line[i] === '\\' && line[i + 1] === '|') {
+      cur += '|';
+      i++;
+    } else if (line[i] === '|') {
+      cells.push(cur.trim());
+      cur = '';
+    } else {
+      cur += line[i];
+    }
+  }
+  // Tolerate a row whose closing pipe is missing.
+  if (cur.trim()) cells.push(cur.trim());
+  return cells;
+}
+
+// Just enough inline markdown for what X puts in a table cell: bold, italic,
+// inline code and links. Anything else stays literal text.
+function parseInlineMarkdown(src: string): InlineNode[] {
+  const out: InlineNode[] = [];
+  let text = '';
+  const flush = (): void => {
+    if (text) out.push({ type: 'text', value: text });
+    text = '';
+  };
+  for (let i = 0; i < src.length; ) {
+    const rest = src.slice(i);
+    const code = rest.match(/^`([^`]+)`/);
+    const link = rest.match(/^\[([^\]]*)\]\(([^)\s]+)\)/);
+    const strong = rest.match(/^\*\*([\s\S]+?)\*\*/);
+    const em = rest.match(/^\*([^*]+)\*/);
+    const match = code || link || strong || em;
+    if (!match) {
+      text += src[i];
+      i++;
+      continue;
+    }
+    flush();
+    if (code) out.push({ type: 'inlineCode', value: code[1] });
+    else if (link) out.push({ type: 'link', url: link[2], children: parseInlineMarkdown(link[1]) });
+    else if (strong) out.push({ type: 'strong', children: parseInlineMarkdown(strong[1]) });
+    else out.push({ type: 'emphasis', children: parseInlineMarkdown(em![1]) });
+    i += match[0].length;
+  }
+  flush();
+  return out;
 }
 
 // Build inline nodes for one Draft block: walk character runs that share the

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "__MSG_extensionName__",
   "short_name": "XClipper",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "description": "__MSG_extensionDescription__",
   "default_locale": "en",
   "permissions": [

--- a/tests/article-table-ast.test.ts
+++ b/tests/article-table-ast.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect } from 'vitest';
+import { JSDOM } from 'jsdom';
+import { domToAst } from '../src/content/dom-to-ast';
+import { renderMarkdown } from '../src/ast/render-markdown';
+import { renderPdfHtml } from '../src/ast/render-pdf-html';
+
+// X Article tables live in a non-editable <section> block, the same wrapper
+// code blocks and separators use. Without a dedicated branch the extractor
+// falls through to the paragraph fallback and concatenates every cell.
+
+function loadArticle(bodyHtml: string): void {
+  const url = 'https://x.com/theonejvo/status/2015401219746128322';
+  const html = `
+    <html>
+      <body>
+        <article role="article">
+          <div data-testid="User-Name">
+            <a href="/theonejvo"><span>Jamieson</span></a>
+            <a href="/theonejvo"><span>@theonejvo</span></a>
+          </div>
+          <time datetime="2026-01-01T00:00:00.000Z"></time>
+          <div data-testid="twitter-article-title">Tables</div>
+          <div data-testid="twitterArticleRichTextView">
+            <div data-testid="longformRichTextComponent">
+              <div data-contents="true">${bodyHtml}</div>
+            </div>
+          </div>
+        </article>
+      </body>
+    </html>
+  `;
+  const dom = new JSDOM(html, { url });
+  document.documentElement.replaceWith(
+    dom.window.document.documentElement.cloneNode(true) as HTMLElement
+  );
+  Object.defineProperty(window, 'location', {
+    value: { ...window.location, pathname: new URL(url).pathname, href: url },
+    writable: true,
+    configurable: true,
+  });
+}
+
+function firstBlock() {
+  const ast = domToAst();
+  if (ast.body.type !== 'article') throw new Error('expected an article');
+  return { ast, block: ast.body.children[0] };
+}
+
+describe('domToAst() article tables', () => {
+  it('extracts a header row and data rows', () => {
+    loadArticle(`
+      <section data-block="true" contenteditable="false">
+        <table>
+          <tr><th><span>Loop</span></th><th><span>Reach for</span></th></tr>
+          <tr><td><span>Turn-based</span></td><td><span>Skills</span></td></tr>
+          <tr><td><span>Goal-based</span></td><td><span>/goal</span></td></tr>
+        </table>
+      </section>
+    `);
+
+    const { ast, block } = firstBlock();
+    expect(block).toEqual({
+      type: 'table',
+      header: {
+        type: 'tableRow',
+        children: [
+          { type: 'tableCell', children: [{ type: 'text', value: 'Loop' }] },
+          { type: 'tableCell', children: [{ type: 'text', value: 'Reach for' }] },
+        ],
+      },
+      children: [
+        {
+          type: 'tableRow',
+          children: [
+            { type: 'tableCell', children: [{ type: 'text', value: 'Turn-based' }] },
+            { type: 'tableCell', children: [{ type: 'text', value: 'Skills' }] },
+          ],
+        },
+        {
+          type: 'tableRow',
+          children: [
+            { type: 'tableCell', children: [{ type: 'text', value: 'Goal-based' }] },
+            { type: 'tableCell', children: [{ type: 'text', value: '/goal' }] },
+          ],
+        },
+      ],
+    });
+
+    expect(renderMarkdown(ast)).toContain(
+      '| Loop | Reach for |\n'
+      + '| --- | --- |\n'
+      + '| Turn-based | Skills |\n'
+      + '| Goal-based | /goal |'
+    );
+  });
+
+  it('keeps cell formatting and links', () => {
+    loadArticle(`
+      <section data-block="true" contenteditable="false">
+        <table>
+          <tr><th><span>Command</span></th></tr>
+          <tr><td><span style="font-weight: bold;">/goal</span><span> — see </span><a href="https://example.com/docs"><span>docs</span></a></td></tr>
+        </table>
+      </section>
+    `);
+
+    expect(renderMarkdown(firstBlock().ast)).toContain(
+      '| **/goal** — see [docs](https://example.com/docs) |'
+    );
+  });
+
+  it('emits an empty header when the table has no th row', () => {
+    loadArticle(`
+      <section data-block="true" contenteditable="false">
+        <table>
+          <tr><td><span>a</span></td><td><span>b</span></td></tr>
+        </table>
+      </section>
+    `);
+
+    const { ast, block } = firstBlock();
+    expect(block).toMatchObject({ type: 'table', children: [{ type: 'tableRow' }] });
+    expect(block).not.toHaveProperty('header');
+    expect(renderMarkdown(ast)).toContain('|  |  |\n| --- | --- |\n| a | b |');
+  });
+
+  it('escapes pipes and flattens hard breaks inside a cell', () => {
+    loadArticle(`
+      <section data-block="true" contenteditable="false">
+        <table>
+          <tr><th><span>Syntax</span></th></tr>
+          <tr><td><span>a | b</span><br><span>next line</span></td></tr>
+        </table>
+      </section>
+    `);
+
+    const md = renderMarkdown(firstBlock().ast);
+    expect(md).toContain('| a \\| b next line |');
+    expect(md).not.toContain('a | b |');
+  });
+
+  it('pads short rows so the column count stays stable', () => {
+    loadArticle(`
+      <section data-block="true" contenteditable="false">
+        <table>
+          <tr><th><span>a</span></th><th><span>b</span></th><th><span>c</span></th></tr>
+          <tr><td><span>1</span></td></tr>
+        </table>
+      </section>
+    `);
+
+    expect(renderMarkdown(firstBlock().ast)).toContain('| a | b | c |\n| --- | --- | --- |\n| 1 |  |  |');
+  });
+
+  it('renders a real table element for PDF', () => {
+    loadArticle(`
+      <section data-block="true" contenteditable="false">
+        <table>
+          <tr><th><span>Loop</span></th></tr>
+          <tr><td><span>Turn-based</span></td></tr>
+        </table>
+      </section>
+    `);
+
+    const html = renderPdfHtml(firstBlock().ast);
+    expect(html).toContain('<table><thead><tr><th>Loop</th></tr></thead><tbody><tr><td>Turn-based</td></tr></tbody></table>');
+  });
+});

--- a/tests/article-table-ast.test.ts
+++ b/tests/article-table-ast.test.ts
@@ -139,6 +139,26 @@ describe('domToAst() article tables', () => {
     expect(md).not.toContain('a | b |');
   });
 
+  // Escaping the pipe alone would turn the author's `\` + `|` into `\\|`,
+  // which reads as an escaped backslash plus a live pipe — the row splits.
+  it('escapes a backslash before escaping the pipe', () => {
+    loadArticle(`
+      <section data-block="true" contenteditable="false">
+        <table>
+          <tr><th><span>Syntax</span></th></tr>
+          <tr><td><span>C:\\ | next</span></td></tr>
+        </table>
+      </section>
+    `);
+
+    const cellLine = renderMarkdown(firstBlock().ast)
+      .split('\n')
+      .find((l) => l.includes('C:'))!;
+    expect(cellLine).toBe('| C:\\\\ \\| next |');
+    // One cell, not two: the escaped pipe must not close it early.
+    expect(cellLine.split(/(?<!\\)\|/).filter((s) => s.trim()).length).toBe(1);
+  });
+
   it('pads short rows so the column count stays stable', () => {
     loadArticle(`
       <section data-block="true" contenteditable="false">

--- a/tests/ast-render-markdown.test.ts
+++ b/tests/ast-render-markdown.test.ts
@@ -3,9 +3,10 @@ import { readFileSync, existsSync } from 'node:fs';
 import { resolve, join } from 'node:path';
 import { JSDOM } from 'jsdom';
 import { domToAst } from '../src/content/dom-to-ast';
-import { renderMarkdown } from '../src/ast/render-markdown';
+import { renderMarkdown, renderMarkdownBody } from '../src/ast/render-markdown';
 import { postProcess } from '../src/shared/post-process';
 import type { ExtractedContent, TweetMetadata } from '../src/types/messages';
+import type { Document, InlineNode } from '../src/ast/types';
 
 // Phase 3 parity test: AST extractor → AST → renderMarkdown → postProcess,
 // compared against the existing .md fixture. Diffs here are either renderer
@@ -115,4 +116,71 @@ describe('AST renderMarkdown parity', () => {
       expect(normalize(processed.markdown)).toBe(normalize(expected));
     });
   }
+});
+
+// Authors on X often style the trailing space of a run, so the AST carries
+// whitespace inside strong/emphasis. Markdown can't: `**bold **` isn't bold.
+describe('emphasis edge whitespace', () => {
+  const author = { name: 'A', handle: 'a' };
+  const tweetDoc = (text: InlineNode[]): Document => ({
+    version: 1,
+    metadata: {
+      type: 'tweet',
+      sourceUrl: 'https://x.com/a/status/1',
+      tweetId: '1',
+      author,
+      date: '2026-01-01T00:00:00.000Z',
+    },
+    body: { type: 'tweet', author, date: '2026-01-01T00:00:00.000Z', tweetId: '1', text, media: [] },
+  });
+  const render = (text: InlineNode[]): string => renderMarkdownBody(tweetDoc(text));
+
+  it('hoists a trailing space out of strong', () => {
+    expect(render([
+      { type: 'strong', children: [{ type: 'text', value: 'Best used for: ' }] },
+      { type: 'text', value: 'Shorter tasks.' },
+    ])).toBe('**Best used for:** Shorter tasks.');
+  });
+
+  it('hoists a trailing space out of emphasis', () => {
+    expect(render([
+      { type: 'emphasis', children: [{ type: 'text', value: 'written by ' }] },
+      { type: 'text', value: 'someone' },
+    ])).toBe('*written by* someone');
+  });
+
+  it('hoists a leading space', () => {
+    expect(render([
+      { type: 'text', value: 'and' },
+      { type: 'strong', children: [{ type: 'text', value: ' dynamic workflows' }] },
+    ])).toBe('and **dynamic workflows**');
+  });
+
+  it('drops the markers when the run is only whitespace', () => {
+    expect(render([
+      { type: 'text', value: 'a' },
+      { type: 'strong', children: [{ type: 'text', value: ' ' }] },
+      { type: 'text', value: 'b' },
+    ])).toBe('a b');
+  });
+
+  it('drops the markers when the run is only zero-width characters', () => {
+    expect(render([
+      { type: 'text', value: 'turns.' },
+      { type: 'strong', children: [{ type: 'text', value: '\u200d' }] },
+    ])).toBe('turns.\u200d');
+  });
+
+  it('keeps a run that has a zero-width character alongside real text', () => {
+    expect(render([
+      { type: 'strong', children: [{ type: 'text', value: 'bold\u200d' }] },
+    ])).toBe('**bold\u200d**');
+  });
+
+  it('leaves an already-tight run alone', () => {
+    expect(render([
+      { type: 'strong', children: [{ type: 'text', value: 'Triggered by' }] },
+      { type: 'text', value: ': A user prompt.' },
+    ])).toBe('**Triggered by**: A user prompt.');
+  });
 });

--- a/tests/fixtures/ClaudeDevs-2074208949205881033.md
+++ b/tests/fixtures/ClaudeDevs-2074208949205881033.md
@@ -1,0 +1,177 @@
+---
+author: "ClaudeDevs"
+handle: "@ClaudeDevs"
+source: "https://x.com/ClaudeDevs/status/2074208949205881033"
+date: 2026-07-06T19:08:45.000Z
+type: article
+likes: 17835
+reposts: 2717
+replies: 329
+bookmarks: 38844
+views: 6161826
+---
+# Getting started with loops
+
+*By ClaudeDevs (@ClaudeDevs)*
+
+![Banner](https://pbs.twimg.com/media/HMkRVmsaEAA3Dl5?format=jpg&name=large)
+
+There’s a lot of talk right now about "designing loops" instead of prompting your coding agent. If you spend some time on X trying to pin down what a loop actually is, you'll come across multiple different answers.
+
+On the Claude Code team, we define **loops as agents repeating cycles of work until a stop condition is met**. We categorize a few different types of loops based on:
+
+- How they are triggered
+- How they are stopped
+- What Claude Code primitive is used
+- What type of task is most appropriate for each.
+
+We’ll cover the main loop types, when to use each, and how to maintain code quality while managing token usage. Not all tasks require complex loops; start with the simplest solution and use these patterns selectively.
+
+---
+
+## Turn-based loops
+
+![Image](https://pbs.twimg.com/media/HMkOVNybEAAncbL?format=jpg&name=large)
+
+- **Triggered by**: A user prompt.
+- **Stop criteria**: Claude judges it has completed the task or needs additional context.
+- **Best used for:** Shorter tasks that are not part of a regular process or schedule.
+- **Managed usage by:** Write specific prompts and improve verification using skills to reduce the number of turns.‍
+
+Every prompt you send starts a manual loop with you directing each turn. Claude gathers context, takes action, checks its work, repeats if needed, and responds. We call this the agentic loop.
+
+For example, ask Claude to create a like button. It reads your code, makes the edit, runs the tests, and hands back something it *believes* works. You then manually check the work, and write the next prompt.
+
+You can improve the verification step by encoding your manual steps as a SKILL.md so Claude can check more of its own work, end-to-end. This should include tools or connectors to allow Claude to *see*, *measure* or *interact* with the result. The more quantitative the checks are, the easier it is for Claude to self-verify.
+
+For example, in your SKILL.md file you may specify:
+
+```markdown
+--- 
+name: verify-frontend-change 
+description: Verify any UI change end-to-end before declaring it done. 
+--- 
+
+# Verifying frontend changes 
+Never report a UI change as complete based on a successful edit alone. Verify it the way a human reviewer would: 
+
+1. Start the dev server and open the edited page in the browser. 
+
+2. Interact with the change directly. For a new control (button, input, toggle): click it, confirm the expected state change, and screenshot before/after. 
+
+3. Check the browser console: zero new errors or warnings. 
+
+4. Use the Chrome Devtools MCP, run a performance trace and audit Core Web Vitals.
+
+If any step fails, fix the issue and rerun from step 1 — do not hand back partially verified work.
+```
+
+---
+
+## Goal-based loop (/goal)
+
+![Image](https://pbs.twimg.com/media/HMkOlk3bcAAHX46?format=jpg&name=large)
+
+- **Triggered by**: A manual prompt in real-time.
+- **Stop criteria**: Goal achieved OR maximum number of turns reached.
+- **Best used for:** Tasks that have verifiable exit criteria.
+- **Managed usage by:** Setting a specific completion criteria and explicit turn caps, “stop after 5 tries.”
+
+Sometimes, a single turn is not enough, especially for more complex tasks. Agents do better when they can iterate. You can extend how long Claude keeps iterating by defining what done looks like with /goal.
+
+When you define the success criteria, Claude doesn’t have to make a determination on what is “good enough” and end the loop early. Each time Claude tries to stop, an evaluator model checks your condition and sends it back to work until the goal is met or a number of turns you define is reached.
+
+This is why deterministic criteria, such as number of tests passed or clearing a certain score threshold, are so effective.
+
+For example:
+
+```bash
+/goal get the homepage Lighthouse score to 90 or above, stop after 5 tries.
+```
+
+---
+
+## Time-based loop (/loop and /schedule)
+
+- **Triggered by**: A specified time interval.
+- **Stop criteria**: You cancel it, or the work completes (the PR merges, the queue is empty).
+- **Best used for:** For recurring work, or interfacing with external environments / systems.
+- **Managed usage by:** Set longer intervals or react based on events rather than time.
+
+Some agentic work is recurring: the task stays the same and only the inputs change. For example, summarizing Slack messages every morning. Other work depends on external systems, and a simple way to interface with one is to check it on an interval and react to what changed. For example, a PR which may receive code reviews or fail CI.
+
+For these, you can trigger when Claude runs with `/loop` which re-runs a prompt on an interval. For example:
+
+```bash
+/loop 5m check my PR, address review comments, and fix failing CI
+```
+
+`/loop` runs on your computer, so if you turn it off, it stops. You can move the loop to the cloud by creating a routine with  `/schedule`.
+
+---
+
+## Proactive loops
+
+![Image](https://pbs.twimg.com/media/HMkPQM8bEAA3RAk?format=jpg&name=large)
+
+- **Triggered by**: An event or schedule, with no human in real time.
+- **Stop criteria**: Each task exits when its goal is met. The routine itself runs until you turn it off.
+- **Best used for:** Recurring streams of well-defined work: bug reports, issue triage, migrations, dependency upgrades, etc.
+- **Managed usage by:** Routing routines to smaller, faster models and using the most capable model for judgment calls.
+
+The primitives above, along with other Claude Code features like **auto mode** and **dynamic workflows** (research preview) can be composed into a loop for long-running work.
+
+For example, to handle incoming feedback, you can use:
+
+1. **`/schedule`** (research preview) to run a routine that checks for new reports
+2. **`/goal`** to define what done looks and **skills** to document how to verify it
+3. **Dynamic workflows** to orchestrate agents that triage each report, fix it, and review the fix
+4. **Auto mode** so the routine runs without stopping to ask for permission
+
+Putting it together, a prompt could look like this:
+
+```bash
+/schedule every hour: check the project-feedback channel for bug reports. /goal: don't stop until every report found this run is triaged, actioned, and responded to. When fixing a bug, use a workflow to explore three solutions in parallel worktrees and have a judge adversarially review them.
+```
+
+---
+
+## Maintaining code quality
+
+The quality of a loop’s output depends on the system around it. When designing the system:
+
+- **Keep the codebase itself clean**: Claude follows patterns and conventions that already exist in your codebase.
+- **Give Claude a way to verify its own work**: Encode what good looks like for you and your team with [skills](https://code.claude.com/docs/en/skills).
+- **Make docs easy to reach:** Frameworks and libraries docs have up-to-date best practices.
+- **Use a second agent for code reviews**: A reviewer with fresh context is less biased and not influenced by the main agent’s reasoning. You can use the built-in `/code-review` skill or [Code Review](https://code.claude.com/docs/en/code-review) for Github.
+
+When an individual result doesn’t meet the standard, don’t stop at fixing the individual issue, try to encode it to improve the system for all future iterations.
+
+---
+
+## Managing token usage
+
+To manage token usage, loops should have clear boundaries:
+
+- **Choose the right primitive and model for the job:** Smaller tasks don’t need multiple agents or loops. Some tasks can use cheaper and faster models.
+- **Define clear success and stop criteria:** Be specific about what done looks like so Claude can arrive at the solution sooner (but not too soon).
+- **Pilot before a large run:** Dynamic workflows can spawn hundreds of agents. Gauge usage on a smaller slice of the work first.
+- **Use scripts for deterministic work**: Running a script is cheaper than reasoning through the steps. For example, a PDF skill can ship a form-filling script that Claude runs each time, instead of re-deriving the code.
+- **Don’t run routines more often that you need to:** Match the interval to how often the thing you’re watching changes
+- **Review usage:** The `/usage` command breaks down recent usage by skills, subagents, and MCPs, `/goal` with no arguments shows number of turns and token usage so far, `/workflows` shows each agent’s token usage and you can stop an agent at any time.
+
+---
+
+## Getting started
+
+To summarize:
+
+LoopYou hand offUse it whenReach forTurn-basedThe checkYou're exploring or decidingCustom verification skillsGoal-basedThe stop conditionYou know what done looks like/goalTime-basedThe triggerThe work happens outside your project on a schedule/loop, /scheduleProactiveThe promptThe work is recurring and well-definedAll of the above, and dynamic workflows
+
+To get started with loops, look at the work you already do. Pick one task where you’re the bottleneck and ask which piece you could hand off: can you write the verification check? Is the goal clear enough? Does the work arrive on a schedule?
+
+Once you have an idea, run the loop, observe the results like where it stalls or over-reaches, and don’t be afraid to iterate on it.
+
+For more information, read the Claude Code docs on [running agents in parallel,](https://code.claude.com/docs/en/agents) as well as the [loop](https://code.claude.com/docs/en/goal), [schedule](https://code.claude.com/docs/en/routines), [goal](https://code.claude.com/docs/en/goal), and [dynamic workflows](https://code.claude.com/docs/en/workflows#orchestrate-subagents-at-scale-with-dynamic-workflows) pages.
+
+*This article was written by* [@delba_oliveira](https://x.com/@delba_oliveira)

--- a/tests/fixtures/ClaudeDevs-2074208949205881033.md
+++ b/tests/fixtures/ClaudeDevs-2074208949205881033.md
@@ -166,7 +166,12 @@ To manage token usage, loops should have clear boundaries:
 
 To summarize:
 
-LoopYou hand offUse it whenReach forTurn-basedThe checkYou're exploring or decidingCustom verification skillsGoal-basedThe stop conditionYou know what done looks like/goalTime-basedThe triggerThe work happens outside your project on a schedule/loop, /scheduleProactiveThe promptThe work is recurring and well-definedAll of the above, and dynamic workflows
+| Loop | You hand off | Use it when | Reach for |
+| --- | --- | --- | --- |
+| Turn-based | The check | You're exploring or deciding | Custom verification skills |
+| Goal-based | The stop condition | You know what done looks like | /goal |
+| Time-based | The trigger | The work happens outside your project on a schedule | /loop, /schedule |
+| Proactive | The prompt | The work is recurring and well-defined | All of the above, and dynamic workflows |
 
 To get started with loops, look at the work you already do. Pick one task where you’re the bottleneck and ask which piece you could hand off: can you write the verification check? Is the goal clear enough? Does the work arrive on a schedule?
 

--- a/tests/json-to-ast-live.test.ts
+++ b/tests/json-to-ast-live.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { existsSync, readFileSync } from 'node:fs';
 import { jsonToAst } from '../src/graphql/json-to-ast';
+import { tweetDetailToDocument } from '../src/graphql/tweet-detail';
 import { parseTimelinePage } from '../src/graphql/timeline';
 import { renderMarkdown } from '../src/ast/render-markdown';
 
@@ -72,5 +73,30 @@ if (!path) {
   // Surface the skip the way extractor.test.ts does, so it isn't silent.
   console.warn(
     '[json-to-ast-live] no captured GraphQL response found (looked in _local/) — skipping real-data validation'
+  );
+}
+
+// A real TweetDetail for an X Article whose body contains a table and code
+// blocks — both arrive as atomic MARKDOWN entities holding raw markdown, the
+// one part of the body X doesn't send as structured Draft.js.
+const ARTICLE_CAPTURE = '_local/article-with-table.json';
+const articlePath = existsSync(ARTICLE_CAPTURE) ? ARTICLE_CAPTURE : undefined;
+
+describe.skipIf(!articlePath)('tweetDetailToDocument — real captured article', () => {
+  const raw = articlePath ? JSON.parse(readFileSync(ARTICLE_CAPTURE, 'utf8')) : undefined;
+
+  it('maps the article body to markdown with its table and code blocks intact', () => {
+    const doc = tweetDetailToDocument(raw, '2074208949205881033');
+    expect(doc).toBeTruthy();
+    const md = renderMarkdown(doc!);
+    expect(md).toContain('| --- | --- | --- | --- |');
+    expect(md).toContain('| Proactive | The prompt |');
+    expect(md).toContain('```bash');
+  });
+});
+
+if (!articlePath) {
+  console.warn(
+    `[json-to-ast-live] no captured article response at ${ARTICLE_CAPTURE} — skipping table/code-block validation`
   );
 }

--- a/tests/json-to-ast.test.ts
+++ b/tests/json-to-ast.test.ts
@@ -397,6 +397,100 @@ describe('jsonToAst — X Articles', () => {
       { type: 'paragraph', children: [{ type: 'text', value: 'after' }] },
     ]);
   });
+
+  // Code blocks and tables are the one part of an article X does NOT send as
+  // structured Draft.js — an atomic MARKDOWN entity holds raw markdown source.
+  // Before these were mapped, every code block and table in a Fast Batch
+  // export was silently dropped.
+  const withMarkdownEntities = (...markdown: string[]) => ({
+    ...articleResult,
+    article: {
+      article_results: {
+        result: {
+          ...articleResult.article.article_results.result,
+          content_state: {
+            blocks: markdown.map((_, i) => ({
+              type: 'atomic',
+              text: ' ',
+              entityRanges: [{ key: i, offset: 0, length: 1 }],
+            })),
+            entityMap: markdown.map((md, i) => ({
+              key: String(i),
+              value: { type: 'MARKDOWN', data: { markdown: md } },
+            })),
+          },
+        },
+      },
+    },
+  });
+
+  const blocksOf = (result: unknown): unknown[] =>
+    (jsonToAst(result).body as { children: unknown[] }).children;
+
+  it('maps a MARKDOWN entity holding a fenced code block', () => {
+    expect(blocksOf(withMarkdownEntities('```bash\n/loop 5m check my PR\n\n```'))).toEqual([
+      { type: 'code', lang: 'bash', value: '/loop 5m check my PR' },
+    ]);
+  });
+
+  it('maps an unfenced-language code block without a lang', () => {
+    expect(blocksOf(withMarkdownEntities('```\nplain\n```'))).toEqual([
+      { type: 'code', value: 'plain' },
+    ]);
+  });
+
+  it('maps a MARKDOWN entity holding a GFM table, with cell formatting', () => {
+    const md = '| **Loop**  | **Reach for**  |\n| --- | --- |\n|  Turn-based | `/goal` |';
+    expect(blocksOf(withMarkdownEntities(md))).toEqual([
+      {
+        type: 'table',
+        header: {
+          type: 'tableRow',
+          children: [
+            { type: 'tableCell', children: [{ type: 'strong', children: [{ type: 'text', value: 'Loop' }] }] },
+            { type: 'tableCell', children: [{ type: 'strong', children: [{ type: 'text', value: 'Reach for' }] }] },
+          ],
+        },
+        children: [
+          {
+            type: 'tableRow',
+            children: [
+              { type: 'tableCell', children: [{ type: 'text', value: 'Turn-based' }] },
+              { type: 'tableCell', children: [{ type: 'inlineCode', value: '/goal' }] },
+            ],
+          },
+        ],
+      },
+    ]);
+  });
+
+  it('treats a table with no delimiter row as all-data, and unescapes cell pipes', () => {
+    const block = blocksOf(withMarkdownEntities('| a \\| b | c |'))[0] as {
+      type: string;
+      header?: unknown;
+      children: { children: { children: unknown[] }[] }[];
+    };
+    expect(block.type).toBe('table');
+    expect(block.header).toBeUndefined();
+    expect(block.children[0].children[0].children).toEqual([{ type: 'text', value: 'a | b' }]);
+  });
+
+  it('parses links and italics inside a cell', () => {
+    const md = '| x |\n| --- |\n| see [docs](https://example.com) and *this* |';
+    const row = (blocksOf(withMarkdownEntities(md))[0] as {
+      children: { children: { children: unknown[] }[] }[];
+    }).children[0];
+    expect(row.children[0].children).toEqual([
+      { type: 'text', value: 'see ' },
+      { type: 'link', url: 'https://example.com', children: [{ type: 'text', value: 'docs' }] },
+      { type: 'text', value: ' and ' },
+      { type: 'emphasis', children: [{ type: 'text', value: 'this' }] },
+    ]);
+  });
+
+  it('drops a MARKDOWN entity whose shape is neither a fence nor a table', () => {
+    expect(blocksOf(withMarkdownEntities('just some prose'))).toEqual([]);
+  });
 });
 
 describe('jsonToTweetNode — cards', () => {

--- a/tests/json-to-ast.test.ts
+++ b/tests/json-to-ast.test.ts
@@ -282,7 +282,7 @@ describe('jsonToAst — X Articles', () => {
     expect(doc.metadata.engagement).toEqual({ likes: 7, views: 50 });
     expect(doc.body).toEqual({
       type: 'article',
-      banner: { type: 'image', url: 'https://pbs.twimg.com/media/cover.jpg' },
+      banner: { type: 'image', url: 'https://pbs.twimg.com/media/cover?format=jpg&name=large' },
       children: [
         { type: 'paragraph', children: [{ type: 'text', value: 'A teaser of the article body.' }] },
         {
@@ -355,7 +355,7 @@ describe('jsonToAst — X Articles', () => {
           { type: 'listItem', children: [{ type: 'paragraph', children: [{ type: 'text', value: 'second' }] }] },
         ],
       },
-      { type: 'image', url: 'https://pbs.twimg.com/media/pic.jpg' },
+      { type: 'image', url: 'https://pbs.twimg.com/media/pic?format=jpg&name=large' },
     ]);
   });
 
@@ -490,6 +490,80 @@ describe('jsonToAst — X Articles', () => {
 
   it('drops a MARKDOWN entity whose shape is neither a fence nor a table', () => {
     expect(blocksOf(withMarkdownEntities('just some prose'))).toEqual([]);
+  });
+
+  // X's editor marks every heading's text Bold, which rendered as
+  // `## **Heading**` — the `##` already carries that. Partial bold is the
+  // author's own emphasis and survives. Keeps parity with the DOM extractor.
+  const withHeading = (text: string, styles: unknown[]) => ({
+    ...articleResult,
+    article: {
+      article_results: {
+        result: {
+          ...articleResult.article.article_results.result,
+          content_state: {
+            blocks: [{ type: 'header-two', text, inlineStyleRanges: styles }],
+            entityMap: [],
+          },
+        },
+      },
+    },
+  });
+
+  it('drops the bold X puts on a whole heading', () => {
+    const result = withHeading('Getting started', [{ style: 'Bold', offset: 0, length: 15 }]);
+    expect(blocksOf(result)).toEqual([
+      { type: 'heading', depth: 2, children: [{ type: 'text', value: 'Getting started' }] },
+    ]);
+    expect(renderMarkdown(jsonToAst(result))).toContain('## Getting started');
+  });
+
+  it('keeps bold on part of a heading', () => {
+    const result = withHeading('Getting started', [{ style: 'Bold', offset: 0, length: 7 }]);
+    expect(blocksOf(result)).toEqual([
+      {
+        type: 'heading',
+        depth: 2,
+        children: [
+          { type: 'strong', children: [{ type: 'text', value: 'Getting' }] },
+          { type: 'text', value: ' started' },
+        ],
+      },
+    ]);
+  });
+});
+
+// X's GraphQL returns the canonical media URL; the DOM extractor emits the
+// sized variant found on the page. Same image — the mapper normalizes to the
+// DOM's form so a post exported either way produces identical markdown.
+describe('jsonToAst — media URL parity with the DOM extractor', () => {
+  it('rewrites a canonical pbs media URL to the sized variant', () => {
+    const node = jsonToTweetNode(
+      tweet({
+        extended_entities: {
+          media: [{ type: 'photo', media_url_https: 'https://pbs.twimg.com/media/HMkR1.jpg' }],
+        },
+      })
+    );
+    expect(node.media).toEqual([
+      { kind: 'image', url: 'https://pbs.twimg.com/media/HMkR1?format=jpg&name=large' },
+    ]);
+  });
+
+  it('leaves a URL that is already sized, or not a pbs media URL, alone', () => {
+    const already = 'https://pbs.twimg.com/media/HMkR1?format=jpg&name=small';
+    const foreign = 'https://example.com/pic.jpg';
+    const node = jsonToTweetNode(
+      tweet({
+        extended_entities: {
+          media: [
+            { type: 'photo', media_url_https: already },
+            { type: 'photo', media_url_https: foreign },
+          ],
+        },
+      })
+    );
+    expect(node.media.map((m) => m.url)).toEqual([already, foreign]);
   });
 });
 


### PR DESCRIPTION
Five output bugs in X Article exports, found by chasing one report of stray `**` in an exported file.

## What was wrong

**Emphasis broke on a styled trailing space.** X Article authors routinely bold a label together with the space after it, so the AST faithfully carried whitespace inside `strong`. Markdown can't: a closing delimiter preceded by whitespace isn't a delimiter, so `**Best used for: **Shorter tasks` rendered as literal asterisks. Thirteen occurrences in one article. This was fixed once before — 1.2.0, as a Turndown custom rule — and the rule was lost in the Content AST rewrite (ADR 0001). Restored in the renderer this time, so both acquisition paths get it.

**Empty bold runs left stray asterisks.** X ends some article paragraphs with a bold zero-width joiner, which exported as a bare `****`.

**Tables collapsed into one run.** An article table sits in a non-editable `<section>` — the same wrapper code blocks and separators use — with no branch of its own, so it fell through to the paragraph fallback: `LoopYou hand offUse it whenReach for…`. Adds `TableNode`/`TableRowNode`/`TableCellNode`, a table branch in the article extractor, a GFM table in `renderMarkdown` and a bordered `<table>` in `renderPdfHtml`.

**Fast Batch dropped every code block and table.** X sends those two as an atomic `MARKDOWN` entity holding raw markdown source — the one part of an article body that isn't structured Draft.js. `atomicBlock` knew only `DIVIDER` and `MEDIA`, so it returned `undefined` for them. Measured against a real `TweetDetail` capture: 8,177 chars with zero fences and zero table rows, against 9,868 for the same article through the DOM extractor.

**Fast Batch diverged from a normal export** on two more points: headings came out `## **Getting started**` (X's editor marks all heading text bold), and image URLs used the canonical `…/HMkR.jpg` form where a normal export writes `…?format=jpg&name=large`. Same post, two different files depending on which engine fetched it.

## Verification

A real `TweetDetail` capture for the article that surfaced all of this now renders byte-identical to the DOM extractor's output apart from three known lines — two where Fast Batch is *more* faithful (it reads the author's `**Loop**` and `` `/goal` `` markdown source; the DOM sees X's CSS-styled rendering) and one mention that has no LINK entity in the payload to recover.

- `tests/article-table-ast.test.ts` — 6 tests, builds its own DOM so it runs in CI
- `tests/ast-render-markdown.test.ts` — 7 tests for the emphasis rule
- `tests/json-to-ast.test.ts` — 10 tests for MARKDOWN entities, heading bold, URL normalization
- `tests/json-to-ast-live.test.ts` — asserts against the gitignored capture, skips without it

228 tests pass, `tsc --noEmit` clean, `npm run build` clean.

## Note on the fixture suite

`tests/fixtures/ClaudeDevs-getting-started-with-loops.md` was **silently skipping** — `extractor.test.ts` pairs a `.md` with an `.html` whose filename contains the status id, and neither file had one, so the test warned and passed. Renamed to `ClaudeDevs-2074208949205881033.{md,html}`; the golden is now committed and actually exercised.
