### PR TITLE
fix(batch): follow X's new /i/history routes for Bookmarks and Likes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **Bookmarks and Likes batch export follow X's new History address**: X is moving Bookmarks and Likes under a single History hub — `x.com/i/history` and `x.com/i/history/likes` — and batch export didn't recognize either page, so the Bookmarks and Likes tabs found nothing to collect and **Open Bookmarks** led to the old address. Both new addresses now work, alongside the old `/i/bookmarks` and `/<handle>/likes` for accounts the rollout hasn't reached. The hub's other tabs (Videos, Articles) are deliberately left alone, so History browsing never gets exported as bookmarks.
+- **Bookmarks and Likes batch export follow X's new History address**: X is moving Bookmarks and Likes under a single History hub — `x.com/i/history` and `x.com/i/history/likes` — and batch export didn't recognize either page, so the Bookmarks and Likes tabs found nothing to collect and **Open Bookmarks** led to the old address. Both new addresses now work, alongside the old `/i/bookmarks` and `/<handle>/likes` for accounts the rollout hasn't reached.
 
 ---
 ## [2.7.1] - 2026-08-02

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
+## [2.7.2] - 2026-08-15
+
+### Fixed
+
+- **Bookmarks and Likes batch export follow X's new History address**: X is moving Bookmarks and Likes under a single History hub — `x.com/i/history` and `x.com/i/history/likes` — and batch export didn't recognize either page, so the Bookmarks and Likes tabs found nothing to collect and **Open Bookmarks** led to the old address. Both new addresses now work, alongside the old `/i/bookmarks` and `/<handle>/likes` for accounts the rollout hasn't reached. The hub's other tabs (Videos, Articles) are deliberately left alone, so History browsing never gets exported as bookmarks.
+
+---
 ## [2.7.1] - 2026-08-02
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ---
 ## [2.7.2] - 2026-08-15
 
+### Added
+
+- **Open Likes button jumps straight to your liked posts**: the batch export **Likes** tab used to grey its button out whenever you weren't already on a Likes page, leaving you to go find the page yourself — it had no fixed address to send you to. Your own likes now sit at a fixed address under X's History hub, so the tab offers a working **Open Likes** button, the way Bookmarks and Timeline already did. The label is English for now in every language, until it's translated.
+
 ### Fixed
 
 - **Bookmarks and Likes batch export follow X's new History address**: X is moving Bookmarks and Likes under a single History hub — `x.com/i/history` and `x.com/i/history/likes` — and batch export didn't recognize either page, so the Bookmarks and Likes tabs found nothing to collect and **Open Bookmarks** led to the old address. Both new addresses now work, alongside the old `/i/bookmarks` and `/<handle>/likes` for accounts the rollout hasn't reached. The hub's other tabs (Videos, Articles) are deliberately left alone, so History browsing never gets exported as bookmarks.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "xclipper",
