### PR TITLE
style(popup): move the Auto/Super red signal from segments to the (i)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Open Likes button jumps straight to your liked posts**: the batch export **Likes** tab used to grey its button out whenever you weren't already on a Likes page, leaving you to go find the page yourself — it had no fixed address to send you to. Your own likes now sit at a fixed address under X's History hub, so the tab offers a working **Open Likes** button, the way Bookmarks and Timeline already did. The label is English for now in every language, until it's translated.
 
+### Changed
+
+- **Auto and Super no longer wash the popup in red**: choosing one of the session-based engines used to turn the engine segment *and* the active source icon solid red, which read as an alarm rather than a mode. Both now use the same blue as every other selected control, and the "this runs through your logged-in X session" signal moved to the small ⓘ beside the explanation — red, and shown only for Auto and Super.
+
 ### Fixed
 
 - **Bookmarks and Likes batch export follow X's new History address**: X is moving Bookmarks and Likes under a single History hub — `x.com/i/history` and `x.com/i/history/likes` — and batch export didn't recognize either page, so the Bookmarks and Likes tabs found nothing to collect and **Open Bookmarks** led to the old address. Both new addresses now work, alongside the old `/i/bookmarks` and `/<handle>/likes` for accounts the rollout hasn't reached.

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -13,8 +13,6 @@
   --success-bg: rgba(0, 186, 124, 0.12);
   --error: #f4212e;
   --error-bg: rgba(244, 33, 46, 0.12);
-  --error-glow: rgba(244, 33, 46, 0.28);
-  --error-tint: rgba(244, 33, 46, 0.16);
   --warning: #9a6700;
   --warning-bg: rgba(212, 167, 44, 0.14);
   --border-subtle: rgba(0, 0, 0, 0.08);
@@ -936,7 +934,7 @@ body {
   margin-inline-end: 4px;
 }
 
-/* ─── Fast Batch toggle (red, sits above Export settings) ─────── */
+/* ─── Fast Batch toggle (sits above Export settings) ──────────── */
 /* Batch engine selector: Manual | Auto | Super — one segmented control that
  * replaces the old Fast on/off + Super on/off toggles. Full-width so it reads as
  * a primary choice; the fetch-mode segment (.fast-seg) below twins its shape. */
@@ -971,20 +969,13 @@ body {
   border-left: 1px solid var(--border-subtle);
 }
 
-/* Manual selected — the batch accent (same blue as the Export button + the
- * fetch-mode segment), the neutral "selected" for the no-permission engine. */
+/* Selected engine — the batch accent (same blue as the Export button + the
+ * fetch-mode segment) for every engine, Manual included. The "uses your X
+ * session" signal is carried by the red (i) beside the caption, not by a red
+ * segment. */
 .mode-seg-btn.active {
   background: var(--batch);
   color: #fff;
-}
-
-/* Auto / Super carry the "uses your X session" signal in red when active, so the
- * consent-bearing engines stay visually distinct from plain Manual. */
-#mode-auto.active,
-#mode-super.active {
-  background: var(--error);
-  color: #fff;
-  box-shadow: 0 2px 8px var(--error-glow);
 }
 
 .mode-seg-btn .beta-badge {
@@ -1043,12 +1034,15 @@ body {
   flex: 1;
 }
 
+/* Shown for Auto/Super only — it is the single red mark in the batch view, the
+ * "uses your logged-in X session" signal that used to colour the whole engine
+ * segment and the active source tab. */
 .mode-info {
   display: inline-flex;
   align-items: center;
   flex-shrink: 0;
   margin-bottom: 1px;
-  color: var(--text-secondary);
+  color: var(--error);
   cursor: help;
 }
 
@@ -1227,14 +1221,6 @@ body {
 .fast-step[data-tooltip]:hover::after,
 .fast-step[data-tooltip]:focus-visible::after {
   transform: translateX(0) translateY(0);
-}
-
-/* When Auto/Super is selected the red signals are the engine selector, the step
- * lights, and the ACTIVE source tab — everything else (Export button, progress,
- * reset buttons) stays the normal blue to avoid a wall of red. */
-#view-main.fast-on .batch-tab.active {
-  background: var(--error);
-  box-shadow: 0 2px 8px var(--error-glow);
 }
 
 /* Fast Batch has no honest determinate total — collection is open-ended and


### PR DESCRIPTION
## What

Auto and Super used to paint two large surfaces red: the engine segment itself, and the active source icon in the row above it (`#view-main.fast-on .batch-tab.active`). Together they read as an alarm state rather than "you picked a mode".

Red now survives in exactly one place — the ⓘ next to the engine caption, which is already Auto/Super-only — so the "runs through your logged-in X session" signal is still there, just proportionate.

## Changes

- `#mode-auto.active, #mode-super.active` removed — Auto and Super use the shared `.mode-seg-btn.active` blue, same as Manual and the fetch-mode segment.
- `#view-main.fast-on .batch-tab.active` removed — the active source icon stays blue in every engine. The `.fast-on` class itself is kept; it still drives the progress-bar and status-row layout.
- `.mode-info` recoloured to `var(--error)`. It's unhidden only for Auto/Super (`fast-batch-ui.ts:151`), so it appears exactly when the signal applies.
- Dropped `--error-glow` (orphaned by the two removals) and `--error-tint` (already dead before this branch).

Red left in the popup, all still live: `.status.error`, `.fast-locked-hint`, and the `missing` step light.

## Verification

`npm run typecheck` clean, `npx vitest run` 255 passed. CSS-only — no extractor or renderer output changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
