### PR TITLE
fix(ast): render PDF dates in UTC to match stored timestamps

### DIFF
--- a/src/ast/render-pdf-html.ts
+++ b/src/ast/render-pdf-html.ts
@@ -125,7 +125,7 @@ function renderAuthorHeader(tweet: TweetNode): string {
 function formatDate(iso: string): string {
   const d = new Date(iso);
   if (isNaN(d.getTime())) return '';
-  return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+  return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric', timeZone: 'UTC' });
 }
 
 function renderEngagement(e: NonNullable<TweetNode['engagement']>): string {


### PR DESCRIPTION
## What

One-line fix: `formatDate` in `src/ast/render-pdf-html.ts` formatted the stored UTC timestamp with `toLocaleDateString` in the machine's local timezone, so PDF exports made west of UTC could show the previous day's date for late-evening tweets. Adding `timeZone: 'UTC'` makes the PDF date match the stored timestamp and the Markdown export's date.

## Why it qualifies as a direct PR

Per CONTRIBUTING this is a small bug fix — no output-format change beyond correcting a wrong date, no locale strings, no permissions.

## Testing

`npm test`: 221 passed / 8 skipped with this change applied; typecheck and build clean.
