### PR TITLE
fix(fast-batch): follow X's rename of the profile timeline operation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
+## [2.7.3] - 2026-08-20
+
+### Fixed
+
+- **Profile export works again in Auto and Super**: the **Profile** tab's first step light stayed red however often you reloaded the profile page, so a profile export could never start — X renamed the request that loads a profile's posts, and XClipper was still watching for the old name. Both names are now recognized, so the light turns green the way it always did for Bookmarks and Likes. Bookmarks and Likes were never affected. (#107)
+
+---
 ## [2.7.2] - 2026-08-15
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "xclipper",
-  "version": "2.7.2",
+  "version": "2.7.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "xclipper",
-      "version": "2.7.2",
+      "version": "2.7.3",
       "license": "PolyForm-Noncommercial-1.0.0",
       "devDependencies": {
         "@puppeteer/browsers": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xclipper",
-  "version": "2.7.2",
+  "version": "2.7.3",
   "description": "XClipper — free, source-available web clipper for X (Twitter). Download threads, posts, and articles as Markdown or PDF for Obsidian, research, and AI/RAG workflows. Works locally — no API, no accounts, no tracking.",
   "license": "PolyForm-Noncommercial-1.0.0",
   "private": true,

--- a/src/background/fast-batch.ts
+++ b/src/background/fast-batch.ts
@@ -150,12 +150,19 @@ export interface FastBatchResult {
 
 export type FastSource = 'bookmarks' | 'profile' | 'likes';
 
-// Which captured GraphQL operation backs each source, + a label for progress.
-const SOURCE_CONFIG: Record<FastSource, { op: string; label: string }> = {
-  bookmarks: { op: 'Bookmarks', label: 'bookmarks' },
-  profile: { op: 'UserTweets', label: 'posts' },
-  likes: { op: 'Likes', label: 'likes' },
+// Which captured GraphQL operations back each source, + a label for progress.
+// Listed newest-first: X renames these (the profile Posts timeline went from
+// `UserTweets` to `UserOriginalsTimeline`), and the old name keeps working for
+// clients still being served it, so whichever was captured is used (#107).
+const SOURCE_CONFIG: Record<FastSource, { ops: string[]; label: string }> = {
+  bookmarks: { ops: ['Bookmarks'], label: 'bookmarks' },
+  profile: { ops: ['UserOriginalsTimeline', 'UserTweets'], label: 'posts' },
+  likes: { ops: ['Likes'], label: 'likes' },
 };
+
+// The captured request for a source's feed, or undefined if none was seen yet.
+const feedTemplate = (source: FastSource): string | undefined =>
+  SOURCE_CONFIG[source].ops.map((op) => templates[op]).find(Boolean);
 
 // Resume-mode frontier per source (issue #83): the cursor where the last Resume
 // run stopped consuming, so the next continues from there.
@@ -282,7 +289,8 @@ async function runFastBatchExport(opts: FastBatchOptions = {}): Promise<FastBatc
   // profile / likes), and (to expand threads/articles) TweetDetail. After an
   // extension reload neither has been seen yet. Check BOTH up front (before
   // paginating) and give one plain hint — the user does it once, then it works.
-  const needFeed = !templates[cfg.op];
+  const template = feedTemplate(source);
+  const needFeed = !template;
   const needTweetDetail = expandThreads && !templates.TweetDetail;
   if (needFeed || needTweetDetail) {
     const feedHint = `Reload your ${cfg.label} page`;
@@ -292,11 +300,10 @@ async function runFastBatchExport(opts: FastBatchOptions = {}): Promise<FastBatc
         : needFeed
           ? `${feedHint}, then click Export again.`
           : 'Open any one tweet, then click Export again.';
-    log(`preconditions missing (${cfg.op}:${needFeed} tweetDetail:${needTweetDetail})`);
+    log(`preconditions missing (${cfg.ops.join('/')}:${needFeed} tweetDetail:${needTweetDetail})`);
     setProgress({ status: 'error', needTweetDetail, error: msg });
     return null;
   }
-  const template = templates[cfg.op];
 
   const settings = await loadSettings();
   // Profile: drop reposts unless the user opted to include them (matches Standard).
@@ -705,7 +712,7 @@ export function initFastBatch(): void {
       void (async () => {
         await restoreSession(); // templates may live in session storage after a SW restart
         sendResponse({
-          feed: !!templates[SOURCE_CONFIG[src].op],
+          feed: !!feedTemplate(src),
           tweetDetail: !!templates.TweetDetail,
         } satisfies FastBatchReadyResponse);
       })();

--- a/src/background/x-session.ts
+++ b/src/background/x-session.ts
@@ -41,9 +41,12 @@ function captureHeaders(
     void chrome.storage.session.set({ [SESSION_AUTH_KEY]: auth });
   }
 
-  const op = details.url.match(/\/graphql\/[^/]+\/(Bookmarks|Likes|UserTweets|TweetDetail)\b/)?.[1];
+  const op = details.url.match(
+    /\/graphql\/[^/]+\/(Bookmarks|Likes|UserOriginalsTimeline|UserTweets|TweetDetail)\b/
+  )?.[1];
   if (op && templates[op] !== details.url) {
     templates[op] = details.url;
+    log('captured', op); // which step lights go green is otherwise invisible
     void chrome.storage.session.set({ [SESSION_TEMPLATES_KEY]: { ...templates } });
   }
   return undefined; // observe-only; never block/modify

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "__MSG_extensionName__",
   "short_name": "XClipper",
-  "version": "2.7.2",
+  "version": "2.7.3",
   "description": "__MSG_extensionDescription__",
   "default_locale": "en",
   "permissions": [


### PR DESCRIPTION
Fixes #107.

## The problem

In Auto and Super, the **Profile** source could never become ready: its first step light stayed red no matter how often the profile page was reloaded, so a profile export could not start (pre-flight failed with *"Reload your posts page, then click Export again."*). Bookmarks and Likes were unaffected.

## Root cause

X renamed the profile Posts timeline operation. A profile page now fires **`UserOriginalsTimeline`**, not `UserTweets`. The capture regex matched only the four known names, so the profile request was observed and discarded — `fastBatchTemplates` held `Bookmarks`, `Likes` and `TweetDetail` and nothing else. Bookmarks and Likes kept working because their op names are unchanged.

Found by temporarily logging every GraphQL op the browser fires while a profile page loads:

```
saw op UserByScreenName
saw op ProfileSpotlightsQuery
saw op UserOriginalsTimeline   ← the posts timeline
saw op UsersByRestIds
```

Same family as 88a2d1e, where X moved Bookmarks and Likes under `/i/history`.

## The change

- `x-session.ts` — capture `UserOriginalsTimeline` alongside the existing ops.
- `fast-batch.ts` — `SOURCE_CONFIG` now names *several* operations per source, newest first, and `feedTemplate()` resolves whichever was captured. X still serves the old name to some clients, so accepting either avoids a hard cutover and makes the next rename a one-line change.
- `x-session.ts` — log each captured template. This was previously invisible, which is what made the bug take two wrong theories to find.

Nothing changes for Bookmarks or Likes, and the Standard (Manual) engine never used this path.

## Verification

Manually verified against a live session: the Profile light turns green after a profile reload, and an export pulls the right posts. `npm run typecheck` clean, 255 tests pass, `npm run build` clean.

The response side needed no change — `findTimeline()` already falls back to a generic search for the `instructions` array, so the new payload key parses as-is.

## Follow-ups (not in this PR)

- The replayed request carries the `userId` of whichever profile was captured last, so capturing profile A then exporting from profile B may pull A's posts. Pre-existing, unrelated to the rename.
- `UserOriginalsTimeline` may already exclude reposts server-side, which would make `includeReposts` a no-op on this path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
