### PR TITLE
Add AI ZIP export for Markdown and media

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -20,6 +20,18 @@
   "btn_pdf_hint": {
     "message": "Generate a formatted PDF export with current settings, then choose where to save it."
   },
+  "btn_ai_zip": {
+    "message": "Export for AI (.zip)"
+  },
+  "btn_ai_zip_hint": {
+    "message": "Package Markdown and local media into one .zip for uploading to an AI chat."
+  },
+  "packaging_zip": {
+    "message": "Packaging…"
+  },
+  "ai_zip_downloaded": {
+    "message": "AI ZIP downloaded!"
+  },
   "btn_obsidian": {
     "message": "Add to Obsidian"
   },

--- a/src/background/ai-zip.ts
+++ b/src/background/ai-zip.ts
@@ -1,0 +1,44 @@
+import type { DownloadAiZipRequest } from '../types/messages';
+import { isAllowedImageUrl } from './security';
+import type { ZipEntry } from './zip';
+
+export type ImageByteLoader = (url: string) => Promise<Uint8Array>;
+
+export function aiZipFilename(markdownFilename: string): string {
+  return markdownFilename.replace(/\.md$/i, '') + '.zip';
+}
+
+export function normalizeZipEntryName(name: string): string | null {
+  const normalized = String(name ?? '')
+    .normalize('NFKC')
+    .replace(/\\/g, '/')
+    .replace(/\/+/g, '/')
+    .replace(/[\x00-\x1f]/g, '_')
+    .split('/')
+    .filter((part) => part && part !== '.' && part !== '..')
+    .join('/');
+
+  return normalized || null;
+}
+
+export async function buildAiZipEntries(
+  message: DownloadAiZipRequest,
+  loadImageBytes: ImageByteLoader
+): Promise<ZipEntry[]> {
+  const markdownName = normalizeZipEntryName(message.filename) || 'xclipper.md';
+  const entries: ZipEntry[] = [{ name: markdownName, content: message.content }];
+  const usedNames = new Set(entries.map((entry) => entry.name));
+
+  for (const img of message.images ?? []) {
+    if (!img || typeof img.url !== 'string' || typeof img.filename !== 'string') continue;
+    if (!isAllowedImageUrl(img.url)) continue;
+
+    const entryName = normalizeZipEntryName(img.filename);
+    if (!entryName || usedNames.has(entryName)) continue;
+
+    entries.push({ name: entryName, content: await loadImageBytes(img.url) });
+    usedNames.add(entryName);
+  }
+
+  return entries;
+}

--- a/src/background/background.ts
+++ b/src/background/background.ts
@@ -1,5 +1,6 @@
 import type {
   AutoExtractRequest,
+  DownloadAiZipRequest,
   DownloadRequest,
   PdfPrintRequest,
   PdfPrintResponse,
@@ -14,6 +15,8 @@ import {
 import { initBatch } from './batch';
 import { initFastBatch } from './fast-batch';
 import { normalizeStatusUrl } from './batch-state';
+import { aiZipFilename, buildAiZipEntries } from './ai-zip';
+import { buildZip, zipDataUrl } from './zip';
 
 // ─── Context menu: Save / Copy tweet as Markdown ────────────────────
 
@@ -257,6 +260,14 @@ function loadDownloadFolder(): Promise<string> {
   });
 }
 
+async function fetchImageBytes(url: string): Promise<Uint8Array> {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`Failed to fetch media for ZIP (${response.status})`);
+  }
+  return new Uint8Array(await response.arrayBuffer());
+}
+
 // ─── PDF via Chrome's print engine ─────────────────────────────────
 //
 // Content sends PDF_PRINT_REQUEST { html, filenameBase }. We stash the HTML