-  "version": "2.7.1",
+  "version": "2.7.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "xclipper",
-      "version": "2.7.1",
+      "version": "2.7.2",
       "license": "PolyForm-Noncommercial-1.0.0",
       "devDependencies": {
         "@puppeteer/browsers": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xclipper",
-  "version": "2.7.1",
+  "version": "2.7.2",
   "description": "XClipper — free, source-available web clipper for X (Twitter). Download threads, posts, and articles as Markdown or PDF for Obsidian, research, and AI/RAG workflows. Works locally — no API, no accounts, no tracking.",
   "license": "PolyForm-Noncommercial-1.0.0",
   "private": true,

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -233,6 +233,9 @@
   "btn_batch_go_timeline": {
     "message": "Open Timeline"
   },
+  "btn_batch_go_likes": {
+    "message": "Open Likes"
+  },
   "group_batch": {
     "message": "Batch export"
   },

--- a/src/background/fast-batch.ts
+++ b/src/background/fast-batch.ts
@@ -14,7 +14,7 @@
 // live:
 //   1) chrome://extensions → XClipper → service worker (Inspect)
 //   2) await xclipperFastBatch()      // grants permission, then EXPORTS bookmarks
-// If it says no request was captured, open https://x.com/i/bookmarks, scroll
+// If it says no request was captured, open https://x.com/i/history, scroll
 // once, and re-run.
 
 import type { Document } from '../ast/types';

--- a/src/background/x-session.ts
+++ b/src/background/x-session.ts
@@ -96,7 +96,7 @@ class HttpError extends Error {
 
 export async function authedFetchJson(url: string): Promise<unknown> {
   if (!auth) {
-    throw new Error('No X auth captured yet — open x.com (e.g. /i/bookmarks) once, then retry');
+    throw new Error('No X auth captured yet — open x.com (e.g. /i/history) once, then retry');
   }
   const res = await fetch(url, {
     method: 'GET',

--- a/src/content/injector.ts
+++ b/src/content/injector.ts
@@ -4,6 +4,7 @@
 
 import { getStatusUrl, normalizeStatusUrl } from './status-url';
 import { decorateSelection, enterSelection, exitSelection } from './selection';
+import { pageSourceOfPath, type XPage } from '../shared/x-routes';
 
 const BUTTON_ATTR = 'data-xclipper-injected';
 let decorated = new WeakSet<Element>();
@@ -285,45 +286,17 @@ function scan(): void {
 // when the source changes, so a later visit doesn't export items removed
 // meanwhile.
 
-// Top-level x.com paths that are app surfaces, not profile handles.
-const NON_PROFILE_PATHS = new Set([
-  'home', 'explore', 'notifications', 'messages', 'settings', 'search',
-  'compose', 'jobs', 'communities', 'premium', 'verified-orgs', 'about',
-  'tos', 'privacy', 'login', 'logout', 'signup', 'share', 'intent',
-  'hashtag', 'places', 'topics', 'account', 'follower_requests',
-]);
-
-type HarvestSource =
-  | { kind: 'bookmarks'; key: string }
-  | { kind: 'profile'; key: string; handle: string }
-  | { kind: 'likes'; key: string }
-  | { kind: 'timeline'; key: string }
-  | null;
+type HarvestSource = (XPage & { key: string }) | null;
 
 function harvestSourceOfPage(): HarvestSource {
-  const path = window.location.pathname;
-  // X moved Bookmarks and Likes under one History surface (/i/history and
-  // /i/history/likes); the older routes still resolve, so match both. Likes
-  // must be tested first — /i/history/likes would otherwise read as Bookmarks.
-  // Likes shows tweets by many authors (the ones the user liked), so unlike a
-  // profile we keep every author's permalink.
-  if (path === '/i/history/likes') return { kind: 'likes', key: 'likes' };
-  if (path === '/i/history' || path === '/i/history/bookmarks' || path.startsWith('/i/bookmarks')) {
-    return { kind: 'bookmarks', key: 'bookmarks' };
-  }
-  // Home feed shows tweets by many authors (like Likes) — keep every author's
-  // permalink (no repost filter, which only applies to a profile).
-  if (path === '/home') return { kind: 'timeline', key: 'timeline' };
-  // Legacy per-account Likes route.
-  const liked = path.match(/^\/([A-Za-z0-9_]{1,15})\/likes$/);
-  if (liked && !NON_PROFILE_PATHS.has(liked[1].toLowerCase())) {
-    return { kind: 'likes', key: `likes:${liked[1].toLowerCase()}` };
-  }
-  const m = path.match(/^\/([A-Za-z0-9_]{1,15})$/);
-  if (m && !NON_PROFILE_PATHS.has(m[1].toLowerCase())) {
-    return { kind: 'profile', key: `profile:${m[1].toLowerCase()}`, handle: m[1] };
-  }
-  return null;
+  const page = pageSourceOfPath(window.location.pathname);
+  if (!page) return null;
+  // Key the dedupe set per account wherever the route names one, so walking
+  // from one profile (or one Likes page) to another starts a fresh set.
+  return {
+    ...page,
+    key: page.handle ? `${page.source}:${page.handle.toLowerCase()}` : page.source,
+  };
 }
 
 const harvested = new Set<string>();
@@ -345,7 +318,7 @@ function harvestTimeline(): HarvestSource {
   for (const article of document.querySelectorAll('article[role="article"]')) {
     const url = getStatusUrl(article);
     if (!url) continue;
-    if (source.kind === 'profile' && !includeReposts) {
+    if (source.source === 'profile' && source.handle && !includeReposts) {
       // Repost cells link to the original author's permalink — skip them so
       // a profile export contains the profile owner's own posts.
       const author = url.match(/x\.com\/([^/]+)\/status\//)?.[1] || '';
@@ -364,8 +337,8 @@ try {
     if (msg && msg.action === 'XCLIPPER_HARVEST') {
       const source = harvestTimeline(); // catch cells rendered since the last mutation
       sendResponse({
-        source: source ? source.kind : null,
-        ...(source?.kind === 'profile' ? { handle: source.handle } : {}),
+        source: source ? source.source : null,
+        ...(source?.source === 'profile' ? { handle: source.handle } : {}),
         urls: Array.from(harvested),
       });
       return false;

--- a/src/content/injector.ts
+++ b/src/content/injector.ts
@@ -296,21 +296,28 @@ const NON_PROFILE_PATHS = new Set([
 type HarvestSource =
   | { kind: 'bookmarks'; key: string }
   | { kind: 'profile'; key: string; handle: string }
-  | { kind: 'likes'; key: string; handle: string }
+  | { kind: 'likes'; key: string }
   | { kind: 'timeline'; key: string }
   | null;
 
 function harvestSourceOfPage(): HarvestSource {
   const path = window.location.pathname;
-  if (path.startsWith('/i/bookmarks')) return { kind: 'bookmarks', key: 'bookmarks' };
+  // X moved Bookmarks and Likes under one History surface (/i/history and
+  // /i/history/likes); the older routes still resolve, so match both. Likes
+  // must be tested first — /i/history/likes would otherwise read as Bookmarks.
+  // Likes shows tweets by many authors (the ones the user liked), so unlike a
+  // profile we keep every author's permalink.
+  if (path === '/i/history/likes') return { kind: 'likes', key: 'likes' };
+  if (path === '/i/history' || path === '/i/history/bookmarks' || path.startsWith('/i/bookmarks')) {
+    return { kind: 'bookmarks', key: 'bookmarks' };
+  }
   // Home feed shows tweets by many authors (like Likes) — keep every author's
   // permalink (no repost filter, which only applies to a profile).
   if (path === '/home') return { kind: 'timeline', key: 'timeline' };
-  // Likes live at /<handle>/likes and show tweets by many authors (the ones
-  // the user liked) — so, unlike a profile, we keep every author's permalink.
+  // Legacy per-account Likes route.
   const liked = path.match(/^\/([A-Za-z0-9_]{1,15})\/likes$/);
   if (liked && !NON_PROFILE_PATHS.has(liked[1].toLowerCase())) {
-    return { kind: 'likes', key: `likes:${liked[1].toLowerCase()}`, handle: liked[1] };
+    return { kind: 'likes', key: `likes:${liked[1].toLowerCase()}` };
   }
   const m = path.match(/^\/([A-Za-z0-9_]{1,15})$/);
   if (m && !NON_PROFILE_PATHS.has(m[1].toLowerCase())) {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "__MSG_extensionName__",
   "short_name": "XClipper",
-  "version": "2.7.1",
+  "version": "2.7.2",
   "description": "__MSG_extensionDescription__",
   "default_locale": "en",
   "permissions": [

--- a/src/popup/batch-ui.ts
+++ b/src/popup/batch-ui.ts
@@ -86,7 +86,7 @@ const TAB_ICONS: Record<BatchTab, SVGElement> = {
 // Sources with a fixed URL we can open directly (no handle needed). Profile and
 // Likes are per-account, so they can't be opened generically.
 const OPEN_URLS: Partial<Record<BatchTab, string>> = {
-  bookmarks: 'https://x.com/i/bookmarks',
+  bookmarks: 'https://x.com/i/history',
   timeline: 'https://x.com/home',
 };
 
@@ -674,7 +674,10 @@ function sourceFromUrl(url: string | undefined): BatchTab | null {
   } catch {
     return null;
   }
-  if (path === '/i/bookmarks') return 'bookmarks';
+  // Bookmarks and Likes now live under X's History surface; the older routes
+  // still resolve, so accept both. `/i/history/likes` falls through to the
+  // Likes test below.
+  if (path === '/i/history' || path === '/i/history/bookmarks' || path === '/i/bookmarks') return 'bookmarks';
   if (path === '/home') return 'timeline';
   if (/\/likes$/.test(path)) return 'likes';
   const reserved = new Set(['/home', '/explore', '/notifications', '/messages', '/search', '/settings', '/i', '/compose']);

--- a/src/popup/batch-ui.ts
+++ b/src/popup/batch-ui.ts
@@ -83,10 +83,12 @@ const TAB_ICONS: Record<BatchTab, SVGElement> = {
   timeline: btnBatchIconTimeline,
 };
 
-// Sources with a fixed URL we can open directly (no handle needed). Profile and
-// Likes are per-account, so they can't be opened generically.
+// Sources with a fixed URL we can open directly (no handle needed). Likes is
+// your own and now sits at a fixed address under History, so it qualifies too;
+// only Profile is per-account and can't be opened generically.
 const OPEN_URLS: Partial<Record<BatchTab, string>> = {
   bookmarks: 'https://x.com/i/history',
+  likes: 'https://x.com/i/history/likes',
   timeline: 'https://x.com/home',
 };
 
@@ -101,7 +103,8 @@ let jobIsActive = false;
 let appendable = false;
 // When the active tab's source has a canonical URL but the user isn't on it,
 // the action button becomes "Open <page>" and navigates there instead of
-// exporting. Only sources that need no handle (bookmarks, timeline) qualify.
+// exporting. Only sources that need no handle (bookmarks, likes, timeline)
+// qualify.
 let openTarget: string | undefined;
 // Last polled snapshot, so a tab switch can re-evaluate progress visibility
 // immediately instead of waiting for the next poll.
@@ -298,9 +301,10 @@ function gateWrongSource(source: HarvestResult['source']): boolean {
   }
   if (activeTab === 'likes' && source !== 'likes') {
     hideDedupAndResets();
+    openTarget = OPEN_URLS.likes;
     setButton(
-      t('btn_batch_likes', 'Export likes'),
-      false,
+      t('btn_batch_go_likes', 'Open Likes'),
+      true,
       t('btn_batch_open_likes', 'Open your Likes page on x.com to export the posts you have liked.')
     );
     return true;

--- a/src/popup/batch-ui.ts
+++ b/src/popup/batch-ui.ts
@@ -18,6 +18,7 @@ import type {
 } from '../types/messages';
 import { hostMatches } from '../shared/media';
 import { loadSettings } from '../shared/settings';
+import { pageSourceOfPath, type XPage } from '../shared/x-routes';
 // Pure module (no chrome.* at import time) — safe to share with the popup.
 import {
   EXPORTED_LEDGER_KEY,
@@ -669,33 +670,24 @@ export async function initBatchUi(): Promise<void> {
 }
 
 // Best-effort page type from the URL, for initial tab focus when the injector
-// hasn't reported a source yet (e.g. right after an extension reload).
-function sourceFromUrl(url: string | undefined): BatchTab | null {
+// hasn't reported a source yet (e.g. right after an extension reload). Shares
+// the injector's route table so the two can't drift.
+function pageFromUrl(url: string | undefined): XPage | null {
   if (!url) return null;
-  let path: string;
   try {
-    path = new URL(url).pathname.replace(/\/+$/, '');
+    return pageSourceOfPath(new URL(url).pathname);
   } catch {
     return null;
   }
-  // Bookmarks and Likes now live under X's History surface; the older routes
-  // still resolve, so accept both. `/i/history/likes` falls through to the
-  // Likes test below.
-  if (path === '/i/history' || path === '/i/history/bookmarks' || path === '/i/bookmarks') return 'bookmarks';
-  if (path === '/home') return 'timeline';
-  if (/\/likes$/.test(path)) return 'likes';
-  const reserved = new Set(['/home', '/explore', '/notifications', '/messages', '/search', '/settings', '/i', '/compose']);
-  if (/^\/[A-Za-z0-9_]{1,15}$/.test(path) && !reserved.has(path)) return 'profile';
-  return null;
+}
+
+function sourceFromUrl(url: string | undefined): BatchTab | null {
+  return pageFromUrl(url)?.source ?? null;
 }
 
 // Profile handle straight from the URL — Fast doesn't need the injector, so this
 // works even when the page wasn't reloaded after an extension update.
 function handleFromUrl(url: string | undefined): string | undefined {
-  if (sourceFromUrl(url) !== 'profile') return undefined;
-  try {
-    return new URL(url as string).pathname.replace(/^\/+|\/+$/g, '').split('/')[0] || undefined;
-  } catch {
-    return undefined;
-  }
+  const page = pageFromUrl(url);
+  return page?.source === 'profile' ? page.handle : undefined;
 }

--- a/src/shared/x-routes.ts
+++ b/src/shared/x-routes.ts
@@ -10,9 +10,11 @@ export type XPageSource = 'bookmarks' | 'likes' | 'timeline' | 'profile';
 
 export interface XPage {
   source: XPageSource;
-  // Whose page it is, when the route names an account: a profile's owner, or
-  // the account whose likes are shown on the legacy `/<handle>/likes` route.
-  // The History routes are always the signed-in user's own, so they carry none.
+  // Whose page it is, when the route names an account. For a profile that's
+  // whoever's posts you're looking at; for the legacy `/<handle>/likes` route
+  // it can only ever be you, since X made likes private years ago — it's kept
+  // so switching accounts still re-keys the harvest. The History routes name
+  // nobody, being always your own.
   handle?: string;
 }
 
@@ -29,10 +31,16 @@ const NON_PROFILE_PATHS = new Set([
 export function pageSourceOfPath(pathname: string): XPage | null {
   const path = pathname.replace(/\/+$/, '');
 
-  // X moved Bookmarks and Likes under one History hub. Likes is tested first,
-  // or `/i/history/likes` reads as the hub's own path. The hub's other tabs
-  // (Videos, Articles) are deliberately left unmatched — they hold browsing
-  // history, not saved posts, and must never export as bookmarks.
+  // X moved Bookmarks and Likes under one History hub, which lands on its
+  // Bookmarks tab at the bare path. Likes is tested first, or `/i/history/likes`
+  // reads as that bare path.
+  //
+  // Both are matched exactly, never by prefix. The web hub carries just these
+  // two tabs today, but the mobile app already adds Videos and Articles, so
+  // more are expected here — and watch history is not something the user saved.
+  // Anything new under the hub stays unharvested until this module says
+  // otherwise. (If X ever re-points the bare path at a different default tab,
+  // the Bookmarks mapping below needs revisiting.)
   if (path === '/i/history/likes') return { source: 'likes' };
   if (path === '/i/history' || path === '/i/history/bookmarks') return { source: 'bookmarks' };
   // Pre-History route, still resolving for accounts the rollout hasn't reached.

--- a/src/shared/x-routes.ts
+++ b/src/shared/x-routes.ts
@@ -1,0 +1,55 @@
+// Which x.com page you're on, as far as batch export cares.
+//
+// Two callers have to agree on this: the injector, which harvests permalinks
+// from the live page, and the popup, which focuses the matching source tab
+// from the active tab's URL. They each carried their own matchers until X
+// moved Bookmarks and Likes under the History hub and both needed the same
+// edit — so the mapping lives here once, pure and tested.
+
+export type XPageSource = 'bookmarks' | 'likes' | 'timeline' | 'profile';
+
+export interface XPage {
+  source: XPageSource;
+  // Whose page it is, when the route names an account: a profile's owner, or
+  // the account whose likes are shown on the legacy `/<handle>/likes` route.
+  // The History routes are always the signed-in user's own, so they carry none.
+  handle?: string;
+}
+
+// Top-level x.com paths that are app surfaces, not profile handles.
+const NON_PROFILE_PATHS = new Set([
+  'home', 'explore', 'notifications', 'messages', 'settings', 'search',
+  'compose', 'jobs', 'communities', 'premium', 'verified-orgs', 'about',
+  'tos', 'privacy', 'login', 'logout', 'signup', 'share', 'intent',
+  'hashtag', 'places', 'topics', 'account', 'follower_requests', 'i',
+]);
+
+// A pathname only — no origin, no query string. Returns null for any page
+// batch export can't harvest, which is most of x.com.
+export function pageSourceOfPath(pathname: string): XPage | null {
+  const path = pathname.replace(/\/+$/, '');
+
+  // X moved Bookmarks and Likes under one History hub. Likes is tested first,
+  // or `/i/history/likes` reads as the hub's own path. The hub's other tabs
+  // (Videos, Articles) are deliberately left unmatched — they hold browsing
+  // history, not saved posts, and must never export as bookmarks.
+  if (path === '/i/history/likes') return { source: 'likes' };
+  if (path === '/i/history' || path === '/i/history/bookmarks') return { source: 'bookmarks' };
+  // Pre-History route, still resolving for accounts the rollout hasn't reached.
+  // Prefix-matched because bookmark folders sit underneath it.
+  if (path === '/i/bookmarks' || path.startsWith('/i/bookmarks/')) return { source: 'bookmarks' };
+
+  if (path === '/home') return { source: 'timeline' };
+
+  // Legacy per-account Likes route.
+  const liked = path.match(/^\/([A-Za-z0-9_]{1,15})\/likes$/);
+  if (liked && !NON_PROFILE_PATHS.has(liked[1].toLowerCase())) {
+    return { source: 'likes', handle: liked[1] };
+  }
+
+  const profile = path.match(/^\/([A-Za-z0-9_]{1,15})$/);
+  if (profile && !NON_PROFILE_PATHS.has(profile[1].toLowerCase())) {
+    return { source: 'profile', handle: profile[1] };
+  }
+  return null;
+}

--- a/src/shared/x-routes.ts
+++ b/src/shared/x-routes.ts
@@ -31,9 +31,11 @@ const NON_PROFILE_PATHS = new Set([
 export function pageSourceOfPath(pathname: string): XPage | null {
   const path = pathname.replace(/\/+$/, '');
 
-  // X moved Bookmarks and Likes under one History hub, which lands on its
-  // Bookmarks tab at the bare path. Likes is tested first, or `/i/history/likes`
-  // reads as that bare path.
+  // X moved Bookmarks and Likes under one History hub. Bookmarks is the hub's
+  // default tab and has no path of its own — selecting it returns to the bare
+  // `/i/history`, and `/i/history/bookmarks` just redirects there — so the bare
+  // path IS the bookmarks page. Likes is tested first, or its path reads as
+  // that bare one.
   //
   // Both are matched exactly, never by prefix. The web hub carries just these
   // two tabs today, but the mobile app already adds Videos and Articles, so
@@ -42,9 +44,10 @@ export function pageSourceOfPath(pathname: string): XPage | null {
   // otherwise. (If X ever re-points the bare path at a different default tab,
   // the Bookmarks mapping below needs revisiting.)
   if (path === '/i/history/likes') return { source: 'likes' };
-  if (path === '/i/history' || path === '/i/history/bookmarks') return { source: 'bookmarks' };
-  // Pre-History route, still resolving for accounts the rollout hasn't reached.
-  // Prefix-matched because bookmark folders sit underneath it.
+  if (path === '/i/history') return { source: 'bookmarks' };
+  // Pre-History routes. These now redirect to the hub, so they're only reached
+  // on accounts the rollout hasn't finished with — but the redirect means a tab
+  // sitting on one is rare either way. Prefix-matched for bookmark folders.
   if (path === '/i/bookmarks' || path.startsWith('/i/bookmarks/')) return { source: 'bookmarks' };
 
   if (path === '/home') return { source: 'timeline' };

--- a/tests/x-routes.test.ts
+++ b/tests/x-routes.test.ts
@@ -6,13 +6,10 @@ import { pageSourceOfPath } from '../src/shared/x-routes';
 // notice, because the matchers simply stopped matching.
 
 describe('pageSourceOfPath() — History hub', () => {
-  // The hub lands on its Bookmarks tab, so the bare path is a bookmarks page.
+  // Bookmarks is the hub's default tab and has no path of its own: selecting it
+  // returns to the bare path, which is therefore the bookmarks page itself.
   it('reads the hub root as Bookmarks', () => {
     expect(pageSourceOfPath('/i/history')).toEqual({ source: 'bookmarks' });
-  });
-
-  it('reads the hub Bookmarks tab as Bookmarks', () => {
-    expect(pageSourceOfPath('/i/history/bookmarks')).toEqual({ source: 'bookmarks' });
   });
 
   it('reads the hub Likes tab as Likes, with no handle', () => {

--- a/tests/x-routes.test.ts
+++ b/tests/x-routes.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from 'vitest';
+import { pageSourceOfPath } from '../src/shared/x-routes';
+
+// The route table these cover is the one X broke when it moved Bookmarks and
+// Likes under the History hub: both batch sources went quiet, with no error to
+// notice, because the matchers simply stopped matching.
+
+describe('pageSourceOfPath() — History hub', () => {
+  it('reads the hub root as Bookmarks', () => {
+    expect(pageSourceOfPath('/i/history')).toEqual({ source: 'bookmarks' });
+  });
+
+  it('reads the hub Bookmarks tab as Bookmarks', () => {
+    expect(pageSourceOfPath('/i/history/bookmarks')).toEqual({ source: 'bookmarks' });
+  });
+
+  it('reads the hub Likes tab as Likes, with no handle', () => {
+    expect(pageSourceOfPath('/i/history/likes')).toEqual({ source: 'likes' });
+  });
+
+  it('does not let the hub root swallow its Likes tab', () => {
+    // `/i/history` must be matched exactly, not by prefix, or the longer path
+    // resolves to Bookmarks and every liked post exports into a bookmarks run.
+    expect(pageSourceOfPath('/i/history/likes')?.source).toBe('likes');
+  });
+
+  // The hub also holds Videos and Articles — browsing history, not saved posts.
+  // Harvesting those as bookmarks would export things the user never saved.
+  it.each(['/i/history/videos', '/i/history/articles'])(
+    'refuses to harvest the %s tab',
+    (path) => {
+      expect(pageSourceOfPath(path)).toBeNull();
+    }
+  );
+
+  it('ignores a trailing slash', () => {
+    expect(pageSourceOfPath('/i/history/')).toEqual({ source: 'bookmarks' });
+    expect(pageSourceOfPath('/i/history/likes/')).toEqual({ source: 'likes' });
+  });
+});
+
+describe('pageSourceOfPath() — pre-History routes', () => {
+  it('still reads the old Bookmarks path', () => {
+    expect(pageSourceOfPath('/i/bookmarks')).toEqual({ source: 'bookmarks' });
+  });
+
+  it('still reads a bookmark folder', () => {
+    expect(pageSourceOfPath('/i/bookmarks/1584645550433751040')).toEqual({
+      source: 'bookmarks',
+    });
+  });
+
+  it('still reads per-account Likes, keeping the handle', () => {
+    // The handle keys the dedupe set, so walking from one account's likes to
+    // another's starts a fresh harvest instead of sharing one set.
+    expect(pageSourceOfPath('/elonmusk/likes')).toEqual({
+      source: 'likes',
+      handle: 'elonmusk',
+    });
+  });
+});
+
+describe('pageSourceOfPath() — profiles and timeline', () => {
+  it('reads the home feed as the timeline', () => {
+    expect(pageSourceOfPath('/home')).toEqual({ source: 'timeline' });
+  });
+
+  it('reads a bare handle as that profile', () => {
+    expect(pageSourceOfPath('/jack')).toEqual({ source: 'profile', handle: 'jack' });
+  });
+
+  it('preserves the handle as written, for display', () => {
+    expect(pageSourceOfPath('/ElonMusk')?.handle).toBe('ElonMusk');
+  });
+
+  // App surfaces sit at the same depth as a handle. Treating one as a profile
+  // would arm the export against a page with no posts to collect.
+  it.each([
+    '/explore',
+    '/notifications',
+    '/messages',
+    '/settings',
+    '/jobs',
+    '/communities',
+    '/i',
+  ])('does not mistake %s for a profile', (path) => {
+    expect(pageSourceOfPath(path)).toBeNull();
+  });
+
+  it('does not mistake a reserved path with /likes for a Likes page', () => {
+    expect(pageSourceOfPath('/settings/likes')).toBeNull();
+  });
+
+  it.each([
+    '/jack/status/20',
+    '/jack/media',
+    '/jack/with_replies',
+    '/i/bookmarksfoo',
+    '/search',
+    '/',
+  ])('returns null for %s', (path) => {
+    expect(pageSourceOfPath(path)).toBeNull();
+  });
+});

--- a/tests/x-routes.test.ts
+++ b/tests/x-routes.test.ts
@@ -6,6 +6,7 @@ import { pageSourceOfPath } from '../src/shared/x-routes';
 // notice, because the matchers simply stopped matching.
 
 describe('pageSourceOfPath() — History hub', () => {
+  // The hub lands on its Bookmarks tab, so the bare path is a bookmarks page.
   it('reads the hub root as Bookmarks', () => {
     expect(pageSourceOfPath('/i/history')).toEqual({ source: 'bookmarks' });
   });
@@ -24,10 +25,13 @@ describe('pageSourceOfPath() — History hub', () => {
     expect(pageSourceOfPath('/i/history/likes')?.source).toBe('likes');
   });
 
-  // The hub also holds Videos and Articles — browsing history, not saved posts.
-  // Harvesting those as bookmarks would export things the user never saved.
+  // Bookmarks and Likes are the only tabs on the web hub today, but the mobile
+  // app already has Videos and Articles and the web rollout is expected to
+  // follow. Those hold watch/read history, not saved posts — harvesting them as
+  // bookmarks would export things the user never saved. Prefix-matching the hub
+  // would do exactly that the day they land.
   it.each(['/i/history/videos', '/i/history/articles'])(
-    'refuses to harvest the %s tab',
+    'refuses to harvest the %s tab if the web rollout adds it',
     (path) => {
       expect(pageSourceOfPath(path)).toBeNull();
     }
@@ -50,12 +54,13 @@ describe('pageSourceOfPath() — pre-History routes', () => {
     });
   });
 
-  it('still reads per-account Likes, keeping the handle', () => {
-    // The handle keys the dedupe set, so walking from one account's likes to
-    // another's starts a fresh harvest instead of sharing one set.
-    expect(pageSourceOfPath('/elonmusk/likes')).toEqual({
+  it('still reads the old Likes route, keeping the handle', () => {
+    // Only ever your own handle — X made likes private years ago. The handle
+    // keys the dedupe set, so switching X accounts starts a fresh harvest
+    // rather than inheriting the previous account's.
+    expect(pageSourceOfPath('/jack/likes')).toEqual({
       source: 'likes',
-      handle: 'elonmusk',
+      handle: 'jack',
     });
   });
 });


### PR DESCRIPTION
X moved Bookmarks and Likes under a single **History** hub. Batch export matched the old paths, so both sources went quiet — the tabs found nothing to collect, with no error to notice, and **Open Bookmarks** led to the old address.

| | before | after |
|---|---|---|
| Bookmarks | `/i/bookmarks` | `/i/history` |
| Likes | `/<handle>/likes` | `/i/history/likes` |

The pre-History paths stay matched: they redirect to the hub now, but the rollout isn't finished and an account that hasn't received it presumably still serves them natively. A stale matcher costs nothing; a missing one silently harvests zero posts.

Verified against the live page (screenshots in the originating conversation): the hub has two tabs, Bookmarks and Likes, and Bookmarks is the default with no path of its own — selecting it returns to the bare `/i/history`, and `/i/history/bookmarks` redirects there. So the bare path *is* the bookmarks page.

## Also here

**Open Likes button** (`4e104c4`) — the Likes tab used to grey its button out when you weren't already on a Likes page, since likes had no fixed address to send you to. Now they do. Only `_locales/en` gets the new string; the other 11 fall back to English via `t()` until translated.

**One tested route module** (`775c9f8`) — the injector and the popup each carried their own matchers and both needed this same edit. Neither was reachable from a test: `injector.ts` injects buttons and registers listeners at import, `batch-ui.ts` pulls in the popup DOM. The mapping now lives in `src/shared/x-routes.ts` — pure, no DOM, no Chrome APIs — with 26 cases.

The hub is matched **exactly, never by prefix**. The mobile app already has Videos and Articles tabs and web is expected to follow; prefix-matching would harvest watch history as bookmarks the day they land. Two guard cases assert it doesn't.

## Behavior changes beyond the fix

All corrections, all in `775c9f8`:

- The popup adopted the injector's fuller reserved-path list, so `/jobs`, `/communities`, `/tos` no longer read as profiles.
- The popup matched *any* path ending in `/likes`; it now matches the real routes.
- The old `startsWith('/i/bookmarks')` matched `/i/bookmarksfoo`; folders are matched explicitly.
- Likes keeps its handle on the legacy route, so its dedupe key stays per-account — re-keying the harvest when you switch X accounts.

## Release

Bumped to **2.7.2** (`package.json`, `package-lock.json`, `src/manifest.json`) with a CHANGELOG entry under Added and Fixed. No tag created.

## Testing

`npm run typecheck`, `npm test` (255 passing, +26 new), `npm run build` — all clean.

Not covered by any test, and worth doing before release: load `dist/` unpacked, scroll `/i/history`, and confirm the popup counts posts and the Likes tab offers **Open Likes**. That path needs the live DOM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)