### PR TITLE
Fast Batch: save video / GIF files (progressive MP4) with local media saving (#95)

### DIFF
--- a/src/_locales/ar/messages.json
+++ b/src/_locales/ar/messages.json
@@ -404,11 +404,20 @@
   "opt_obsidian_tags_info": {
     "message": "إظهار عناصر الوسوم النائبة"
   },
-  "opt_save_images_title": {
-    "message": "تنزيل الصور إلى مجلد بجانب ملف Markdown"
+  "opt_save_local_title": {
+    "message": "إيقاف: الإبقاء على الوسائط كروابط إلى X. الصور: تنزيل الصور إلى مجلد بجانب ملف Markdown. الوسائط: حفظ الفيديو أيضاً بصيغة .mp4 — وحجمه أكبر بكثير."
   },
-  "opt_save_images": {
-    "message": "حفظ الصور محلياً (مع .md فقط)"
+  "opt_save_local": {
+    "message": "حفظ محلي (مع .md فقط)"
+  },
+  "opt_save_local_off": {
+    "message": "إيقاف"
+  },
+  "opt_save_local_images": {
+    "message": "الصور"
+  },
+  "opt_save_local_media": {
+    "message": "الوسائط"
   },
   "opt_metadata_title": {
     "message": "إضافة الإعجابات وإعادات النشر والمشاهدات كـ YAML frontmatter"

--- a/src/_locales/de/messages.json
+++ b/src/_locales/de/messages.json
@@ -404,11 +404,20 @@
   "opt_obsidian_tags_info": {
     "message": "Tag-Platzhalter anzeigen"
   },
-  "opt_save_images_title": {
-    "message": "Bilder in einem Ordner neben der Markdown-Datei speichern"
+  "opt_save_local_title": {
+    "message": "Aus: Medien als Links zu X behalten. Bilder: Bilder in einem Ordner neben der Markdown-Datei speichern. Medien: zusätzlich Videos als .mp4 speichern — diese sind deutlich größer."
   },
-  "opt_save_images": {
-    "message": "Bilder lokal speichern (nur mit .md)"
+  "opt_save_local": {
+    "message": "Lokal speichern (nur mit .md)"
+  },
+  "opt_save_local_off": {
+    "message": "Aus"
+  },
+  "opt_save_local_images": {
+    "message": "Bilder"
+  },
+  "opt_save_local_media": {
+    "message": "Medien"
   },
   "opt_metadata_title": {
     "message": "Likes, Reposts, Aufrufe als YAML-Frontmatter hinzufügen"

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -449,11 +449,20 @@
   "opt_obsidian_tags_info": {
     "message": "Show tag placeholders"
   },
-  "opt_save_images_title": {
-    "message": "Download images to a folder next to the Markdown file"
+  "opt_save_local_title": {
+    "message": "Off: keep media as links to X. Images: download images to a folder next to the Markdown file. Media: save videos as .mp4 too — these are far larger."
   },
-  "opt_save_images": {
-    "message": "Save images locally (only with .md)"
+  "opt_save_local": {
+    "message": "Save locally (only with .md)"
+  },
+  "opt_save_local_off": {
+    "message": "Off"
+  },
+  "opt_save_local_images": {
+    "message": "Images"
+  },
+  "opt_save_local_media": {
+    "message": "Media"
   },
   "opt_metadata_title": {
     "message": "Add likes, reposts, views as YAML frontmatter"

--- a/src/_locales/es/messages.json
+++ b/src/_locales/es/messages.json
@@ -404,11 +404,20 @@
   "opt_obsidian_tags_info": {
     "message": "Mostrar marcadores de etiquetas"
   },
-  "opt_save_images_title": {
-    "message": "Descarga las imágenes en una carpeta junto al archivo Markdown"
+  "opt_save_local_title": {
+    "message": "Desactivado: mantener el contenido como enlaces a X. Imágenes: descargar las imágenes en una carpeta junto al archivo Markdown. Multimedia: descargar también los vídeos en .mp4, mucho más pesados."
   },
-  "opt_save_images": {
-    "message": "Guardar imágenes localmente (solo con .md)"
+  "opt_save_local": {
+    "message": "Guardar localmente (solo con .md)"
+  },
+  "opt_save_local_off": {
+    "message": "Desactivado"
+  },
+  "opt_save_local_images": {
+    "message": "Imágenes"
+  },
+  "opt_save_local_media": {
+    "message": "Multimedia"
   },
   "opt_metadata_title": {
     "message": "Añade me gusta, reposts y vistas como frontmatter YAML"

--- a/src/_locales/fa/messages.json
+++ b/src/_locales/fa/messages.json
@@ -404,11 +404,20 @@
   "opt_obsidian_tags_info": {
     "message": "نمایش placeholder های برچسب"
   },
-  "opt_save_images_title": {
-    "message": "دانلود تصاویر در پوشه‌ای در کنار فایل Markdown"
+  "opt_save_local_title": {
+    "message": "خاموش: رسانه به صورت پیوند به X باقی می‌ماند. تصاویر: دانلود تصاویر در پوشه‌ای در کنار فایل Markdown. رسانه: ذخیره ویدیوها به صورت .mp4 نیز — حجم آن‌ها بسیار بیشتر است."
   },
-  "opt_save_images": {
-    "message": "ذخیره محلی تصاویر (فقط با .md)"
+  "opt_save_local": {
+    "message": "ذخیره محلی (فقط با .md)"
+  },
+  "opt_save_local_off": {
+    "message": "Off"
+  },
+  "opt_save_local_images": {
+    "message": "Images"
+  },
+  "opt_save_local_media": {
+    "message": "Media"
   },
   "opt_metadata_title": {
     "message": "افزودن لایک‌ها، بازنشرها و بازدیدها به YAML frontmatter"

--- a/src/_locales/fr/messages.json
+++ b/src/_locales/fr/messages.json
@@ -404,11 +404,20 @@
   "opt_obsidian_tags_info": {
     "message": "Afficher les placeholders de tags"
   },
-  "opt_save_images_title": {
-    "message": "Télécharger les images dans un dossier à côté du fichier Markdown"
+  "opt_save_local_title": {
+    "message": "Désactivé : conserver les médias sous forme de liens vers X. Images : enregistrer les images dans un dossier à côté du fichier Markdown. Médias : enregistrer aussi les vidéos en .mp4 — bien plus volumineuses."
   },
-  "opt_save_images": {
-    "message": "Enregistrer les images localement (seulement avec .md)"
+  "opt_save_local": {
+    "message": "Enregistrer localement (seulement avec .md)"
+  },
+  "opt_save_local_off": {
+    "message": "Désactivé"
+  },
+  "opt_save_local_images": {
+    "message": "Images"
+  },
+  "opt_save_local_media": {
+    "message": "Médias"
   },
   "opt_metadata_title": {
     "message": "Ajouter les j'aime, reposts, vues en tant que YAML frontmatter"

--- a/src/_locales/hi/messages.json
+++ b/src/_locales/hi/messages.json
@@ -404,11 +404,20 @@
   "opt_obsidian_tags_info": {
     "message": "टैग placeholders दिखाएँ"
   },
-  "opt_save_images_title": {
-    "message": "Markdown फ़ाइल के बगल वाले फ़ोल्डर में इमेज डाउनलोड करें"
+  "opt_save_local_title": {
+    "message": "Off: मीडिया X के लिंक के रूप में ही रहेगा। Images: Markdown फ़ाइल के बगल वाले फ़ोल्डर में इमेज डाउनलोड करें। Media: वीडियो भी .mp4 में सेव करें — ये बहुत बड़े होते हैं।"
   },
-  "opt_save_images": {
-    "message": "Images locally save करें (केवल .md)"
+  "opt_save_local": {
+    "message": "Locally save करें (केवल .md)"
+  },
+  "opt_save_local_off": {
+    "message": "Off"
+  },
+  "opt_save_local_images": {
+    "message": "Images"
+  },
+  "opt_save_local_media": {
+    "message": "Media"
   },
   "opt_metadata_title": {
     "message": "likes, reposts, views को YAML frontmatter में जोड़ें"

--- a/src/_locales/it/messages.json
+++ b/src/_locales/it/messages.json
@@ -404,11 +404,20 @@
   "opt_obsidian_tags_info": {
     "message": "Mostra i placeholder dei tag"
   },
-  "opt_save_images_title": {
-    "message": "Scarica le immagini in una cartella accanto al file Markdown"
+  "opt_save_local_title": {
+    "message": "Off: mantieni i media come link a X. Immagini: scarica le immagini in una cartella accanto al file Markdown. Media: salva anche i video in .mp4 — molto più pesanti."
   },
-  "opt_save_images": {
-    "message": "Salva immagini in locale (solo con .md)"
+  "opt_save_local": {
+    "message": "Salva in locale (solo con .md)"
+  },
+  "opt_save_local_off": {
+    "message": "Off"
+  },
+  "opt_save_local_images": {
+    "message": "Immagini"
+  },
+  "opt_save_local_media": {
+    "message": "Media"
   },
   "opt_metadata_title": {
     "message": "Aggiungi like, repost, visualizzazioni come frontmatter YAML"

--- a/src/_locales/ja/messages.json
+++ b/src/_locales/ja/messages.json
@@ -404,11 +404,20 @@
   "opt_obsidian_tags_info": {
     "message": "タグのプレースホルダーを表示"
   },
-  "opt_save_images_title": {
-    "message": "Markdownファイルと同じフォルダに画像をダウンロードする"
+  "opt_save_local_title": {
+    "message": "オフ: メディアは X へのリンクのままにします。画像: Markdown ファイルと同じフォルダに画像をダウンロードします。メディア: 動画も .mp4 で保存します（サイズが大幅に大きくなります）。"
   },
-  "opt_save_images": {
-    "message": "画像をローカル保存（.md のみ）"
+  "opt_save_local": {
+    "message": "ローカル保存（.md のみ）"
+  },
+  "opt_save_local_off": {
+    "message": "オフ"
+  },
+  "opt_save_local_images": {
+    "message": "画像"
+  },
+  "opt_save_local_media": {
+    "message": "メディア"
   },
   "opt_metadata_title": {
     "message": "いいね、リポスト、閲覧数をYAMLフロントマターとして追加"

--- a/src/_locales/pt_BR/messages.json
+++ b/src/_locales/pt_BR/messages.json
@@ -404,11 +404,20 @@
   "opt_obsidian_tags_info": {
     "message": "Mostrar placeholders de tags"
   },
-  "opt_save_images_title": {
-    "message": "Baixar imagens para uma pasta ao lado do arquivo Markdown"
+  "opt_save_local_title": {
+    "message": "Desligado: manter a mídia como links para o X. Imagens: baixar as imagens para uma pasta ao lado do arquivo Markdown. Mídia: salvar também os vídeos em .mp4 — bem maiores."
   },
-  "opt_save_images": {
-    "message": "Salvar imagens localmente (somente com .md)"
+  "opt_save_local": {
+    "message": "Salvar localmente (somente com .md)"
+  },
+  "opt_save_local_off": {
+    "message": "Desligado"
+  },
+  "opt_save_local_images": {
+    "message": "Imagens"
+  },
+  "opt_save_local_media": {
+    "message": "Mídia"
   },
   "opt_metadata_title": {
     "message": "Adicionar curtidas, reposts, visualizações como YAML frontmatter"

--- a/src/_locales/ru/messages.json
+++ b/src/_locales/ru/messages.json
@@ -404,11 +404,20 @@
   "opt_obsidian_tags_info": {
     "message": "Показать плейсхолдеры тегов"
   },
-  "opt_save_images_title": {
-    "message": "Скачивать изображения в папку рядом с Markdown-файлом"
+  "opt_save_local_title": {
+    "message": "Выкл.: оставить медиа ссылками на X. Изображения: скачивать изображения в папку рядом с Markdown-файлом. Медиа: сохранять также видео в .mp4 — они значительно больше."
   },
-  "opt_save_images": {
-    "message": "Сохранять изображения локально (только с .md)"
+  "opt_save_local": {
+    "message": "Сохранять локально (только с .md)"
+  },
+  "opt_save_local_off": {
+    "message": "Выкл."
+  },
+  "opt_save_local_images": {
+    "message": "Изображения"
+  },
+  "opt_save_local_media": {
+    "message": "Медиа"
   },
   "opt_metadata_title": {
     "message": "Добавлять лайки, репосты, просмотры как YAML frontmatter"

--- a/src/_locales/zh_CN/messages.json
+++ b/src/_locales/zh_CN/messages.json
@@ -404,11 +404,20 @@
   "opt_obsidian_tags_info": {
     "message": "显示标签占位符"
   },
-  "opt_save_images_title": {
-    "message": "将图片下载到 Markdown 文件旁的文件夹中"
+  "opt_save_local_title": {
+    "message": "关闭：媒体保留为 X 链接。图片：将图片下载到 Markdown 文件旁的文件夹中。媒体：同时将视频保存为 .mp4——体积大得多。"
   },
-  "opt_save_images": {
-    "message": "本地保存图片（仅 .md）"
+  "opt_save_local": {
+    "message": "本地保存（仅 .md）"
+  },
+  "opt_save_local_off": {
+    "message": "关闭"
+  },
+  "opt_save_local_images": {
+    "message": "图片"
+  },
+  "opt_save_local_media": {
+    "message": "媒体"
   },
   "opt_metadata_title": {
     "message": "将点赞、转发、浏览量作为 YAML frontmatter 添加"

--- a/src/ast/collect-media.ts
+++ b/src/ast/collect-media.ts
@@ -1,0 +1,101 @@
+import type { Block, Document, MediaItem, TweetNode } from './types';
+
+export interface CollectedMedia {
+  kind: 'image' | 'video' | 'gif';
+  url: string;
+  posterUrl?: string;
+  tweetId?: string;
+}
+
+export function collectMedia(doc: Document): CollectedMedia[] {
+  const media: CollectedMedia[] = [];
+
+  switch (doc.body.type) {
+    case 'tweet':
+      collectTweetMedia(doc.body, media);
+      break;
+    case 'thread':
+      for (const tweet of doc.body.tweets) collectTweetMedia(tweet, media);
+      break;
+    case 'article':
+      collectArticleBlocks(doc.body.children, media);
+      break;
+  }
+
+  return media;
+}
+
+export function isDownloadableVideo(media: CollectedMedia): boolean {
+  return (media.kind === 'video' || media.kind === 'gif')
+    && media.url !== media.posterUrl
+    && isProgressiveMp4(media.url);
+}
+
+export function isProgressiveMp4(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    return parsed.protocol === 'https:'
+      && parsed.hostname === 'video.twimg.com'
+      && parsed.pathname.toLowerCase().endsWith('.mp4');
+  } catch {
+    return false;
+  }
+}
+
+function collectTweetMedia(tweet: TweetNode, out: CollectedMedia[]): void {
+  for (const media of tweet.media) out.push(collectedTweetMedia(media, tweet.tweetId));
+  if (tweet.quotedTweet) collectTweetMedia(tweet.quotedTweet, out);
+}
+
+function collectedTweetMedia(media: MediaItem, tweetId: string): CollectedMedia {
+  return {
+    kind: media.kind,
+    url: media.url,
+    ...(media.posterUrl !== undefined ? { posterUrl: media.posterUrl } : {}),
+    tweetId,
+  };
+}
+
+function collectArticleBlocks(blocks: Block[], out: CollectedMedia[]): void {
+  for (const block of blocks) collectArticleBlock(block, out);
+}
+
+function collectArticleBlock(block: Block, out: CollectedMedia[]): void {
+  switch (block.type) {
+    case 'tweet':
+      collectTweetMedia(block, out);
+      return;
+    case 'thread':
+      for (const tweet of block.tweets) collectTweetMedia(tweet, out);
+      return;
+    case 'article':
+      collectArticleBlocks(block.children, out);
+      return;
+    case 'image':
+      out.push({ kind: 'image', url: block.url });
+      return;
+    case 'video':
+      out.push({
+        kind: 'video',
+        url: block.sourceUrl,
+        ...(block.posterUrl !== undefined ? { posterUrl: block.posterUrl } : {}),
+      });
+      return;
+    case 'list':
+      for (const item of block.children) collectArticleBlocks(item.children, out);
+      return;
+    case 'listItem':
+    case 'blockquote':
+      collectArticleBlocks(block.children, out);
+      return;
+    case 'paragraph':
+    case 'heading':
+    case 'code':
+    case 'table':
+    case 'poll':
+    case 'linkCard':
+    case 'articleCard':
+    case 'thematicBreak':
+      return;
+  }
+}

--- a/src/ast/render-markdown.ts
+++ b/src/ast/render-markdown.ts
@@ -13,6 +13,11 @@ import type {
   TableNode,
   TableCellNode,
 } from './types';
+import { isProgressiveMp4 } from './collect-media';
+
+export interface MarkdownRenderOptions {
+  includeVideoLinks?: boolean;
+}
 
 // AST → markdown body, matching the shape produced by the legacy Turndown
 // pipeline (header + body + source footer). postProcess() then prepends YAML
@@ -21,12 +26,12 @@ import type {
 // Goal: semantic parity with the existing .md fixtures. Where the AST encodes
 // information the legacy pipeline lost (e.g. t.co → resolved URL), the
 // renderer emits the AST-truthful form; those are justified diffs.
-export function renderMarkdown(doc: Document): string {
+export function renderMarkdown(doc: Document, options: MarkdownRenderOptions = {}): string {
   const { body, metadata } = doc;
   const parts: string[] =
-    body.type === 'tweet'   ? renderTweetDocument(body, metadata) :
-    body.type === 'thread'  ? renderThreadDocument(body, metadata) :
-    /* article */             renderArticleDocument(body, metadata);
+    body.type === 'tweet'   ? renderTweetDocument(body, metadata, options) :
+    body.type === 'thread'  ? renderThreadDocument(body, metadata, options) :
+    /* article */             renderArticleDocument(body, metadata, options);
 
   parts.push('', '---', '', `> Source: ${metadata.sourceUrl}`, `> Date: ${metadata.date}`);
   return parts.join('\n');
@@ -35,14 +40,14 @@ export function renderMarkdown(doc: Document): string {
 // Body content only — no author header and no Source/Date footer. The CSV
 // `text` column uses this, since author / url / date already have their own
 // columns; re-emitting them inside the text would be redundant.
-export function renderMarkdownBody(doc: Document): string {
+export function renderMarkdownBody(doc: Document, options: MarkdownRenderOptions = {}): string {
   const { body } = doc;
-  if (body.type === 'article') return renderArticleChildren(body.children);
+  if (body.type === 'article') return renderArticleChildren(body.children, options);
   const parts: string[] = [];
   const tweets = body.type === 'thread' ? body.tweets : [body];
   tweets.forEach((tweet, idx) => {
     if (idx > 0) parts.push('', '---', '');
-    appendTweetBody(parts, tweet);
+    appendTweetBody(parts, tweet, options);
   });
   return parts.join('\n').trim();
 }
@@ -53,22 +58,34 @@ function tweetHeader(meta: DocumentMetadata): string {
   return `# ${meta.author.name} (@${meta.author.handle})`;
 }
 
-function renderTweetDocument(tweet: TweetNode, meta: DocumentMetadata): string[] {
+function renderTweetDocument(
+  tweet: TweetNode,
+  meta: DocumentMetadata,
+  options: MarkdownRenderOptions,
+): string[] {
   const parts: string[] = [tweetHeader(meta), ''];
-  appendTweetBody(parts, tweet);
+  appendTweetBody(parts, tweet, options);
   return parts;
 }
 
-function renderThreadDocument(thread: ThreadNode, meta: DocumentMetadata): string[] {
+function renderThreadDocument(
+  thread: ThreadNode,
+  meta: DocumentMetadata,
+  options: MarkdownRenderOptions,
+): string[] {
   const parts: string[] = [tweetHeader(meta), ''];
   thread.tweets.forEach((tweet, idx) => {
     if (idx > 0) parts.push('', '---', '');
-    appendTweetBody(parts, tweet);
+    appendTweetBody(parts, tweet, options);
   });
   return parts;
 }
 
-function renderArticleDocument(article: ArticleNode, meta: DocumentMetadata): string[] {
+function renderArticleDocument(
+  article: ArticleNode,
+  meta: DocumentMetadata,
+  options: MarkdownRenderOptions,
+): string[] {
   const parts: string[] = [];
   if (meta.title) {
     parts.push(`# ${meta.title}`, '', `*By ${meta.author.name} (@${meta.author.handle})*`, '');
@@ -76,17 +93,21 @@ function renderArticleDocument(article: ArticleNode, meta: DocumentMetadata): st
     parts.push(`# Article by ${meta.author.name} (@${meta.author.handle})`, '');
   }
   if (article.banner) parts.push(`![Banner](${article.banner.url})`, '');
-  const body = renderArticleChildren(article.children);
+  const body = renderArticleChildren(article.children, options);
   if (body) parts.push(body);
   return parts;
 }
 
 // ─── Tweet body ─────────────────────────────────────────────────────
 
-function appendTweetBody(parts: string[], tweet: TweetNode): void {
+function appendTweetBody(
+  parts: string[],
+  tweet: TweetNode,
+  options: MarkdownRenderOptions,
+): void {
   const text = renderInlineForTweet(tweet.text);
-  const mediaLines = tweet.media.map(renderMediaItem);
-  const embed = renderTweetEmbed(tweet);
+  const mediaLines = tweet.media.map((media) => renderMediaItem(media, options));
+  const embed = renderTweetEmbed(tweet, options);
   const pollLines = tweet.poll ? renderPoll(tweet.poll) : '';
 
   // Legacy layout: text + (poll appended to text) + media + embed.
@@ -115,17 +136,17 @@ function appendTweetBody(parts: string[], tweet: TweetNode): void {
   }
 }
 
-function renderTweetEmbed(tweet: TweetNode): string {
-  if (tweet.quotedTweet) return renderQuotedTweetBlock(tweet.quotedTweet);
+function renderTweetEmbed(tweet: TweetNode, options: MarkdownRenderOptions): string {
+  if (tweet.quotedTweet) return renderQuotedTweetBlock(tweet.quotedTweet, options);
   if (tweet.articleCard) return renderArticleCardBlock(tweet.articleCard);
   if (tweet.linkCard) return renderLinkCardBlock(tweet.linkCard);
   return '';
 }
 
-function renderQuotedTweetBlock(quote: TweetNode): string {
+function renderQuotedTweetBlock(quote: TweetNode, options: MarkdownRenderOptions): string {
   const headerLine = `**${quote.author.name} (@${quote.author.handle})**`;
   const text = renderInlineForTweet(quote.text);
-  const mediaLines = quote.media.map(renderMediaItem);
+  const mediaLines = quote.media.map((media) => renderMediaItem(media, options));
 
   const segments: string[] = [headerLine];
   // Article-card quote: cover image + 📝 title + description, after the
@@ -185,9 +206,16 @@ function renderPoll(poll: PollNode): string {
   return out;
 }
 
-function renderMediaItem(m: MediaItem): string {
+function renderMediaItem(m: MediaItem, options: MarkdownRenderOptions): string {
   if (m.kind === 'video' || m.kind === 'gif') {
-    return `![🎥 Video](${m.posterUrl ?? m.url})`;
+    const hasRealMp4 = m.url !== m.posterUrl && isProgressiveMp4(m.url);
+    const videoLink = `[▶ ${m.kind === 'gif' ? 'GIF' : 'Video'}](${m.url})`;
+    if (hasRealMp4 && options.includeVideoLinks && m.posterUrl) {
+      return `![🎥 Video](${m.posterUrl})\n\n${videoLink}`;
+    }
+    if (hasRealMp4 && options.includeVideoLinks) return videoLink;
+    if (m.posterUrl) return `![🎥 Video](${m.posterUrl})`;
+    return '[🎥 Video]';
   }
   // Legacy pipeline always rendered "Image" as the alt for tweet photos,
   // discarding the DOM alt (which X populates with strings like "Image" or
@@ -285,17 +313,17 @@ function wrapEmphasis(inner: string, marker: string): string {
 
 // ─── Article body ───────────────────────────────────────────────────
 
-function renderArticleChildren(blocks: Block[]): string {
+function renderArticleChildren(blocks: Block[], options: MarkdownRenderOptions): string {
   const out: string[] = [];
   for (const block of blocks) {
-    const md = renderArticleBlock(block);
+    const md = renderArticleBlock(block, options);
     if (md) out.push(md);
   }
   // Collapse runs of 3+ blank lines (legacy pipeline does the same).
   return out.join('\n\n').replace(/\n{3,}/g, '\n\n').trim();
 }
 
-function renderArticleBlock(block: Block): string {
+function renderArticleBlock(block: Block, options: MarkdownRenderOptions): string {
   switch (block.type) {
     case 'paragraph':
       return renderInlineForArticle(block.children);
@@ -305,7 +333,7 @@ function renderArticleBlock(block: Block): string {
       const lines = block.children.map((item, i) => {
         const bullet = block.ordered ? `${i + 1}. ` : '- ';
         const inner = item.children
-          .map((b) => (b.type === 'paragraph' ? renderInlineForArticle(b.children) : renderArticleBlock(b)))
+          .map((b) => (b.type === 'paragraph' ? renderInlineForArticle(b.children) : renderArticleBlock(b, options)))
           .join('\n');
         return `${bullet}${inner}`;
       });
@@ -321,17 +349,21 @@ function renderArticleBlock(block: Block): string {
       return renderTable(block);
     case 'blockquote':
       return block.children
-        .map(renderArticleBlock)
+        .map((child) => renderArticleBlock(child, options))
         .join('\n\n')
         .split('\n').map((l) => `> ${l}`).join('\n');
     case 'video':
-      return `![🎥 Video](${block.posterUrl})`;
+      return renderMediaItem({
+        kind: 'video',
+        url: block.sourceUrl,
+        ...(block.posterUrl !== undefined ? { posterUrl: block.posterUrl } : {}),
+      }, options);
     case 'articleCard':
       // In article body flow the card is the whole block — render it as a
       // blockquote stanza, same shape as the in-tweet form.
       return renderArticleCardBlock(block).replace(/^\n\n/, '');
     case 'tweet':
-      return renderQuotedTweetBlock(block).replace(/^\n\n/, '');
+      return renderQuotedTweetBlock(block, options).replace(/^\n\n/, '');
     default:
       return '';
   }

--- a/src/ast/render-pdf-html.ts
+++ b/src/ast/render-pdf-html.ts
@@ -239,8 +239,12 @@ function renderArticleBlock(block: Block): string {
       return `<blockquote>${block.children.map(renderArticleBlock).join('')}</blockquote>`;
     case 'image':
       return `<figure class="article-image"><img src="${escapeAttr(block.url)}" alt="${escapeAttr(block.alt || '')}">${block.caption ? `<figcaption>${escapeHtml(block.caption)}</figcaption>` : ''}</figure>`;
-    case 'video':
+    case 'video': {
+      // An MP4 URL inside <img> renders as a broken-image glyph; with no
+      // poster there is nothing visual to show, so drop the figure.
+      if (!block.posterUrl) return '';
       return `<figure class="article-image"><img src="${escapeAttr(block.posterUrl)}" alt="${escapeAttr(block.alt || '')}"></figure>`;
+    }
     case 'thematicBreak':
       return '<hr>';
     case 'table':

--- a/src/ast/render-pdf-html.ts
+++ b/src/ast/render-pdf-html.ts
@@ -125,7 +125,7 @@ function renderAuthorHeader(tweet: TweetNode): string {
 function formatDate(iso: string): string {
   const d = new Date(iso);
   if (isNaN(d.getTime())) return '';
-  return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+  return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric', timeZone: 'UTC' });
 }
 
 function renderEngagement(e: NonNullable<TweetNode['engagement']>): string {

--- a/src/ast/types.ts
+++ b/src/ast/types.ts
@@ -102,7 +102,7 @@ export interface ImageNode {
 
 export interface VideoNode {
   type: 'video';
-  posterUrl: string;
+  posterUrl?: string;
   sourceUrl: string;
   alt?: string;
 }

--- a/src/background/batch-sink.ts
+++ b/src/background/batch-sink.ts
@@ -10,7 +10,7 @@
 import type { ExtractedContent } from '../types/messages';
 import type { Document } from '../ast/types';
 import { renderDigest } from '../ast/render-digest';
-import { renderMarkdown } from '../ast/render-markdown';
+import { renderMarkdown, type MarkdownRenderOptions } from '../ast/render-markdown';
 import { renderPdfHtmlMany } from '../ast/render-pdf-html';
 import type { BatchFormat, Settings } from '../shared/settings';
 import {
@@ -58,13 +58,16 @@ export function formatOptionsFrom(s: Settings): FormatOptions {
 // Reconstruct the ExtractedContent the format builders + postProcess expect from
 // an AST. renderMarkdown gives the raw body Markdown (no frontmatter) used by the
 // TXT and CSV-description paths — the same string single-export passes.
-export function docToExtracted(doc: Document): ExtractedContent {
+export function docToExtracted(
+  doc: Document,
+  renderOptions: MarkdownRenderOptions = {},
+): ExtractedContent {
   const m = doc.metadata;
   return {
     type: m.type,
     author: { name: m.author.name, handle: m.author.handle },
     title: m.title,
-    markdown: renderMarkdown(doc),
+    markdown: renderMarkdown(doc, renderOptions),
     sourceUrl: m.sourceUrl,
     date: m.date,
     tweetId: m.tweetId,
@@ -93,7 +96,7 @@ export function buildCombined(format: BatchFormat, docs: Document[], opts: Forma
     case 'json':
       return { content: JSON.stringify(docs, null, 2), mime: 'application/json', ext: 'json' };
     case 'csv':
-      return { content: buildCsvTable(docs.map(docToExtracted), opts), mime: 'text/csv', ext: 'csv' };
+      return { content: buildCsvTable(docs.map((doc) => docToExtracted(doc)), opts), mime: 'text/csv', ext: 'csv' };
   }
 }
 

--- a/src/background/fast-batch.ts
+++ b/src/background/fast-batch.ts
@@ -25,6 +25,7 @@ import type {
   FastBatchStatusResponse,
 } from '../types/messages';
 import { isExtensionPageSender } from './security';
+import { collectMedia, isDownloadableVideo } from '../ast/collect-media';
 import { jsonToAst } from '../graphql/json-to-ast';
 import { tweetDetailToDocument } from '../graphql/tweet-detail';
 import { getVariables, paginateTimeline, setVariablesParam } from '../graphql/timeline';
@@ -315,6 +316,15 @@ async function runFastBatchExport(opts: FastBatchOptions = {}): Promise<FastBatc
   // images override it off — image bytes can't be fetched into the zip —
   // but images only ever download for Markdown, so only 'md' blocks.
   const zip = settings.batchZip && output !== 'combined' && !(settings.downloadImages && format === 'md');
+  // Local MP4s ride the per-item Markdown path only: combined and CSV return
+  // before writePerItem so they'd discard the download list, and zip is already
+  // mutually exclusive with local media. saveVideos is the Media position of
+  // the popup's save-locally control; every other position stays poster-only.
+  const localVideo =
+    output === 'separate' &&
+    format === 'md' &&
+    settings.saveVideos &&
+    resolveDownloadImages('download', settings.downloadImages);
   const frontmatterFields = settings.obsidianFriendly
     ? settings.frontmatterFieldsObsidian
     : settings.frontmatterFields;
@@ -354,9 +364,22 @@ async function runFastBatchExport(opts: FastBatchOptions = {}): Promise<FastBatc
     // Expansion can change the canonical id, so track both — see Item.feedId.
     const expandedId = doc.metadata.tweetId;
     const isStub = s.needsExpand && !s.ledger;
-    const result = postProcess(docToExtracted(doc), {
+    // Structural: walk the AST for the MP4 rather than parsing the rendered
+    // Markdown back out. renderedUrl is what the renderer wrote into the
+    // [▶ Video] token; downloadUrl is what we fetch — the same today, kept
+    // separate because that is the seam a later phase would widen.
+    const videoAttachments = localVideo
+      ? collectMedia(doc)
+          .filter(isDownloadableVideo)
+          .map((m) => ({ renderedUrl: m.url, downloadUrl: m.url }))
+      : undefined;
+    const result = postProcess(docToExtracted(
+      doc,
+      localVideo ? { includeVideoLinks: true } : undefined,
+    ), {
       includeMetadata: settings.includeMetadata,
       downloadImages: resolveDownloadImages('download', settings.downloadImages),
+      videoAttachments,
       inlineStats: settings.inlineStats,
       obsidianFriendly: settings.obsidianFriendly,
       filenameTemplate: settings.filenameTemplate.trim(),

--- a/src/graphql/json-to-ast.ts
+++ b/src/graphql/json-to-ast.ts
@@ -63,11 +63,18 @@ interface RawEntities {
   media?: (RawIndexed & { url?: string })[];
 }
 
+interface RawVideoVariant {
+  bitrate?: number;
+  bit_rate?: number;
+  content_type?: string;
+  url?: string;
+}
+
 interface RawMedia {
   type?: string; // 'photo' | 'video' | 'animated_gif'
   media_url_https?: string;
   ext_alt_text?: string | null;
-  video_info?: { variants?: { bitrate?: number; content_type?: string; url?: string }[] };
+  video_info?: { variants?: RawVideoVariant[] };
 }
 
 interface RawBinding {
@@ -147,7 +154,11 @@ interface RawContentState {
 }
 interface RawMediaEntity {
   media_id?: string;
-  media_info?: { original_img_url?: string };
+  media_info?: {
+    original_img_url?: string;
+    preview_image?: { original_img_url?: string };
+    variants?: RawVideoVariant[];
+  };
 }
 
 // A timeline entry's tweet may be wrapped (e.g. TweetWithVisibilityResults).
@@ -322,7 +333,7 @@ function normalizeMediaUrl(url: string): string {
 }
 
 // An atomic block carries a single entity: a DIVIDER (→ horizontal rule),
-// MEDIA (→ image, resolved via media_entities by mediaId) or MARKDOWN
+// MEDIA (→ image/video, resolved via media_entities by mediaId) or MARKDOWN
 // (→ code block or table).
 function atomicBlock(
   b: RawDraftBlock,
@@ -337,7 +348,17 @@ function atomicBlock(
   if (ent?.type !== 'MEDIA') return undefined;
   const mediaId = ent.data?.mediaItems?.[0]?.mediaId;
   if (!mediaId) return undefined;
-  const url = mediaById.get(mediaId)?.media_info?.original_img_url;
+  const info = mediaById.get(mediaId)?.media_info;
+  const posterUrl = info?.preview_image?.original_img_url;
+  const sourceUrl = bestVariant(info?.variants ?? []);
+  if (sourceUrl) {
+    return {
+      type: 'video',
+      sourceUrl,
+      ...(posterUrl ? { posterUrl: normalizeMediaUrl(posterUrl) } : {}),
+    };
+  }
+  const url = info?.original_img_url ?? posterUrl;
   return url ? { type: 'image', url: normalizeMediaUrl(url) } : undefined;
 }
 
@@ -594,10 +615,11 @@ function media(items: RawMedia[]): MediaItem[] {
 
 // Highest-bitrate progressive MP4 (X also ships HLS .m3u8 variants with no
 // bitrate, which a downloader can't save directly — prefer the mp4s).
-function bestVariant(variants: { bitrate?: number; content_type?: string; url?: string }[]): string | undefined {
+function bestVariant(variants: RawVideoVariant[]): string | undefined {
   const mp4 = variants.filter((v) => v.content_type === 'video/mp4' && v.url);
   if (mp4.length === 0) return variants.find((v) => v.url)?.url;
-  return mp4.sort((a, b) => (b.bitrate ?? 0) - (a.bitrate ?? 0))[0].url;
+  const bitrate = (v: RawVideoVariant): number => v.bitrate ?? v.bit_rate ?? 0;
+  return mp4.sort((a, b) => bitrate(b) - bitrate(a))[0].url;
 }
 
 type CardResult =

--- a/src/popup/actions.ts
+++ b/src/popup/actions.ts
@@ -9,7 +9,7 @@ import { buildFormatExport, type ExportFormat } from '../shared/export-formats';
 import { recordExport } from '../shared/review-prompt';
 import { buildObsidianUrl } from '../shared/obsidian';
 import { hostMatches } from '../shared/media';
-import { currentFrontmatterFields, readSingleFormat, applySingleFormat, persistAll } from './settings-form';
+import { currentFrontmatterFields, readSingleFormat, applySingleFormat, persistAll, saveLocalEnabled } from './settings-form';
 import type { BatchFormat } from '../shared/settings';
 import {
   btnDownload,
@@ -21,7 +21,6 @@ import {
   chkMetadata,
   chkInlineStats,
   chkObsidianFriendly,
-  chkDownloadImages,
   txtFilenameTemplate,
   txtObsidianTags,
   txtObsidianVault,
@@ -147,7 +146,7 @@ async function extractMarkdown(
   // markdown via URL, not a filesystem package, so leave images as remote
   // URLs (Obsidian renders pbs.twimg.com inline fine).
   const downloadImages =
-    forAction === 'obsidian' ? false : resolveDownloadImages(forAction, chkDownloadImages.checked);
+    forAction === 'obsidian' ? false : resolveDownloadImages(forAction, saveLocalEnabled());
 
   // Need engagement data if either renderer wants it.
   const data = await extractContent(includeMetadata || inlineStats);

--- a/src/popup/dom.ts
+++ b/src/popup/dom.ts
@@ -74,7 +74,10 @@ export const fastStepExpand = document.getElementById('fast-step-expand') as HTM
 export const batchSection = document.getElementById('batch-section') as HTMLDivElement;
 
 // ─── Settings checkboxes ─────────────────────────────────────────────
-export const chkDownloadImages = document.getElementById('chk-download-images') as HTMLInputElement;
+export const saveLocalField = document.getElementById('save-local-field') as HTMLDivElement;
+export const saveLocalOff = document.getElementById('save-local-off') as HTMLInputElement;
+export const saveLocalImages = document.getElementById('save-local-images') as HTMLInputElement;
+export const saveLocalMedia = document.getElementById('save-local-media') as HTMLInputElement;
 export const chkMetadata = document.getElementById('chk-include-metadata') as HTMLInputElement;
 export const chkCloseTab = document.getElementById('chk-close-tab') as HTMLInputElement;
 export const chkInlineCopies = document.getElementById('chk-inline-copies') as HTMLInputElement;

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -62,7 +62,9 @@
               <polyline points="6 9 12 15 18 9" />
             </svg>
           </summary>
-          <label class="toggle-label" data-tooltip="Download images to a folder next to the markdown file" data-i18n-tooltip="opt_save_images_title">
+          <div class="batch-field save-local-field" id="save-local-field"
+            data-tooltip="Off: link to media on X. Images: save images next to the markdown file. Media: save videos as .mp4 too — these are much larger."
+            data-i18n-tooltip="opt_save_local_title">
             <span class="toggle-text">
               <svg class="toggle-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
                 stroke-linecap="round" stroke-linejoin="round">
@@ -70,11 +72,17 @@
                 <circle cx="8.5" cy="8.5" r="1.5" />
                 <polyline points="21 15 16 10 5 21" />
               </svg>
-              <span data-i18n="opt_save_images">Save images locally (only with .md)</span>
+              <span data-i18n="opt_save_local">Save locally (only with .md)</span>
             </span>
-            <input type="checkbox" id="chk-download-images" class="toggle-input" />
-            <span class="toggle-switch"></span>
-          </label>
+            <div class="segmented" role="radiogroup" aria-label="Save locally">
+              <input type="radio" name="save-local" id="save-local-off" value="off" class="seg-input" />
+              <label for="save-local-off" class="seg-label" data-i18n="opt_save_local_off">Off</label>
+              <input type="radio" name="save-local" id="save-local-images" value="images" class="seg-input" />
+              <label for="save-local-images" class="seg-label" data-i18n="opt_save_local_images">Images</label>
+              <input type="radio" name="save-local" id="save-local-media" value="media" class="seg-input" />
+              <label for="save-local-media" class="seg-label" data-i18n="opt_save_local_media">Media</label>
+            </div>
+          </div>
           <label class="toggle-label" data-tooltip="Render likes, reposts, replies, bookmarks, and views as a row in the Markdown body" data-i18n-tooltip="opt_inline_stats_title">
             <span class="toggle-text">
               <svg class="toggle-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"

--- a/src/popup/settings-form.ts
+++ b/src/popup/settings-form.ts
@@ -32,7 +32,10 @@ import {
   outBoth,
   outCombined,
   chkBatchZip,
-  chkDownloadImages,
+  saveLocalField,
+  saveLocalOff,
+  saveLocalImages,
+  saveLocalMedia,
   chkMetadata,
   chkCloseTab,
   chkInlineCopies,
@@ -86,7 +89,8 @@ export function applySingleFormat(fmt: BatchFormat): void {
 
 export function persistAll(): void {
   saveSettings({
-    downloadImages: chkDownloadImages.checked,
+    downloadImages: readSaveLocal() !== 'off',
+    saveVideos: readSaveLocal() === 'media',
     includeMetadata: chkMetadata.checked,
     closeTabAfterExport: chkCloseTab.checked,
     inlineButtonCopies: chkInlineCopies.checked,
@@ -123,6 +127,30 @@ function setBatchOutput(value: BatchOutput): void {
   outCombined.checked = value === 'combined';
 }
 
+// The Off | Images | Media control is presentation over two stored booleans,
+// not a setting of its own — see Settings.saveVideos for why the pair can't
+// collapse into one key. Media implies Images: the poster is an image, and one
+// control beats two.
+type SaveLocal = 'off' | 'images' | 'media';
+
+function readSaveLocal(): SaveLocal {
+  if (saveLocalMedia.checked) return 'media';
+  if (saveLocalImages.checked) return 'images';
+  return 'off';
+}
+
+// The single-export flows only care whether local media is on at all, not
+// which tier — they never download video (Phase 1 is Fast Batch only).
+export function saveLocalEnabled(): boolean {
+  return readSaveLocal() !== 'off';
+}
+
+function setSaveLocal(value: SaveLocal): void {
+  saveLocalOff.checked = value === 'off';
+  saveLocalImages.checked = value === 'images';
+  saveLocalMedia.checked = value === 'media';
+}
+
 // CSV is metadata-only, so a per-item CSV makes no sense — force one combined
 // file and lock the other two options while CSV is selected.
 function syncOutputForFormat(): void {
@@ -144,14 +172,18 @@ function syncBatchToggles(): void {
     chk.disabled = disabled;
     chk.closest('.toggle-label')?.classList.toggle('disabled', disabled);
   };
-  gate(chkDownloadImages, fmt === 'md');
   gate(chkInlineStats, fmt === 'md' || fmt === 'html');
   gate(chkMetadata, fmt === 'md' || fmt === 'csv');
+  // Same greying rule for the save-locally group, but it's a radio set in a
+  // .batch-field rather than a .toggle-label, so gate() doesn't fit it.
+  const saveLocalDisabled = batchMode && fmt !== 'md';
+  for (const r of [saveLocalOff, saveLocalImages, saveLocalMedia]) r.disabled = saveLocalDisabled;
+  saveLocalField.classList.toggle('disabled', saveLocalDisabled);
   // Zip packs the per-item files, so it's meaningless with Combined-only
   // output; local images disable it too (image bytes can't be fetched into
   // the archive — and images only ever download for Markdown). Batch-only
   // control, so no batchMode factor.
-  const zipBlocked = outCombined.checked || (chkDownloadImages.checked && fmt === 'md');
+  const zipBlocked = outCombined.checked || (readSaveLocal() !== 'off' && fmt === 'md');
   chkBatchZip.disabled = zipBlocked;
   chkBatchZip.closest('.toggle-label')?.classList.toggle('disabled', zipBlocked);
 }
@@ -323,7 +355,7 @@ function updateTagsPreview(): void {
 export function initSettingsForm(): void {
   // Restore toggle states on popup open.
   loadSettings().then((settings) => {
-    chkDownloadImages.checked = settings.downloadImages;
+    setSaveLocal(settings.downloadImages ? (settings.saveVideos ? 'media' : 'images') : 'off');
     chkMetadata.checked = settings.includeMetadata;
     chkCloseTab.checked = settings.closeTabAfterExport;
     chkInlineCopies.checked = settings.inlineButtonCopies;
@@ -420,10 +452,12 @@ export function initSettingsForm(): void {
   // ─── Plain change/blur persistence for the remaining controls ───
   // Local images and the output radios gate the zip toggle (and the flood
   // hint), so they re-sync the batch controls, not just persist.
-  chkDownloadImages.addEventListener('change', () => {
-    syncBatchControls();
-    persistAll();
-  });
+  [saveLocalOff, saveLocalImages, saveLocalMedia].forEach((r) =>
+    r.addEventListener('change', () => {
+      syncBatchControls();
+      persistAll();
+    })
+  );
   chkBatchZip.addEventListener('change', () => {
     updateFloodHint();
     persistAll();

--- a/src/shared/post-process.ts
+++ b/src/shared/post-process.ts
@@ -4,6 +4,7 @@ import { isAllowedImageUrl } from './media';
 export interface PostProcessOptions {
   includeMetadata: boolean;
   downloadImages: boolean;
+  videoAttachments?: { renderedUrl: string; downloadUrl: string }[];
   inlineStats?: boolean;
   obsidianFriendly?: boolean;
   filenameTemplate?: string;
@@ -277,6 +278,19 @@ function stripSourceFooter(md: string): string {
   return md.replace(/\n+---\n+> Source:.*\n> Date:.*$/s, '');
 }
 
+export function deriveBasename(url: string, defaultExt: string): string {
+  const urlObj = new URL(url);
+  let fname = urlObj.pathname.split('/').pop() || 'image';
+  const formatMatch = url.match(/format=([a-zA-Z0-9]+)/);
+  if (formatMatch && !fname.includes('.')) fname += `.${formatMatch[1]}`;
+  if (!fname.includes('.')) fname += `.${defaultExt}`;
+  return fname.replace(/[^a-zA-Z0-9_.-]/g, '_');
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
 export function postProcess(
   data: ExtractedContent,
   opts: PostProcessOptions
@@ -386,19 +400,7 @@ export function postProcess(
         }
 
         try {
-          const urlObj = new URL(imgUrl);
-          let fname = urlObj.pathname.split('/').pop() || 'image';
-
-          const formatMatch = imgUrl.match(/format=([a-zA-Z0-9]+)/);
-          if (formatMatch && !fname.includes('.')) {
-            fname += `.${formatMatch[1]}`;
-          }
-          if (!fname.includes('.')) {
-            fname += '.jpg';
-          }
-
-          fname = fname.replace(/[^a-zA-Z0-9_.-]/g, '_');
-          const localPath = `${dirName}/${fname}`;
+          const localPath = `${dirName}/${deriveBasename(imgUrl, 'jpg')}`;
 
           if (!imagesToDownload.find((i) => i.url === imgUrl)) {
             imagesToDownload.push({ url: imgUrl, filename: localPath });
@@ -410,6 +412,29 @@ export function postProcess(
         }
       }
     );
+
+    for (const v of opts.videoAttachments ?? []) {
+      if (!isAllowedImageUrl(v.downloadUrl)) continue;
+      const localPath = `${dirName}/${deriveBasename(v.downloadUrl, 'mp4')}`;
+      const linkRe = new RegExp(
+        `(\\[▶ (?:Video|GIF)\\]\\()${escapeRegExp(v.renderedUrl)}(\\))`,
+        'g'
+      );
+      // Replace via a function, not a replacement string: localPath carries the
+      // user's filename template, and buildFilename doesn't strip '$' — a
+      // template like "$1" would otherwise be read back as a capture group.
+      let linked = false;
+      finalMarkdown = finalMarkdown.replace(linkRe, (_match, open: string, close: string) => {
+        linked = true;
+        return `${open}${localPath}${close}`;
+      });
+      // Only queue what the Markdown actually points at. A missing renderer
+      // token must not leave an orphan .mp4 on disk.
+      if (!linked) continue;
+      if (!imagesToDownload.find((i) => i.url === v.downloadUrl)) {
+        imagesToDownload.push({ url: v.downloadUrl, filename: localPath });
+      }
+    }
   }
 
   return {

--- a/src/shared/settings.ts
+++ b/src/shared/settings.ts
@@ -21,6 +21,12 @@ export type BatchOutput = 'separate' | 'both' | 'combined';
 
 export interface Settings {
   downloadImages: boolean;
+  // Local video (.mp4) alongside local images. Deliberately a second boolean
+  // rather than widening downloadImages into an enum: loadSettings spreads
+  // DEFAULT_SETTINGS over the saved partial, so a replacement key would be
+  // absent for every existing user and silently turn their local images off.
+  // The popup presents the pair as one Off | Images | Media control.
+  saveVideos: boolean;
   includeMetadata: boolean;
   closeTabAfterExport: boolean;
   inlineButtonCopies: boolean;
@@ -62,6 +68,7 @@ export function allEnabled(keys: readonly string[]): FieldMap {
 
 export const DEFAULT_SETTINGS: Settings = {
   downloadImages: false,
+  saveVideos: false, // off — videos are 2–50MB, two orders of magnitude past images
   includeMetadata: true, // on by default
   closeTabAfterExport: false,
   inlineButtonCopies: false, // inline button downloads by default

--- a/tests/ast-render-markdown.test.ts
+++ b/tests/ast-render-markdown.test.ts
@@ -6,7 +6,7 @@ import { domToAst } from '../src/content/dom-to-ast';
 import { renderMarkdown, renderMarkdownBody } from '../src/ast/render-markdown';
 import { postProcess } from '../src/shared/post-process';
 import type { ExtractedContent, TweetMetadata } from '../src/types/messages';
-import type { Document, InlineNode } from '../src/ast/types';
+import type { Document, InlineNode, MediaItem } from '../src/ast/types';
 
 // Phase 3 parity test: AST extractor → AST → renderMarkdown → postProcess,
 // compared against the existing .md fixture. Diffs here are either renderer
@@ -182,5 +182,185 @@ describe('emphasis edge whitespace', () => {
       { type: 'strong', children: [{ type: 'text', value: 'Triggered by' }] },
       { type: 'text', value: ': A user prompt.' },
     ])).toBe('**Triggered by**: A user prompt.');
+  });
+});
+
+describe('video media rendering', () => {
+  const author = { name: 'A', handle: 'a' };
+  const renderMedia = (
+    media: MediaItem,
+    options?: { includeVideoLinks?: boolean },
+  ): string => renderMarkdownBody({
+    version: 1,
+    metadata: {
+      type: 'tweet',
+      sourceUrl: 'https://x.com/a/status/1',
+      tweetId: '1',
+      author,
+      date: '2026-01-01T00:00:00.000Z',
+    },
+    body: {
+      type: 'tweet',
+      author,
+      date: '2026-01-01T00:00:00.000Z',
+      tweetId: '1',
+      text: [],
+      media: [media],
+    },
+  }, options);
+
+  it('keeps a real MP4 poster-only by default', () => {
+    const mp4 = 'https://video.twimg.com/vid/clip.MP4?tag=27';
+    const poster = 'https://pbs.twimg.com/media/poster.jpg';
+    expect(renderMedia({ kind: 'video', url: mp4, posterUrl: poster }))
+      .toBe(`![🎥 Video](${poster})`);
+  });
+
+  it('renders a real MP4 link when video links are enabled', () => {
+    const mp4 = 'https://video.twimg.com/vid/clip.MP4?tag=27';
+    const poster = 'https://pbs.twimg.com/media/poster.jpg';
+    expect(renderMedia(
+      { kind: 'video', url: mp4, posterUrl: poster },
+      { includeVideoLinks: true },
+    ))
+      .toBe(`![🎥 Video](${poster})\n\n[▶ Video](${mp4})`);
+  });
+
+  it('keeps a non-video.twimg MP4 poster-only when video links are enabled', () => {
+    const mp4 = 'https://pbs.twimg.com/x/clip.mp4';
+    const poster = 'https://pbs.twimg.com/media/poster.jpg';
+    const rendered = renderMedia(
+      { kind: 'video', url: mp4, posterUrl: poster },
+      { includeVideoLinks: true },
+    );
+
+    expect(rendered).toBe(`![🎥 Video](${poster})`);
+    expect(rendered).not.toContain('[▶ Video]');
+    expect(rendered).not.toContain(mp4);
+  });
+
+  it('keeps a real MP4 without a poster as plain text by default', () => {
+    const mp4 = 'https://video.twimg.com/vid/clip.mp4?tag=27';
+    const rendered = renderMedia({ kind: 'video', url: mp4 });
+    expect(rendered).toBe('[🎥 Video]');
+    expect(rendered).not.toContain(mp4);
+    expect(rendered).not.toContain('![');
+  });
+
+  it('renders a real MP4 without a poster as a link when enabled', () => {
+    const mp4 = 'https://video.twimg.com/vid/clip.mp4?tag=27';
+    expect(renderMedia(
+      { kind: 'video', url: mp4 },
+      { includeVideoLinks: true },
+    )).toBe(`[▶ Video](${mp4})`);
+  });
+
+  it('renders HLS with a poster as the poster only', () => {
+    const hls = 'https://video.twimg.com/vid/clip.m3u8';
+    const poster = 'https://pbs.twimg.com/media/poster.jpg';
+    expect(renderMedia({ kind: 'video', url: hls, posterUrl: poster }))
+      .toBe(`![🎥 Video](${poster})`);
+  });
+
+  it('renders HLS without a poster as plain video text', () => {
+    const hls = 'https://video.twimg.com/vid/clip.m3u8';
+    const rendered = renderMedia({ kind: 'video', url: hls });
+    expect(rendered).toBe('[🎥 Video]');
+    expect(rendered).not.toContain(hls);
+  });
+
+  it('uses the GIF label for an enabled animated GIF MP4 link', () => {
+    const mp4 = 'https://video.twimg.com/vid/clip.mp4';
+    expect(renderMedia(
+      { kind: 'gif', url: mp4 },
+      { includeVideoLinks: true },
+    )).toBe(`[▶ GIF](${mp4})`);
+  });
+
+  it('keeps poster-only media byte-identical', () => {
+    const poster = 'https://pbs.twimg.com/media/poster.jpg';
+    expect(renderMedia({ kind: 'video', url: poster, posterUrl: poster }))
+      .toBe(`![🎥 Video](${poster})`);
+  });
+
+  it('keeps quoted-tweet videos poster-only unless links are enabled', () => {
+    const mp4 = 'https://video.twimg.com/vid/quote.mp4';
+    const poster = 'https://pbs.twimg.com/media/quote.jpg';
+    const quote: Document = {
+      version: 1,
+      metadata: {
+        type: 'tweet',
+        sourceUrl: 'https://x.com/a/status/1',
+        tweetId: '1',
+        author,
+        date: '2026-01-01T00:00:00.000Z',
+      },
+      body: {
+        type: 'tweet',
+        author,
+        date: '2026-01-01T00:00:00.000Z',
+        tweetId: '1',
+        text: [],
+        media: [],
+        quotedTweet: {
+          type: 'tweet',
+          author: { name: 'B', handle: 'b' },
+          date: '2026-01-01T00:00:00.000Z',
+          tweetId: '2',
+          text: [],
+          media: [{ kind: 'video', url: mp4, posterUrl: poster }],
+        },
+      },
+    };
+
+    expect(renderMarkdownBody(quote)).not.toContain(mp4);
+    expect(renderMarkdownBody(quote, { includeVideoLinks: true })).toContain(`[▶ Video](${mp4})`);
+  });
+
+  it('renders an article VideoNode link only when enabled', () => {
+    const mp4 = 'https://video.twimg.com/vid/article.mp4';
+    const poster = 'https://pbs.twimg.com/media/article.jpg';
+    const article: Document = {
+      version: 1,
+      metadata: {
+        type: 'article',
+        sourceUrl: 'https://x.com/a/status/1',
+        tweetId: '1',
+        author,
+        date: '2026-01-01T00:00:00.000Z',
+        title: 'Article',
+      },
+      body: {
+        type: 'article',
+        children: [{ type: 'video', posterUrl: poster, sourceUrl: mp4 }],
+      },
+    };
+
+    expect(renderMarkdownBody(article)).toBe(`![🎥 Video](${poster})`);
+    expect(renderMarkdownBody(article, { includeVideoLinks: true }))
+      .toBe(`![🎥 Video](${poster})\n\n[▶ Video](${mp4})`);
+  });
+
+  it('renders a posterless article VideoNode as link-only when enabled', () => {
+    const mp4 = 'https://video.twimg.com/vid/article.mp4';
+    const article: Document = {
+      version: 1,
+      metadata: {
+        type: 'article',
+        sourceUrl: 'https://x.com/a/status/1',
+        tweetId: '1',
+        author,
+        date: '2026-01-01T00:00:00.000Z',
+        title: 'Article',
+      },
+      body: {
+        type: 'article',
+        children: [{ type: 'video', sourceUrl: mp4 }],
+      },
+    };
+
+    const rendered = renderMarkdownBody(article, { includeVideoLinks: true });
+    expect(rendered).toBe(`[▶ Video](${mp4})`);
+    expect(rendered).not.toContain('![');
   });
 });

--- a/tests/collect-media.test.ts
+++ b/tests/collect-media.test.ts
@@ -1,0 +1,176 @@
+import { describe, it, expect } from 'vitest';
+import { collectMedia, isDownloadableVideo, isProgressiveMp4 } from '../src/ast/collect-media';
+import type { Document, MediaItem, TweetNode } from '../src/ast/types';
+
+const author = { name: 'Example', handle: 'example' };
+const date = '2026-01-01T00:00:00.000Z';
+
+function tweet(tweetId: string, media: MediaItem[] = [], quotedTweet?: TweetNode): TweetNode {
+  return {
+    type: 'tweet',
+    author,
+    date,
+    tweetId,
+    text: [],
+    media,
+    ...(quotedTweet ? { quotedTweet } : {}),
+  };
+}
+
+function document(body: Document['body']): Document {
+  return {
+    version: 1,
+    metadata: {
+      type: body.type,
+      sourceUrl: 'https://x.com/example/status/1',
+      tweetId: '1',
+      author,
+      date,
+    },
+    body,
+  };
+}
+
+describe('collectMedia()', () => {
+  it('collects a tweet media before its quoted tweet media', () => {
+    const doc = document(tweet(
+      '1',
+      [
+        { kind: 'image', url: 'https://images.example/root.jpg' },
+        { kind: 'video', url: 'https://video.example/root.mp4', posterUrl: 'https://images.example/root-poster.jpg' },
+      ],
+      tweet('2', [
+        { kind: 'gif', url: 'https://video.example/quote.mp4', posterUrl: 'https://images.example/quote-poster.jpg' },
+      ])
+    ));
+
+    expect(collectMedia(doc)).toEqual([
+      { kind: 'image', url: 'https://images.example/root.jpg', tweetId: '1' },
+      {
+        kind: 'video',
+        url: 'https://video.example/root.mp4',
+        posterUrl: 'https://images.example/root-poster.jpg',
+        tweetId: '1',
+      },
+      {
+        kind: 'gif',
+        url: 'https://video.example/quote.mp4',
+        posterUrl: 'https://images.example/quote-poster.jpg',
+        tweetId: '2',
+      },
+    ]);
+  });
+
+  it('collects each thread tweet and its quote in thread order', () => {
+    const doc = document({
+      type: 'thread',
+      tweets: [
+        tweet('1', [{ kind: 'image', url: 'https://images.example/first.jpg' }]),
+        tweet(
+          '2',
+          [{ kind: 'video', url: 'https://video.example/second.mp4', posterUrl: 'https://images.example/second-poster.jpg' }],
+          tweet('3', [{ kind: 'image', url: 'https://images.example/quote.jpg' }])
+        ),
+      ],
+    });
+
+    expect(collectMedia(doc).map((media) => media.url)).toEqual([
+      'https://images.example/first.jpg',
+      'https://video.example/second.mp4',
+      'https://images.example/quote.jpg',
+    ]);
+  });
+
+  it('walks nested article blocks in order and uses video sourceUrl', () => {
+    const doc = document({
+      type: 'article',
+      children: [
+        { type: 'image', url: 'https://images.example/first.jpg' },
+        {
+          type: 'blockquote',
+          children: [
+            {
+              type: 'video',
+              posterUrl: 'https://images.example/block-poster.jpg',
+              sourceUrl: 'https://video.example/block.mp4',
+            },
+          ],
+        },
+        tweet(
+          '4',
+          [{ kind: 'image', url: 'https://images.example/embed.jpg' }],
+          tweet('5', [{ kind: 'gif', url: 'https://video.example/quoted.mp4' }])
+        ),
+        {
+          type: 'list',
+          ordered: false,
+          children: [
+            {
+              type: 'listItem',
+              children: [
+                { type: 'image', url: 'https://images.example/list.jpg' },
+                {
+                  type: 'thread',
+                  tweets: [tweet('6', [{ kind: 'video', url: 'https://video.example/thread.mp4' }])],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(collectMedia(doc)).toEqual([
+      { kind: 'image', url: 'https://images.example/first.jpg' },
+      {
+        kind: 'video',
+        url: 'https://video.example/block.mp4',
+        posterUrl: 'https://images.example/block-poster.jpg',
+      },
+      { kind: 'image', url: 'https://images.example/embed.jpg', tweetId: '4' },
+      { kind: 'gif', url: 'https://video.example/quoted.mp4', tweetId: '5' },
+      { kind: 'image', url: 'https://images.example/list.jpg' },
+      { kind: 'video', url: 'https://video.example/thread.mp4', tweetId: '6' },
+    ]);
+  });
+
+  it('collects a posterless article MP4 as downloadable video', () => {
+    const mp4 = 'https://video.twimg.com/ext_tw_video/x/clip.mp4?tag=12';
+    const [media] = collectMedia(document({
+      type: 'article',
+      children: [{ type: 'video', sourceUrl: mp4 }],
+    }));
+
+    expect(media).toEqual({ kind: 'video', url: mp4 });
+    expect(media).not.toHaveProperty('posterUrl');
+    expect(isDownloadableVideo(media)).toBe(true);
+  });
+});
+
+describe('isDownloadableVideo()', () => {
+  it('accepts progressive videos and gifs but rejects images and poster-only video', () => {
+    expect(isDownloadableVideo({ kind: 'video', url: 'https://video.twimg.com/video.mp4' })).toBe(true);
+    expect(isDownloadableVideo({ kind: 'gif', url: 'https://video.twimg.com/gif.mp4' })).toBe(true);
+    expect(isDownloadableVideo({ kind: 'image', url: 'https://images.example/image.mp4' })).toBe(false);
+    expect(isDownloadableVideo({
+      kind: 'video',
+      url: 'https://video.twimg.com/poster.mp4',
+      posterUrl: 'https://video.twimg.com/poster.mp4',
+    })).toBe(false);
+  });
+
+  it('rejects an MP4 outside video.twimg.com', () => {
+    const mp4 = 'https://pbs.twimg.com/x/clip.mp4';
+    expect(isDownloadableVideo({ kind: 'video', url: mp4 })).toBe(false);
+  });
+});
+
+describe('isProgressiveMp4()', () => {
+  it('requires HTTPS, video.twimg.com, and an MP4 pathname', () => {
+    expect(isProgressiveMp4('https://video.twimg.com/ext_tw_video/x/clip.mp4?tag=12')).toBe(true);
+    expect(isProgressiveMp4('https://pbs.twimg.com/x/clip.mp4')).toBe(false);
+    expect(isProgressiveMp4('https://video.example/path/clip.m3u8')).toBe(false);
+    expect(isProgressiveMp4('http://video.twimg.com/path/clip.mp4')).toBe(false);
+    expect(isProgressiveMp4('not a URL')).toBe(false);
+  });
+});

--- a/tests/fixtures/graphql/tweetdetail-2059312764448051555-video.min.json
+++ b/tests/fixtures/graphql/tweetdetail-2059312764448051555-video.min.json
@@ -1,0 +1,150 @@
+{
+  "data": {
+    "threaded_conversation_with_injections_v2": {
+      "instructions": [
+        {
+          "type": "TimelineAddEntries",
+          "entries": [
+            {
+              "entryId": "tweet-2059312764448051555",
+              "content": {
+                "entryType": "TimelineTimelineItem",
+                "itemContent": {
+                  "tweet_results": {
+                    "result": {
+                      "__typename": "Tweet",
+                      "rest_id": "2059312764448051555",
+                      "core": {
+                        "user_results": {
+                          "result": {
+                            "__typename": "User",
+                            "avatar": {
+                              "image_url": "https://pbs.twimg.com/profile_images/2058393160997597184/KjMnmwcS_normal.jpg"
+                            },
+                            "core": {
+                              "name": "HashingZap ✝️",
+                              "screen_name": "HashZappa"
+                            },
+                            "is_blue_verified": true
+                          }
+                        }
+                      },
+                      "legacy": {
+                        "created_at": "Tue May 26 16:36:37 +0000 2026",
+                        "entities": {
+                          "urls": [
+                            {
+                              "expanded_url": "http://x.com/i/article/2059310076704534528",
+                              "indices": [0, 23],
+                              "url": "https://t.co/eBRMGn3yLT"
+                            }
+                          ]
+                        },
+                        "full_text": "https://t.co/eBRMGn3yLT",
+                        "id_str": "2059312764448051555"
+                      },
+                      "article": {
+                        "article_results": {
+                          "result": {
+                            "rest_id": "2059310076704534528",
+                            "title": "High resolution simulation of Ben Davidson's pole shift theory",
+                            "cover_media": {
+                              "media_id": "2059310142295019524",
+                              "media_info": {
+                                "__typename": "ApiImage",
+                                "original_img_url": "https://pbs.twimg.com/media/HJQjqenakAQYPOP.jpg"
+                              }
+                            },
+                            "content_state": {
+                              "blocks": [
+                                {
+                                  "type": "header-one",
+                                  "text": "Captured article video",
+                                  "inlineStyleRanges": [],
+                                  "entityRanges": []
+                                },
+                                {
+                                  "type": "atomic",
+                                  "text": " ",
+                                  "inlineStyleRanges": [],
+                                  "entityRanges": [
+                                    {
+                                      "key": 0,
+                                      "length": 1,
+                                      "offset": 0
+                                    }
+                                  ]
+                                }
+                              ],
+                              "entityMap": [
+                                {
+                                  "key": "0",
+                                  "value": {
+                                    "data": {
+                                      "entityKey": "4e264549-5523-4e02-979f-1113b3deee7c",
+                                      "mediaItems": [
+                                        {
+                                          "localMediaId": "10",
+                                          "mediaCategory": "AmplifyVideo",
+                                          "mediaId": "2059311116694757376"
+                                        }
+                                      ]
+                                    },
+                                    "mutability": "Immutable",
+                                    "type": "MEDIA"
+                                  }
+                                }
+                              ]
+                            },
+                            "media_entities": [
+                              {
+                                "media_id": "2059311116694757376",
+                                "media_key": "13_2059311116694757376",
+                                "media_info": {
+                                  "__typename": "ApiVideo",
+                                  "preview_image": {
+                                    "original_img_url": "https://pbs.twimg.com/amplify_video_thumb/2059311116694757376/img/P-7i_6SwXeHF5lkV.jpg"
+                                  },
+                                  "variants": [
+                                    {
+                                      "content_type": "application/x-mpegURL",
+                                      "url": "https://video.twimg.com/amplify_video/2059311116694757376/pl/7HziVL2eHw3BdHfQ.m3u8?tag=27"
+                                    },
+                                    {
+                                      "bit_rate": 2176000,
+                                      "content_type": "video/mp4",
+                                      "url": "https://video.twimg.com/amplify_video/2059311116694757376/vid/avc1/1280x720/xpclcol5eLxJgMu9.mp4?tag=27"
+                                    },
+                                    {
+                                      "bit_rate": 256000,
+                                      "content_type": "video/mp4",
+                                      "url": "https://video.twimg.com/amplify_video/2059311116694757376/vid/avc1/480x270/hJSLavBJQntdzKo3.mp4?tag=27"
+                                    },
+                                    {
+                                      "bit_rate": 832000,
+                                      "content_type": "video/mp4",
+                                      "url": "https://video.twimg.com/amplify_video/2059311116694757376/vid/avc1/640x360/spP9RzjrPMP24VQg.mp4?tag=27"
+                                    },
+                                    {
+                                      "bit_rate": 10368000,
+                                      "content_type": "video/mp4",
+                                      "url": "https://video.twimg.com/amplify_video/2059311116694757376/vid/avc1/1920x1080/_vGThNd8HNc3yfnk.mp4?tag=27"
+                                    }
+                                  ]
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/tests/json-to-ast.test.ts
+++ b/tests/json-to-ast.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { jsonToAst, jsonToTweetNode } from '../src/graphql/json-to-ast';
 import { renderMarkdown } from '../src/ast/render-markdown';
+import { isDownloadableVideo } from '../src/ast/collect-media';
 
 // Fixtures here are MODELED ON X's documented GraphQL schema, not captured from
 // a live response (that needs a logged-in session — see ADR 0003). They pin the
@@ -200,6 +201,48 @@ describe('jsonToTweetNode — media', () => {
       { kind: 'video', url: 'https://video/high.mp4', posterUrl: 'https://pbs.twimg.com/poster.jpg' },
     ]);
   });
+
+  it('keeps an HLS-only variant as a non-downloadable fallback', () => {
+    const node = jsonToTweetNode(
+      tweet({
+        extended_entities: {
+          media: [
+            {
+              type: 'video',
+              media_url_https: 'https://pbs.twimg.com/poster.jpg',
+              video_info: {
+                variants: [{ content_type: 'application/x-mpegURL', url: 'https://video/x.m3u8' }],
+              },
+            },
+          ],
+        },
+      })
+    );
+
+    expect(node.media).toEqual([
+      { kind: 'video', url: 'https://video/x.m3u8', posterUrl: 'https://pbs.twimg.com/poster.jpg' },
+    ]);
+    expect(isDownloadableVideo(node.media[0])).toBe(false);
+  });
+
+  it('maps a video without a poster URL', () => {
+    const node = jsonToTweetNode(
+      tweet({
+        extended_entities: {
+          media: [
+            {
+              type: 'video',
+              video_info: {
+                variants: [{ content_type: 'video/mp4', url: 'https://video/clip.mp4' }],
+              },
+            },
+          ],
+        },
+      })
+    );
+
+    expect(node.media).toEqual([{ kind: 'video', url: 'https://video/clip.mp4' }]);
+  });
 });
 
 describe('jsonToTweetNode — quotes and wrappers', () => {
@@ -357,6 +400,40 @@ describe('jsonToAst — X Articles', () => {
       },
       { type: 'image', url: 'https://pbs.twimg.com/media/pic?format=jpg&name=large' },
     ]);
+  });
+
+  it('maps a progressive article video without preview_image to a posterless VideoNode', () => {
+    const mp4 = 'https://video.twimg.com/ext_tw_video/x/clip.mp4?tag=12';
+    const result = {
+      ...articleResult,
+      article: {
+        article_results: {
+          result: {
+            ...articleResult.article.article_results.result,
+            media_entities: [
+              {
+                media_id: 'video-1',
+                media_info: {
+                  variants: [{ content_type: 'video/mp4', url: mp4, bitrate: 832000 }],
+                },
+              },
+            ],
+            content_state: {
+              blocks: [{ type: 'atomic', text: ' ', entityRanges: [{ key: 0, offset: 0, length: 1 }] }],
+              entityMap: [
+                {
+                  key: '0',
+                  value: { type: 'MEDIA', data: { mediaItems: [{ mediaId: 'video-1' }] } },
+                },
+              ],
+            },
+          },
+        },
+      },
+    };
+
+    const body = jsonToAst(result).body as { type: 'article'; children: unknown[] };
+    expect(body.children).toEqual([{ type: 'video', sourceUrl: mp4 }]);
   });
 
   // Atomic DIVIDER entities → thematic break; `blockquote` blocks (grouped when

--- a/tests/post-process.test.ts
+++ b/tests/post-process.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { postProcess, buildFilename, applyFilenameTemplate, applyTagsTemplate, DEFAULT_TAGS_TEMPLATE } from '../src/shared/post-process';
+import { postProcess, buildFilename, applyFilenameTemplate, applyTagsTemplate, DEFAULT_TAGS_TEMPLATE, deriveBasename } from '../src/shared/post-process';
 import type { ExtractedContent } from '../src/types/messages';
+import type { Document } from '../src/ast/types';
+import { collectMedia, isDownloadableVideo } from '../src/ast/collect-media';
+import { docToExtracted } from '../src/background/batch-sink';
 
 function content(markdown: string): ExtractedContent {
   return {
@@ -86,6 +89,155 @@ describe('postProcess() image downloads', () => {
     expect(result.images).toEqual([
       { url: allowedUrl, filename: 'example-123/example.jpg' },
     ]);
+  });
+});
+
+describe('deriveBasename()', () => {
+  it.each([
+    ['https://pbs.twimg.com/media/example?format=jpg&name=large', 'jpg', 'example.jpg'],
+    ['https://pbs.twimg.com/media/HIEVJQ4XoAAXNNi.jpg', 'jpg', 'HIEVJQ4XoAAXNNi.jpg'],
+  ])('keeps image basenames unchanged for %s', (url, defaultExt, expected) => {
+    expect(deriveBasename(url, defaultExt)).toBe(expected);
+  });
+
+  it('derives the basename of a real X video URL', () => {
+    expect(deriveBasename(
+      'https://video.twimg.com/amplify_video/2059311116694757376/vid/avc1/1920x1080/_vGThNd8HNc3yfnk.mp4?tag=27',
+      'mp4'
+    )).toBe('_vGThNd8HNc3yfnk.mp4');
+  });
+
+  it('uses the default extension when the URL pathname has none', () => {
+    expect(deriveBasename('https://video.twimg.com/vid/clip', 'mp4')).toBe('clip.mp4');
+  });
+
+  it('sanitizes filename characters from the pathname', () => {
+    expect(deriveBasename('https://video.twimg.com/vid/clip%20name!.mp4', 'mp4'))
+      .toBe('clip_20name_.mp4');
+  });
+});
+
+describe('postProcess() video attachments', () => {
+  const posterUrl = 'https://pbs.twimg.com/media/poster?format=jpg&name=large';
+  const videoUrl = 'https://video.twimg.com/amplify_video/2059311116694757376/vid/avc1/1920x1080/_vGThNd8HNc3yfnk.mp4?tag=27';
+  const downloadUrl = `${videoUrl}&name=large`;
+
+  it('localizes only video-link tokens, preserves query strings, and deduplicates downloads', () => {
+    const result = postProcess(
+      content([
+        `![🎥 Video](${posterUrl})`,
+        `[▶ Video](${videoUrl})`,
+        `Mention ${videoUrl}`,
+        `[An ordinary link](${videoUrl})`,
+      ].join('\n\n')),
+      {
+        includeMetadata: false,
+        downloadImages: true,
+        filenameTemplate: '{date}-{handle}',
+        videoAttachments: [
+          { renderedUrl: videoUrl, downloadUrl },
+          { renderedUrl: videoUrl, downloadUrl },
+        ],
+      }
+    );
+
+    expect(result.markdown).toContain('![🎥 Video](2026-05-11-example/poster.jpg)');
+    expect(result.markdown).toContain('[▶ Video](2026-05-11-example/_vGThNd8HNc3yfnk.mp4)');
+    expect(result.markdown).toContain(`Mention ${videoUrl}`);
+    expect(result.markdown).toContain(`[An ordinary link](${videoUrl})`);
+    expect(result.images).toEqual([
+      { url: posterUrl, filename: '2026-05-11-example/poster.jpg' },
+      { url: downloadUrl, filename: '2026-05-11-example/_vGThNd8HNc3yfnk.mp4' },
+    ]);
+  });
+
+  // buildFilename strips path separators but not '$'. Replacement STRINGS read
+  // '$1' back as a capture group, so the local path has to go in via a
+  // replacer function or a templated folder name corrupts every video link.
+  it('survives a filename template containing a dollar sign', () => {
+    const result = postProcess(
+      content(`Watch this.\n\n[▶ Video](${videoUrl})`),
+      {
+        includeMetadata: false,
+        downloadImages: true,
+        filenameTemplate: '$1-{handle}',
+        videoAttachments: [{ renderedUrl: videoUrl, downloadUrl }],
+      }
+    );
+
+    expect(result.markdown).toContain('[▶ Video]($1-example/_vGThNd8HNc3yfnk.mp4)');
+    expect(result.markdown).not.toContain('[▶ Video]([▶ Video]');
+    expect(result.images).toEqual([
+      { url: downloadUrl, filename: '$1-example/_vGThNd8HNc3yfnk.mp4' },
+    ]);
+  });
+
+  // Queuing an attachment the Markdown never points at leaves an orphan .mp4.
+  it('does not queue a download when no video link token matched', () => {
+    const result = postProcess(
+      content(`![🎥 Video](${posterUrl})`),
+      {
+        includeMetadata: false,
+        downloadImages: true,
+        videoAttachments: [{ renderedUrl: videoUrl, downloadUrl }],
+      }
+    );
+
+    expect(result.images).toEqual([
+      { url: posterUrl, filename: 'example-123/poster.jpg' },
+    ]);
+  });
+
+  it('renders, localizes, and queues an article VideoNode through the real seams', () => {
+    const articleVideo = 'https://video.twimg.com/vid/article.mp4?tag=27';
+    const articlePoster = 'https://pbs.twimg.com/media/article.jpg';
+    const doc: Document = {
+      version: 1,
+      metadata: {
+        type: 'article',
+        sourceUrl: 'https://x.com/example/status/123',
+        tweetId: '123',
+        author: { name: 'Example', handle: 'example' },
+        date: '2026-05-11T00:00:00.000Z',
+        title: 'Example article',
+      },
+      body: {
+        type: 'article',
+        children: [{ type: 'video', posterUrl: articlePoster, sourceUrl: articleVideo }],
+      },
+    };
+    const videoAttachments = collectMedia(doc)
+      .filter(isDownloadableVideo)
+      .map((media) => ({ renderedUrl: media.url, downloadUrl: media.url }));
+
+    const result = postProcess(
+      docToExtracted(doc, { includeVideoLinks: true }),
+      { includeMetadata: false, downloadImages: true, videoAttachments },
+    );
+
+    expect(result.markdown).toContain('![🎥 Video](example-example-article/article.jpg)');
+    expect(result.markdown).toContain('[▶ Video](example-example-article/article.mp4)');
+    expect(result.images).toEqual([
+      { url: articlePoster, filename: 'example-example-article/article.jpg' },
+      { url: articleVideo, filename: 'example-example-article/article.mp4' },
+    ]);
+  });
+
+  it('keeps slug filenames and Obsidian descriptions valid with a video link', () => {
+    const result = postProcess(
+      content(`# Example (@example)\n\nWatch this clip.\n\n[▶ Video](${videoUrl})`),
+      {
+        includeMetadata: true,
+        downloadImages: true,
+        obsidianFriendly: true,
+        filenameTemplate: '{slug}',
+        videoAttachments: [{ renderedUrl: videoUrl, downloadUrl }],
+      }
+    );
+
+    expect(result.filename).toBe('watch-this-clip-video.md');
+    expect(result.markdown).toContain('description: "Watch this clip. ▶ Video"');
+    expect(result.markdown).toContain('[▶ Video](watch-this-clip-video/_vGThNd8HNc3yfnk.mp4)');
   });
 });
 

--- a/tests/render-digest.test.ts
+++ b/tests/render-digest.test.ts
@@ -1,8 +1,9 @@
 import { describe, it, expect } from 'vitest';
-import type { Document } from '../src/ast/types';
+import type { Document, MediaItem } from '../src/ast/types';
 import { renderDigest } from '../src/ast/render-digest';
+import { docToExtracted } from '../src/background/batch-sink';
 
-function tweetDoc(handle: string, text: string, id: string): Document {
+function tweetDoc(handle: string, text: string, id: string, media: MediaItem[] = []): Document {
   return {
     version: 1,
     metadata: {
@@ -18,7 +19,7 @@ function tweetDoc(handle: string, text: string, id: string): Document {
       date: '2026-06-11',
       tweetId: id,
       text: [{ type: 'text', value: text }],
-      media: [],
+      media,
     },
   };
 }
@@ -39,5 +40,32 @@ describe('renderDigest', () => {
   it('renders a single document without trailing separator noise', () => {
     const digest = renderDigest([tweetDoc('alice', 'only', '1')]);
     expect(digest.trim().endsWith('> Date: 2026-06-11')).toBe(true);
+  });
+
+  it('keeps real MP4s poster-only in a combined digest', () => {
+    const mp4 = 'https://video.twimg.com/vid/clip.mp4?tag=27';
+    const digest = renderDigest([tweetDoc('alice', 'with video', '1', [{
+      kind: 'video',
+      url: mp4,
+      posterUrl: 'https://pbs.twimg.com/media/poster.jpg',
+    }])]);
+
+    expect(digest).not.toContain(mp4);
+    expect(digest).not.toContain('alice-1/clip.mp4');
+  });
+});
+
+describe('docToExtracted video-link option', () => {
+  it('enables video links only when the caller opts in', () => {
+    const mp4 = 'https://video.twimg.com/vid/clip.mp4?tag=27';
+    const doc = tweetDoc('alice', 'with video', '1', [{
+      kind: 'video',
+      url: mp4,
+      posterUrl: 'https://pbs.twimg.com/media/poster.jpg',
+    }]);
+
+    expect(docToExtracted(doc).markdown).not.toContain(mp4);
+    expect(docToExtracted(doc, { includeVideoLinks: true }).markdown)
+      .toContain(`[▶ Video](${mp4})`);
   });
 });

--- a/tests/settings.test.ts
+++ b/tests/settings.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { loadSettings, SETTINGS_KEY, DEFAULT_SETTINGS } from '../src/shared/settings';
+
+// Point chrome.storage.local.get at a fixed saved object for one call.
+function withSaved(saved: Record<string, unknown>): void {
+  (globalThis as unknown as { chrome: { storage: { local: { get: unknown } } } }).chrome.storage.local.get = (
+    _keys: unknown,
+    cb: (r: Record<string, unknown>) => void
+  ) => cb({ [SETTINGS_KEY]: saved });
+}
+
+const originalGet = (globalThis as unknown as { chrome: { storage: { local: { get: unknown } } } }).chrome.storage
+  .local.get;
+
+afterEach(() => {
+  (globalThis as unknown as { chrome: { storage: { local: { get: unknown } } } }).chrome.storage.local.get =
+    originalGet;
+});
+
+describe('loadSettings() upgrade behavior', () => {
+  // The reason saveVideos is a second boolean rather than downloadImages being
+  // replaced by an enum: DEFAULT_SETTINGS is spread OVER the saved partial, so
+  // any key an existing user has never written takes the default. A
+  // replacement key would have defaulted every current user to 'off' and
+  // silently stopped saving their images.
+  it('keeps local images on for a user who saved before saveVideos existed', async () => {
+    withSaved({ downloadImages: true });
+
+    const settings = await loadSettings();
+
+    expect(settings.downloadImages).toBe(true);
+    expect(settings.saveVideos).toBe(false);
+  });
+
+  it('defaults both off when nothing is saved', async () => {
+    withSaved({});
+
+    const settings = await loadSettings();
+
+    expect(settings.downloadImages).toBe(false);
+    expect(settings.saveVideos).toBe(false);
+  });
+
+  it('round-trips an explicit Media selection', async () => {
+    withSaved({ downloadImages: true, saveVideos: true });
+
+    const settings = await loadSettings();
+
+    expect(settings.downloadImages).toBe(true);
+    expect(settings.saveVideos).toBe(true);
+  });
+
+  it('ships saveVideos off by default', () => {
+    expect(DEFAULT_SETTINGS.saveVideos).toBe(false);
+  });
+});

--- a/tests/tweet-detail.test.ts
+++ b/tests/tweet-detail.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { existsSync, readFileSync } from 'node:fs';
 import type { ArticleNode, ThreadNode } from '../src/ast/types';
+import { collectMedia, isDownloadableVideo } from '../src/ast/collect-media';
 import { flattenTweetDetail, tweetDetailToDocument } from '../src/graphql/tweet-detail';
 import { renderMarkdown } from '../src/ast/render-markdown';
 
@@ -57,6 +58,29 @@ describe('tweetDetailToDocument', () => {
     const doc = tweetDetailToDocument(tweetDetail([mk('1', 'alice', 'lone'), mk('2', 'bob', 'reply')]));
     expect(doc.metadata.type).toBe('tweet');
     expect(doc.metadata.tweetId).toBe('1');
+  });
+});
+
+// Minimized from a real public TweetDetail capture for status 2059312764448051555.
+// It preserves X's article MEDIA entity, ApiVideo media_info, and variant field
+// names while dropping replies and unrelated article blocks.
+describe('tweetDetailToDocument — captured article video', () => {
+  const raw = JSON.parse(
+    readFileSync('tests/fixtures/graphql/tweetdetail-2059312764448051555-video.min.json', 'utf8')
+  );
+  const doc = tweetDetailToDocument(raw);
+  const body = doc.body as ArticleNode;
+  const mp4 = 'https://video.twimg.com/amplify_video/2059311116694757376/vid/avc1/1920x1080/_vGThNd8HNc3yfnk.mp4?tag=27';
+  const poster = 'https://pbs.twimg.com/amplify_video_thumb/2059311116694757376/img/P-7i_6SwXeHF5lkV.jpg';
+
+  it('maps the highest-bitrate progressive MP4 into a downloadable VideoNode', () => {
+    expect(doc.metadata.type).toBe('article');
+    expect(body.children.filter((block) => block.type === 'video')).toEqual([
+      { type: 'video', posterUrl: poster, sourceUrl: mp4 },
+    ]);
+    expect(collectMedia(doc).filter(isDownloadableVideo).map((media) => media.url)).toEqual([mp4]);
+    expect(renderMarkdown(doc)).not.toContain(`[▶ Video](${mp4})`);
+    expect(renderMarkdown(doc, { includeVideoLinks: true })).toContain(`[▶ Video](${mp4})`);
   });
 });
 


### PR DESCRIPTION
Closes #95.

## What

Fast Batch now saves each post's highest-bitrate progressive MP4 (videos and animated GIFs) next to the Markdown when local media saving is on. Scope is exactly as agreed in #95: Fast Batch only, `separate` + Markdown output only, HLS-only posts fall back to poster-only unchanged.

## The three decisions from #95, as implemented

1. **Video-link visibility — on-toggle-only.** The `[▶ Video]` link renders only for local-media exports. With the toggle off, every existing user's `.md` stays byte-identical.
2. **Toggle — three-way segmented control, no enum.** The popup control is "Save locally (only with .md)" with `Off | Images | Media`. Settings keep `downloadImages: boolean` unchanged and add `saveVideos: boolean` (default `false`); the control maps to the pair in the popup only, so `loadSettings`' spread-over-partial migration keeps existing users on their current behavior (Images position). Every current consumer of `downloadImages` compiles unchanged, and the batchZip gating covers the Media state as noted in the issue. This adds 3 new strings across the 12 locales.
3. **Filenames — derived from the URL pathname**, reusing the same `deriveBasename` the image path uses, so one folder keeps one naming convention.

## Security

No new manifest permission. Downloads reuse the existing sender validation, path sanitizer, and 8-inflight throttle. One tightening beyond the issue: the renderer accepts progressive MP4s only from `video.twimg.com`, so a crafted GraphQL payload can't point the download at an arbitrary host.

## Testing

- `npm test`: 286 passed / 8 skipped on current `main` (39 new cases covering the AST media traversal, renderer link cases, download post-processing incl. `$`-pattern and orphan-file guards, settings migration, and a captured `TweetDetail` video payload).
- Committed snapshot fixtures are unchanged — with the toggle off, output is byte-identical.
- Manual end-to-end pass on Chrome (2026-08-21, live x.com): video, GIF, HLS-only, and mixed-media posts across the batch modes. That run also surfaced two pre-existing breaks that exist on `main` and are unrelated to this change, filed separately as #110 and #111 (which `main` may since have addressed — see those issues).

## Note on the diff

This branch includes the one-line PDF UTC date fix from #113; until that merges, its commit appears in this diff.