@@ -295,8 +306,8 @@ chrome.runtime.onMessage.addListener((message: PdfPrintRequest, _sender, sendRes
 });
 
 chrome.runtime.onMessage.addListener(
-  (message: DownloadRequest, sender, sendResponse) => {
-    if (!message || message.action !== 'DOWNLOAD_MD') return false;
+  (message: DownloadRequest | DownloadAiZipRequest, sender, sendResponse) => {
+    if (!message || (message.action !== 'DOWNLOAD_MD' && message.action !== 'DOWNLOAD_AI_ZIP')) return false;
 
     if (!isTrustedDownloadSender(sender, chrome.runtime.id)) {
       sendResponse({ success: false, error: 'Untrusted sender' });
@@ -306,8 +317,38 @@ chrome.runtime.onMessage.addListener(
     // Prepend the user-configured subfolder before sanitization so the
     // existing `..` / leading-slash / illegal-char stripping in
     // `sanitizeFilePath` applies to the combined path too.
-    loadDownloadFolder().then((folder) => {
+    loadDownloadFolder().then(async (folder) => {
       const prefix = folder ? folder + '/' : '';
+
+      if (message.action === 'DOWNLOAD_AI_ZIP') {
+        try {
+          const entries = await buildAiZipEntries(message, fetchImageBytes);
+          const d = new Date();
+          chrome.downloads.download(
+            {
+              url: zipDataUrl(buildZip(entries, d)),
+              filename: sanitizeFilePath(prefix + aiZipFilename(message.filename)),
+              saveAs: false,
+            },
+            (downloadId) => {
+              if (chrome.runtime.lastError) {
+                sendResponse({
+                  success: false,
+                  error: chrome.runtime.lastError.message,
+                });
+              } else {
+                sendResponse({ success: true, downloadId });
+              }
+            }
+          );
+        } catch (err) {
+          sendResponse({
+            success: false,
+            error: err instanceof Error ? err.message : String(err),
+          });
+        }
+        return;
+      }
 
       // First download any required images
       if (message.images && message.images.length > 0) {

--- a/src/background/zip.ts
+++ b/src/background/zip.ts
@@ -1,5 +1,5 @@
-// Minimal ZIP writer for the batch "Zip files" option: packs every per-item
-// text file into one archive so a thousand-post run is a single download
+// Minimal ZIP writer for the batch "Zip files" option and single AI package:
+// packs text or binary entries into one archive so related files are a single download
 // instead of a thousand shelf entries. Entries are STORED (no compression) —
 // the container format is the point here, not the byte savings — which keeps
 // this dependency-free and byte-predictable. Names are written as UTF-8 with
@@ -9,7 +9,7 @@
 export interface ZipEntry {
   // Forward-slash relative path inside the archive (may include subfolders).
   name: string;
-  content: string;
+  content: string | Uint8Array;
 }
 
 // Standard CRC-32 (IEEE 802.3), table-driven.
@@ -46,7 +46,7 @@ export function buildZip(entries: ZipEntry[], now = new Date()): Uint8Array {
 
   for (const entry of entries) {
     const name = encoder.encode(entry.name);
-    const data = encoder.encode(entry.content);
+    const data = typeof entry.content === 'string' ? encoder.encode(entry.content) : entry.content;
     const crc = crc32(data);
 
     const local = new Uint8Array(30 + name.length + data.length);

--- a/src/popup/actions.ts
+++ b/src/popup/actions.ts
@@ -3,7 +3,7 @@
 // current selections from the DOM refs and the settings-form field maps; it
 // does not own any settings state.
 
-import type { ExtractResponse, DownloadRequest, ExtractedContent } from '../types/messages';
+import type { ExtractResponse, DownloadAiZipRequest, DownloadRequest, ExtractedContent } from '../types/messages';
 import { postProcess, resolveDownloadImages, buildFilename, type PostProcessResult } from '../shared/post-process';
 import { buildFormatExport, type ExportFormat } from '../shared/export-formats';
 import { recordExport } from '../shared/review-prompt';
@@ -14,6 +14,7 @@ import type { BatchFormat } from '../shared/settings';
 import {
   btnDownload,
   btnCopy,
+  btnAiZip,
   btnPdf,
   btnObsidian,
   fmtButtons,
@@ -31,7 +32,7 @@ import {
 // Every button the export flows disable while one of them is running, so a
 // second click can't race an in-flight extraction (the format selectors too,
 // so the target format can't change mid-flight).
-const allExportButtons = [btnDownload, btnCopy, btnPdf, btnObsidian, ...fmtButtons];
+const allExportButtons = [btnDownload, btnCopy, btnAiZip, btnPdf, btnObsidian, ...fmtButtons];
 
 function showStatus(
   message: string,
@@ -48,7 +49,7 @@ function showStatus(
   }
 }
 
-function setLoading(loading: boolean, target?: 'download' | 'copy' | 'obsidian' | 'pdf'): void {
+function setLoading(loading: boolean, target?: 'download' | 'copy' | 'aiZip' | 'obsidian' | 'pdf'): void {
   for (const btn of allExportButtons) btn.disabled = loading;
 
   // Only animate the button that was actually clicked
@@ -62,6 +63,11 @@ function setLoading(loading: boolean, target?: 'download' | 'copy' | 'obsidian' 
     const cpLabel = btnCopy.querySelector('.btn-label');
     if (cpLabel) cpLabel.textContent = loading ? (chrome.i18n.getMessage('extracting') || 'Extracting…') : (chrome.i18n.getMessage('btn_copy') || 'Copy');
   }
+  if (target === 'aiZip' || !target) {
+    btnAiZip.classList.toggle('loading', loading);
+    const zipLabel = btnAiZip.querySelector('.btn-label');
+    if (zipLabel) zipLabel.textContent = loading ? (chrome.i18n.getMessage('packaging_zip') || 'Packaging…') : (chrome.i18n.getMessage('btn_ai_zip') || 'Export for AI (.zip)');
+  }
   if (target === 'obsidian' || !target) {
     btnObsidian.classList.toggle('loading', loading);
     const obLabel = btnObsidian.querySelector('.btn-label');
@@ -73,18 +79,21 @@ function setLoading(loading: boolean, target?: 'download' | 'copy' | 'obsidian' 
     if (pdfLabel) pdfLabel.textContent = loading ? (chrome.i18n.getMessage('rendering_pdf') || 'Rendering PDF…') : (chrome.i18n.getMessage('btn_pdf') || 'Export .pdf');
   }
 
-  // When stopping, always reset all four to default state
+  // When stopping, always reset every export button to its default state.
   if (!loading) {
     btnDownload.classList.remove('loading');
     btnCopy.classList.remove('loading');
+    btnAiZip.classList.remove('loading');
     btnObsidian.classList.remove('loading');
     btnPdf.classList.remove('loading');
     const dlLabel = btnDownload.querySelector('.btn-label');
     const cpLabel = btnCopy.querySelector('.btn-label');
+    const zipLabel = btnAiZip.querySelector('.btn-label');
     const obLabel = btnObsidian.querySelector('.btn-label');
     const pdfLabel = btnPdf.querySelector('.btn-label');
     if (dlLabel) dlLabel.textContent = chrome.i18n.getMessage('btn_download') || 'Download';
     if (cpLabel) cpLabel.textContent = chrome.i18n.getMessage('btn_copy') || 'Copy';
+    if (zipLabel) zipLabel.textContent = chrome.i18n.getMessage('btn_ai_zip') || 'Export for AI (.zip)';
     if (obLabel) obLabel.textContent = chrome.i18n.getMessage('btn_obsidian') || 'Add to Obsidian';
     if (pdfLabel) pdfLabel.textContent = chrome.i18n.getMessage('btn_pdf') || 'Export .pdf';
   }
@@ -135,7 +144,7 @@ async function extractContent(includeMetadata: boolean): Promise<ExtractedConten
 }
 
 async function extractMarkdown(
-  forAction: 'download' | 'copy' | 'obsidian' = 'download',
+  forAction: 'download' | 'copy' | 'aiZip' | 'obsidian' = 'download',
 ): Promise<PostProcessResult> {
   const includeMetadata = chkMetadata.checked;
   const inlineStats = chkInlineStats.checked;
@@ -147,7 +156,11 @@ async function extractMarkdown(
   // markdown via URL, not a filesystem package, so leave images as remote
   // URLs (Obsidian renders pbs.twimg.com inline fine).
   const downloadImages =
-    forAction === 'obsidian' ? false : resolveDownloadImages(forAction, chkDownloadImages.checked);
+    forAction === 'obsidian'
+      ? false
+      : forAction === 'aiZip'
+        ? true
+        : resolveDownloadImages(forAction, chkDownloadImages.checked);
 
   // Need engagement data if either renderer wants it.
   const data = await extractContent(includeMetadata || inlineStats);
@@ -175,7 +188,7 @@ function handleExtractionError(err: unknown): void {
   setLoading(false);
 }
 
-// Wires the four export buttons. Call once on popup open.
+// Wires the export buttons. Call once on popup open.
 export function initActions(): void {
   // ─── Download / Copy: dispatch on the selected format ───
   // '.md' runs the full Markdown pipeline (frontmatter, local images, filename
@@ -189,6 +202,10 @@ export function initActions(): void {
     const fmt = readSingleFormat();
     if (fmt === 'md') void runMarkdownCopy();
     else void runFormatExport(fmt, 'copy');
+  });
+
+  btnAiZip.addEventListener('click', () => {
+    void runAiZipDownload();
   });
 
   // ─── Format selector: activate + persist the clicked format ───
@@ -307,6 +324,35 @@ async function runMarkdownDownload(): Promise<void> {
         };
         const label = typeLabels[result.type] || chrome.i18n.getMessage('downloaded') || 'Downloaded!';
         showStatus(`✓ ${label}`, 'success');
+        void recordExport();
+      }
+      setLoading(false);
+    });
+  } catch (err) {
+    handleExtractionError(err);
+  }
+}
+
+// ─── Export for AI (.zip): Markdown + local media in one archive ───
+async function runAiZipDownload(): Promise<void> {
+  setLoading(true, 'aiZip');
+  statusEl.className = 'status hidden';
+
+  try {
+    const result = await extractMarkdown('aiZip');
+
+    const downloadMsg: DownloadAiZipRequest = {
+      action: 'DOWNLOAD_AI_ZIP',
+      content: result.markdown,
+      filename: result.filename,
+      images: result.images.length > 0 ? result.images : undefined,
+    };
+
+    chrome.runtime.sendMessage(downloadMsg, (downloadResponse) => {
+      if (chrome.runtime.lastError || !downloadResponse?.success) {
+        showStatus(downloadResponse?.error || chrome.i18n.getMessage('download_failed') || 'Download failed.', 'error');
+      } else {
+        showStatus(`✓ ${chrome.i18n.getMessage('ai_zip_downloaded') || 'AI ZIP downloaded!'}`, 'success');
         void recordExport();
       }
       setLoading(false);

--- a/src/popup/dom.ts
+++ b/src/popup/dom.ts
@@ -6,6 +6,7 @@
 // ─── Action buttons + status line ────────────────────────────────────
 export const btnDownload = document.getElementById('btn-download') as HTMLButtonElement;
 export const btnCopy = document.getElementById('btn-copy') as HTMLButtonElement;
+export const btnAiZip = document.getElementById('btn-ai-zip') as HTMLButtonElement;
 export const btnPdf = document.getElementById('btn-pdf') as HTMLButtonElement;
 export const btnObsidian = document.getElementById('btn-obsidian') as HTMLButtonElement;
 export const statusEl = document.getElementById('status') as HTMLDivElement;

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -366,6 +366,39 @@ body {
   color: var(--obsidian);
 }
 
+.ai-export-row {
+  --ai-zip: #008a5c;
+  --ai-zip-glow: rgba(0, 138, 92, 0.18);
+  display: flex;
+}
+
+.ai-export-row .btn-action {
+  flex: 1 1 auto;
+  width: 100%;
+  padding: 9px 10px;
+  border-radius: var(--radius-sm);
+}
+
+.btn-ai-zip {
+  background: transparent;
+  color: var(--ai-zip);
+  border: 1px solid var(--ai-zip);
+}
+
+.btn-ai-zip:hover {
+  background: var(--ai-zip-glow);
+  color: var(--ai-zip);
+  box-shadow: 0 4px 16px var(--ai-zip-glow);
+}
+
+.btn-ai-zip:active {
+  box-shadow: 0 2px 8px var(--ai-zip-glow);
+}
+
+.btn-ai-zip .btn-icon {
+  color: var(--ai-zip);
+}
+
 /* ─── Review prompt banner ──────────────────────────────────── */
 .review-banner {
   position: relative;

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -254,6 +254,21 @@
             <span class="btn-label" data-i18n="btn_obsidian">Add to Obsidian</span>
           </button>
         </div>
+
+        <div class="ai-export-row">
+          <button id="btn-ai-zip" class="btn-ai-zip btn-action" type="button"
+            data-tooltip="Package Markdown and local media into one .zip for uploading to an AI chat."
+            data-i18n-tooltip="btn_ai_zip_hint">
+            <svg class="btn-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+              stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <path d="M21 8v13H3V8" />
+              <path d="M1 3h22v5H1z" />
+              <path d="M12 12v6" />
+              <path d="m9 15 3 3 3-3" />
+            </svg>
+            <span class="btn-label" data-i18n="btn_ai_zip">Export for AI (.zip)</span>
+          </button>
+        </div>
       </div>
 
       <div id="batch-section" class="batch-section export-panel hidden">

--- a/src/types/messages.ts
+++ b/src/types/messages.ts
@@ -43,6 +43,13 @@ export interface DownloadRequest {
   mime?: string;
 }
 
+export interface DownloadAiZipRequest {
+  action: 'DOWNLOAD_AI_ZIP';
+  content: string;
+  filename: string;
+  images?: { url: string; filename: string }[];
+}
+
 export interface ExportPdfRequest {
   action: 'EXPORT_PDF';
 }

--- a/tests/ai-zip.test.ts
+++ b/tests/ai-zip.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+import {
+  aiZipFilename,
+  buildAiZipEntries,
+  normalizeZipEntryName,
+} from '../src/background/ai-zip';
+
+describe('buildAiZipEntries()', () => {
+  it('packages Markdown plus allowed media using the existing relative names', async () => {
+    const allowedUrl = 'https://pbs.twimg.com/media/example?format=jpg&name=large';
+    const loaded: string[] = [];
+
+    const entries = await buildAiZipEntries(
+      {
+        action: 'DOWNLOAD_AI_ZIP',
+        content: '# Example\n\n![Image](example-123/example.jpg)',
+        filename: 'example-123.md',
+        images: [
+          { url: allowedUrl, filename: 'example-123/example.jpg' },
+          { url: 'https://example.com/not-x-media.jpg', filename: 'example-123/card.jpg' },
+        ],
+      },
+      async (url) => {
+        loaded.push(url);
+        return new Uint8Array([0, 255, 80, 75]);
+      }
+    );
+
+    expect(loaded).toEqual([allowedUrl]);
+    expect(entries).toEqual([
+      { name: 'example-123.md', content: '# Example\n\n![Image](example-123/example.jpg)' },
+      { name: 'example-123/example.jpg', content: new Uint8Array([0, 255, 80, 75]) },
+    ]);
+  });
+
+  it('skips duplicate archive paths', async () => {
+    const entries = await buildAiZipEntries(
+      {
+        action: 'DOWNLOAD_AI_ZIP',
+        content: '# Example',
+        filename: 'example.md',
+        images: [
+          { url: 'https://pbs.twimg.com/media/one?format=jpg', filename: 'example/image.jpg' },
+          { url: 'https://pbs.twimg.com/media/two?format=jpg', filename: 'example/image.jpg' },
+        ],
+      },
+      async () => new Uint8Array([1])
+    );
+
+    expect(entries).toHaveLength(2);
+    expect(entries[1]).toEqual({ name: 'example/image.jpg', content: new Uint8Array([1]) });
+  });
+});
+
+describe('aiZipFilename()', () => {
+  it('replaces a Markdown extension with .zip', () => {
+    expect(aiZipFilename('example-123.md')).toBe('example-123.zip');
+  });
+
+  it('appends .zip when the filename has no Markdown extension', () => {
+    expect(aiZipFilename('example-123')).toBe('example-123.zip');
+  });
+});
+
+describe('normalizeZipEntryName()', () => {
+  it('keeps useful relative paths while dropping traversal segments', () => {
+    expect(normalizeZipEntryName('../thread media/./image.jpg')).toBe('thread media/image.jpg');
+  });
+
+  it('returns null for empty paths', () => {
+    expect(normalizeZipEntryName('../..')).toBeNull();
+  });
+});

--- a/tests/zip.test.ts
+++ b/tests/zip.test.ts
@@ -4,10 +4,10 @@ import { buildZip, zipDataUrl } from '../src/background/zip';
 // Walk the archive's local file headers and read every entry back — a tiny
 // structural reader, enough to prove the container is well-formed without a
 // zip dependency.
-function readEntries(bytes: Uint8Array): { name: string; content: string; crc: number }[] {
+function readEntries(bytes: Uint8Array): { name: string; content: string; data: Uint8Array; crc: number }[] {
   const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
   const decoder = new TextDecoder();
-  const entries: { name: string; content: string; crc: number }[] = [];
+  const entries: { name: string; content: string; data: Uint8Array; crc: number }[] = [];
   let pos = 0;
   while (view.getUint32(pos, true) === 0x04034b50) {
     const crc = view.getUint32(pos + 14, true);
@@ -16,7 +16,8 @@ function readEntries(bytes: Uint8Array): { name: string; content: string; crc: n
     const extraLen = view.getUint16(pos + 28, true);
     const name = decoder.decode(bytes.subarray(pos + 30, pos + 30 + nameLen));
     const start = pos + 30 + nameLen + extraLen;
-    entries.push({ name, content: decoder.decode(bytes.subarray(start, start + size)), crc });
+    const data = bytes.subarray(start, start + size);
+    entries.push({ name, content: decoder.decode(data), data, crc });
     pos = start + size;
   }
   return entries;
@@ -28,7 +29,7 @@ describe('buildZip', () => {
       { name: 'a.md', content: 'hello' },
       { name: '_incomplete_rerun_to_complete/ünïcodé-名前.md', content: '# Ünïcode content 🎉' },
     ]);
-    expect(readEntries(zip)).toEqual([
+    expect(readEntries(zip).map(({ name, content, crc }) => ({ name, content, crc }))).toEqual([
       // CRC-32 of "hello" is the well-known 0x3610a686.
       { name: 'a.md', content: 'hello', crc: 0x3610a686 },
       {
@@ -37,6 +38,12 @@ describe('buildZip', () => {
         crc: expect.any(Number),
       },
     ]);
+  });
+
+  it('stores binary entries without UTF-8 re-encoding them', () => {
+    const bytes = new Uint8Array([0, 255, 80, 75]);
+    const zip = buildZip([{ name: 'media/image.jpg', content: bytes }]);
+    expect(readEntries(zip)[0].data).toEqual(bytes);
   });
 
   it('writes a consistent central directory and end record', () => {


### PR DESCRIPTION
## Summary

Add an "Export for AI (.zip)" single-export option that packages:

- the generated Markdown file
- referenced local X media files

into one self-contained ZIP.

## Why

The goal is to make the path from X thread -> LLM as fast as possible.

Today, Markdown export is already great for AI ingestion, especially with "Save images locally," but the user still has to manage multiple downloaded files. For long threads with images, that means finding the .md, finding the media folder, and uploading several files together.

This feature turns that into a one-step workflow:

Open tweet thread -> Export for AI -> upload one ZIP to ChatGPT / Claude / another LLM

That keeps the high-quality Markdown text while preserving the original media evidence in the same package.

## Implementation Notes

- Reuses the existing Markdown post-processing path
- Forces local media references for the ZIP export
- Reuses XClipper's existing ZIP writer
- Fetches only media URLs already allowed by the existing media host validation
- Does not add new extension permissions

## Test Plan

- npm run typecheck
- TZ=UTC npm test
- npm run build
