### PR TITLE
chore(fast-batch): drop the leftover capture log line (2.7.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
+## [2.7.4] - 2026-08-21
+
+### Changed
+
+- **Fast Batch no longer logs each captured request**: the background console wrote a line every time a bookmarks, likes or profile page fetched another batch of posts while you scrolled. It was a debugging aid left over from the 2.7.3 profile fix; nothing else changes.
+
+---
 ## [2.7.3] - 2026-08-20
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "xclipper",
-  "version": "2.7.3",
+  "version": "2.7.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "xclipper",
-      "version": "2.7.3",
+      "version": "2.7.4",
       "license": "PolyForm-Noncommercial-1.0.0",
       "devDependencies": {
         "@puppeteer/browsers": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xclipper",
-  "version": "2.7.3",
+  "version": "2.7.4",
   "description": "XClipper — free, source-available web clipper for X (Twitter). Download threads, posts, and articles as Markdown or PDF for Obsidian, research, and AI/RAG workflows. Works locally — no API, no accounts, no tracking.",
   "license": "PolyForm-Noncommercial-1.0.0",
   "private": true,

--- a/src/background/x-session.ts
+++ b/src/background/x-session.ts
@@ -46,7 +46,6 @@ function captureHeaders(
   )?.[1];
   if (op && templates[op] !== details.url) {
     templates[op] = details.url;
-    log('captured', op); // which step lights go green is otherwise invisible
     void chrome.storage.session.set({ [SESSION_TEMPLATES_KEY]: { ...templates } });
   }
   return undefined; // observe-only; never block/modify

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "__MSG_extensionName__",
   "short_name": "XClipper",
-  "version": "2.7.3",
+  "version": "2.7.4",
   "description": "__MSG_extensionDescription__",
   "default_locale": "en",
   "permissions": [


### PR DESCRIPTION
Removes one line of debug output that went out with 2.7.3, and bumps to 2.7.4.

## What

`x-session.ts` logged `captured <op>` whenever a stored GraphQL template changed. That condition is `templates[op] !== details.url`, and the URL carries the pagination cursor — so it fired once per *page*, writing a console line for every batch fetched while scrolling bookmarks, likes or a profile, not once per session as intended.

It was a diagnostic aid for #107. The bug is understood, so the line goes.

## Cost, for the record

Not a performance fix. With DevTools closed the call still runs — args evaluated, string built, message handed to Blink's bounded in-memory console buffer — but that's microseconds and a few hundred bytes, freed when the worker is torn down. The reason to remove it is that it's leftover debug output that clutters the console for anyone who opens it.

Worth noting for later, unrelated to this PR: the `chrome.storage.session.set` on the same condition *is* real per-page work (structured clone + IPC to the browser process) and re-stores the template every time the cursor advances, when only a shape change matters.

## Release

2.7.3 is live on the Web Store, so this goes out as 2.7.4 — `package.json`, `package-lock.json`, `src/manifest.json`, and a **Changed** entry in the CHANGELOG. No behavior change.

`npm run typecheck` clean, 255 tests pass, `npm run build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
