### PR TITLE
fix(video): article-body videos in Manual, and video files in a Manual batch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Manual batch now saves videos as files, like Auto and Super**: with local saving on **Media**, a Manual batch wrote each post's video as its thumbnail and stopped there — the same posts run through Auto came out with an `.mp4` and a `▶ Video` link, so the engine you picked silently changed what you got. The batch orchestrator now resolves each post's video the way single export does and rebuilds that item's Markdown around the file. The worker tab still can't ask for it itself — that channel replays your X session and stays closed to page scripts — so the resolution happens in the background, where the batch already runs. (#118)
 - **Article videos now survive a Manual or single export too**: a video in an X Article body reached the export only when the page happened to have its player mounted *and* silent. Otherwise it left as a paragraph reading the video's length — `18:48` — or vanished with no trace, the text running straight from the paragraph before it to the paragraph after. The player is now recognised in every state it renders in, so Manual and single exports keep the video where Auto and Super already did, thumbnail in place and saved as an `.mp4` when local saving is on **Media**. An article video XClipper genuinely can't read now fails the export loudly instead of quietly leaving a hole in it. (#118)
 
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [Unreleased]
+
+### Fixed
+
+- **Article videos now survive a Manual or single export too**: a video in an X Article body reached the export only when the page happened to have its player mounted *and* silent. Otherwise it left as a paragraph reading the video's length — `18:48` — or vanished with no trace, the text running straight from the paragraph before it to the paragraph after. The player is now recognised in every state it renders in, so Manual and single exports keep the video where Auto and Super already did, thumbnail in place and saved as an `.mp4` when local saving is on **Media**. An article video XClipper genuinely can't read now fails the export loudly instead of quietly leaving a hole in it. (#118)
+
+---
+
 ## [2.8.1] - 2026-08-29
 
 ### Fixed

--- a/src/background/batch.ts
+++ b/src/background/batch.ts
@@ -10,14 +10,16 @@
 // or send { action: 'BATCH_START', urls } from any extension page. Cancel
 // with { action: 'BATCH_CONTROL', control: 'cancel' }.
 
+import type { Document } from '../ast/types';
 import type {
   BatchItemResultMessage,
   BatchStartResponse,
   BatchStatusResponse,
 } from '../types/messages';
-import { loadSettings, type BatchFormat, type BatchOutput } from '../shared/settings';
+import { loadSettings, type BatchFormat, type BatchOutput, type Settings } from '../shared/settings';
 import { recordExport } from '../shared/review-prompt';
 import {
+  docToExtracted,
   downloadZipArchive,
   writeCombined,
   writeJsonManifest,
@@ -25,6 +27,9 @@ import {
   zipEntryFromStored,
   type StoredItem,
 } from './batch-sink';
+import { postProcess, resolveDownloadImages } from '../shared/post-process';
+import { resolveLocalVideo } from '../shared/local-video';
+import { resolveVideoUrls } from './resolve-video';
 import {
   isExtensionPageSender,
   isTrustedXContentSender,
@@ -254,6 +259,45 @@ async function dispatchCurrent(job: BatchJob): Promise<void> {
   });
 }
 
+// Fill in this item's videos and rebuild its Markdown around them.
+//
+// The worker tab extracted the post, but it can't ask for the MP4s itself:
+// that channel replays the user's X session and is closed to content scripts
+// by design, so the orchestrator — which is already the background — resolves
+// them here. The item is then re-rendered from the filled-in AST exactly the
+// way Fast Batch renders its own, which is what keeps a Manual batch and an
+// Auto one landing the same files for the same post.
+//
+// Returns undefined when there is nothing to change: local video saving off,
+// no video in the post, or nothing resolved (no permission, a rate limit) —
+// every one of which leaves the worker's own Markdown as the export.
+async function withLocalVideo(
+  doc: Document,
+  settings: Settings
+): Promise<{ markdown: string; images: { url: string; filename: string }[] } | undefined> {
+  if (!settings.saveVideos || !resolveDownloadImages('download', settings.downloadImages)) {
+    return undefined;
+  }
+
+  const resolved = await resolveLocalVideo(doc, doc.metadata.tweetId, async (tweetId) =>
+    [...(await resolveVideoUrls(tweetId))]
+  );
+  if (resolved.status !== 'resolved') return undefined;
+
+  const result = postProcess(docToExtracted(doc, { includeVideoLinks: true }), {
+    includeMetadata: settings.includeMetadata,
+    downloadImages: resolveDownloadImages('download', settings.downloadImages),
+    videoAttachments: resolved.attachments,
+    inlineStats: settings.inlineStats,
+    obsidianFriendly: settings.obsidianFriendly,
+    filenameTemplate: settings.filenameTemplate.trim(),
+    frontmatterFields: settings.obsidianFriendly
+      ? settings.frontmatterFieldsObsidian
+      : settings.frontmatterFields,
+  });
+  return { markdown: result.markdown, images: result.images };
+}
+
 async function handleItemResult(
   msg: BatchItemResultMessage,
   sender: chrome.runtime.MessageSender
@@ -296,20 +340,29 @@ async function handleItemResult(
 
   const { job: advanced, filename } = recordResult(job, outcome);
   if (outcome.success && filename) {
+    const settings = await loadSettings();
     // 'combined' writes nothing per item — the one file is built at finalize.
     // Zip mode also defers to finalize: entries are rebuilt there from the
     // stored docs, so nothing per-item hits the downloads shelf.
     // (msg.doc missing means there's nothing to rebuild from at finalize, so
     // such an item is written loose even in zip mode.)
     if (effectiveOutput(job) !== 'combined' && !(job.zip && msg.doc)) {
+      // Videos reach the disk only once the orchestrator has resolved them —
+      // see withLocalVideo. Its rebuild then replaces the worker's Markdown
+      // and image list; the deferred sinks above never save media, so they
+      // stay on what the worker sent.
+      const withVideo =
+        msg.doc && (job.format ?? 'md') === 'md'
+          ? await withLocalVideo(msg.doc, settings)
+          : undefined;
       await writePerItem(
         advanced.folder,
         job.format ?? 'md',
         filename,
-        msg.markdown as string,
-        msg.images,
+        withVideo?.markdown ?? (msg.markdown as string),
+        withVideo?.images ?? msg.images,
         msg.doc,
-        await loadSettings()
+        settings
       );
     }
     await recordExported(expected);
@@ -332,7 +385,7 @@ async function handleItemResult(
             msg.markdown as string,
             msg.images,
             msg.doc,
-            await loadSettings()
+            settings
           );
         }
       }

--- a/src/background/fast-batch.ts
+++ b/src/background/fast-batch.ts
@@ -25,7 +25,7 @@ import type {
   FastBatchStatusResponse,
 } from '../types/messages';
 import { isExtensionPageSender } from './security';
-import { collectMedia, isDownloadableVideo } from '../ast/collect-media';
+import { videoAttachments } from '../shared/local-video';
 import { jsonToAst } from '../graphql/json-to-ast';
 import { tweetDetailToDocument } from '../graphql/tweet-detail';
 import { getVariables, paginateTimeline, setVariablesParam } from '../graphql/timeline';
@@ -364,22 +364,14 @@ async function runFastBatchExport(opts: FastBatchOptions = {}): Promise<FastBatc
     // Expansion can change the canonical id, so track both — see Item.feedId.
     const expandedId = doc.metadata.tweetId;
     const isStub = s.needsExpand && !s.ledger;
-    // Structural: walk the AST for the MP4 rather than parsing the rendered
-    // Markdown back out. renderedUrl is what the renderer wrote into the
-    // [▶ Video] token; downloadUrl is what we fetch — the same today, kept
-    // separate because that is the seam a later phase would widen.
-    const videoAttachments = localVideo
-      ? collectMedia(doc)
-          .filter(isDownloadableVideo)
-          .map((m) => ({ renderedUrl: m.url, downloadUrl: m.url }))
-      : undefined;
+    const attachments = localVideo ? videoAttachments(doc) : undefined;
     const result = postProcess(docToExtracted(
       doc,
       localVideo ? { includeVideoLinks: true } : undefined,
     ), {
       includeMetadata: settings.includeMetadata,
       downloadImages: resolveDownloadImages('download', settings.downloadImages),
-      videoAttachments,
+      videoAttachments: attachments,
       inlineStats: settings.inlineStats,
       obsidianFriendly: settings.obsidianFriendly,
       filenameTemplate: settings.filenameTemplate.trim(),

--- a/src/content/dom-to-ast/article-body.ts
+++ b/src/content/dom-to-ast/article-body.ts
@@ -205,6 +205,15 @@ function articleBlockToNodes(block: HTMLElement): Block[] {
     return img ? [img] : [];
   }
 
+  // Video block — must run before the image-only gate below. A mounted player
+  // puts its own chrome in the block (a duration pill is text), so that gate
+  // reads the block as prose and the video leaves as a paragraph saying
+  // "18:48"; an unmounted one carries neither <video> nor <img> and leaves
+  // nothing at all. Either way applyVideoUrls then has no node to resolve to
+  // an .mp4, so the video never reaches the export.
+  const video = findArticleBlockVideo(block);
+  if (video) return [video];
+
   // Image-only paragraph — emit ImageNode rather than wrapping in paragraph.
   const img = findArticleBlockImage(block);
   if (img && blockHasOnlyImage(block)) {
@@ -248,6 +257,41 @@ function extractSimpleTweet(block: HTMLElement): TweetNode | undefined {
     || block.querySelector('[data-testid="simpleTweet"] [data-testid="tweet"]');
   if (!tweetArticle) return undefined;
   return articleToTweetNode(tweetArticle);
+}
+
+// X keeps the poster wherever the player's render state puts it: on the
+// mounted <video>, on the thumbnail <img>, or — before either mounts — as the
+// CSS background of the placeholder.
+function findArticleBlockVideo(block: HTMLElement): VideoNode | undefined {
+  const poster = block.querySelector('video[poster]')?.getAttribute('poster')
+    || videoThumbSrc(block)
+    || videoThumbBackground(block);
+  if (poster) {
+    const url = canonicalVideoThumbUrl(poster);
+    return { type: 'video', sourceUrl: url, posterUrl: url };
+  }
+  // A player whose poster we can't find is an unsupported shape, not an empty
+  // block — say so rather than dropping the video silently.
+  if (block.querySelector('[data-testid="videoPlayer"], [data-testid="videoComponent"]')) {
+    throw new Error('domToAst: article video player with no poster');
+  }
+  return undefined;
+}
+
+function videoThumbSrc(block: HTMLElement): string | undefined {
+  for (const img of block.querySelectorAll('img')) {
+    const src = (img as HTMLImageElement).src || '';
+    if (VIDEO_THUMB_RE.test(src)) return src;
+  }
+  return undefined;
+}
+
+function videoThumbBackground(block: HTMLElement): string | undefined {
+  for (const el of block.querySelectorAll<HTMLElement>('[style*="background-image"]')) {
+    const url = el.style.backgroundImage.match(/url\(["']?([^"')]+)["']?\)/)?.[1];
+    if (url && VIDEO_THUMB_RE.test(url)) return url;
+  }
+  return undefined;
 }
 
 function findArticleBlockImage(block: HTMLElement): ImageNode | VideoNode | undefined {

--- a/src/popup/actions.ts
+++ b/src/popup/actions.ts
@@ -15,8 +15,7 @@ import { recordExport } from '../shared/review-prompt';
 import { buildObsidianUrl } from '../shared/obsidian';
 import { hostMatches } from '../shared/media';
 import { renderMarkdown } from '../ast/render-markdown';
-import { applyVideoUrls } from '../ast/apply-video-urls';
-import { collectMedia, isDownloadableVideo } from '../ast/collect-media';
+import { resolveLocalVideo, type VideoAttachment } from '../shared/local-video';
 import { currentFrontmatterFields, readSingleFormat, applySingleFormat, persistAll, saveLocalEnabled, saveLocalMediaEnabled } from './settings-form';
 import type { BatchFormat } from '../shared/settings';
 import {
@@ -165,7 +164,7 @@ async function extractMarkdown(
     downloadImages,
     inlineStats,
     obsidianFriendly,
-    videoAttachments: downloadImages ? await resolveLocalVideo(data) : undefined,
+    videoAttachments: downloadImages ? await localVideoAttachments(data) : undefined,
     filenameTemplate: txtFilenameTemplate.value.trim(),
     obsidianTagsTemplate: txtObsidianTags.value.trim(),
     frontmatterFields: currentFrontmatterFields(obsidianFriendly),
@@ -174,38 +173,26 @@ async function extractMarkdown(
 
 // Turn this post's videos into local files, when the user asked for Media.
 //
-// The DOM extractor only ever sees a poster, so the MP4 comes from the
-// background's captured X session and gets written back onto the AST; the
-// Markdown is then re-rendered so its [▶ Video] link points at the file we're
-// about to save. Re-rendering is safe because the content script renders with
-// no options — includeVideoLinks is the only difference between the two passes.
+// The Markdown is re-rendered from the filled-in AST so its [▶ Video] link
+// points at the file we're about to save. Re-rendering is safe because the
+// content script renders with no options — includeVideoLinks is the only
+// difference between the two passes.
 //
-// Every failure path (no permission, nothing resolved, no AST on the wire)
-// returns undefined, which leaves the export exactly as it is today — but a
-// post that HAS video and still didn't resolve says so, because silently
+// A post that HAS video and still didn't resolve says so, because silently
 // shipping the thumbnail is the one outcome the user can't tell apart from
 // success until they open the folder.
-async function resolveLocalVideo(
-  data: ExtractedContent
-): Promise<{ renderedUrl: string; downloadUrl: string }[] | undefined> {
+async function localVideoAttachments(data: ExtractedContent): Promise<VideoAttachment[] | undefined> {
   if (!saveLocalMediaEnabled() || !data.body) return undefined;
 
-  // A node still standing on its poster is a video we haven't resolved yet.
-  // None here means nothing to fetch, so skip the round trip entirely.
-  const unresolved = collectMedia(data.body).filter(
-    (m) => (m.kind === 'video' || m.kind === 'gif') && m.url === m.posterUrl
-  );
-  if (unresolved.length === 0) return undefined;
-
-  const response: ResolveVideoUrlsResponse | undefined = await chrome.runtime.sendMessage({
-    action: 'RESOLVE_VIDEO_URLS',
-    tweetId: data.tweetId,
+  const result = await resolveLocalVideo(data.body, data.tweetId, async (tweetId) => {
+    const response: ResolveVideoUrlsResponse | undefined = await chrome.runtime.sendMessage({
+      action: 'RESOLVE_VIDEO_URLS',
+      tweetId,
+    });
+    return response?.urls ?? [];
   });
-
-  const applied = response?.urls?.length
-    ? applyVideoUrls(data.body, new Map(response.urls))
-    : 0;
-  if (applied === 0) {
+  if (result.status === 'none') return undefined;
+  if (result.status === 'unresolved') {
     showStatus(
       chrome.i18n.getMessage('video_unresolved') ||
         'Video kept as a link — reload the post once, then export again.',
@@ -215,10 +202,7 @@ async function resolveLocalVideo(
   }
 
   data.markdown = renderMarkdown(data.body, { includeVideoLinks: true });
-
-  return collectMedia(data.body)
-    .filter(isDownloadableVideo)
-    .map((m) => ({ renderedUrl: m.url, downloadUrl: m.url }));
+  return result.attachments;
 }
 
 function handleExtractionError(err: unknown): void {

--- a/src/shared/local-video.ts
+++ b/src/shared/local-video.ts
@@ -1,0 +1,63 @@
+// Turn a post's videos into local files.
+//
+// X plays video through MSE, so a DOM-extracted node carries only its poster
+// (ADR 0003) — the MP4 variant list lives in X's own GraphQL payload. Both DOM
+// export paths need the same three steps around that fetch (is there anything
+// unresolved / fill it in / say what to download), but they reach the fetch
+// differently: the popup asks the background over a message, while the batch
+// orchestrator IS the background and calls it directly. That channel is
+// deliberately closed to content scripts — it replays the user's X session —
+// so the resolver is a parameter rather than something this module picks.
+//
+// Failure is ordinary, not exceptional: no permission, no request template
+// observed yet, a rate limit, a post X streams with no downloadable file. All
+// of them land on 'unresolved', which leaves the export exactly as it was —
+// the thumbnail, and the remote link.
+
+import type { Document } from '../ast/types';
+import { applyVideoUrls } from '../ast/apply-video-urls';
+import { collectMedia, isDownloadableVideo } from '../ast/collect-media';
+
+export interface VideoAttachment {
+  renderedUrl: string;
+  downloadUrl: string;
+}
+
+// [poster path, MP4 URL] pairs, as resolve-video.ts produces them.
+export type Mp4Resolver = (tweetId: string) => Promise<[string, string][]>;
+
+export type LocalVideoResult =
+  | { status: 'none' }
+  | { status: 'unresolved' }
+  | { status: 'resolved'; attachments: VideoAttachment[] };
+
+// Fills the MP4 URLs into `doc` in place. Callers re-render the Markdown from
+// it with `includeVideoLinks` so the ▶ link points at the file being saved.
+export async function resolveLocalVideo(
+  doc: Document,
+  tweetId: string,
+  fetchMp4Urls: Mp4Resolver
+): Promise<LocalVideoResult> {
+  // A node still standing on its poster is a video we haven't resolved yet.
+  // None here means nothing to fetch, so skip the round trip entirely.
+  const unresolved = collectMedia(doc).filter(
+    (m) => (m.kind === 'video' || m.kind === 'gif') && m.url === m.posterUrl
+  );
+  if (unresolved.length === 0) return { status: 'none' };
+
+  const urls = await fetchMp4Urls(tweetId);
+  const applied = urls.length ? applyVideoUrls(doc, new Map(urls)) : 0;
+  if (applied === 0) return { status: 'unresolved' };
+
+  return { status: 'resolved', attachments: videoAttachments(doc) };
+}
+
+// Structural: walk the AST for the MP4s rather than parsing the rendered
+// Markdown back out. renderedUrl is what the renderer wrote into the
+// [▶ Video] token; downloadUrl is what we fetch — the same today, kept
+// separate because that is the seam a later phase would widen.
+export function videoAttachments(doc: Document): VideoAttachment[] {
+  return collectMedia(doc)
+    .filter(isDownloadableVideo)
+    .map((m) => ({ renderedUrl: m.url, downloadUrl: m.url }));
+}

--- a/tests/article-media-ast.test.ts
+++ b/tests/article-media-ast.test.ts
@@ -16,6 +16,28 @@ function loadArticle(html: string): void {
   });
 }
 
+function articleHtml(blocks: string): string {
+  return `
+    <html>
+      <body>
+        <article role="article">
+          <div data-testid="User-Name">
+            <a href="/theonejvo"><span>Jamieson O'Reilly</span></a>
+            <a href="/theonejvo"><span>@theonejvo</span></a>
+          </div>
+          <time datetime="2026-01-01T00:00:00.000Z"></time>
+          <div data-testid="twitter-article-title">Article with video</div>
+          <div data-testid="twitterArticleRichTextView">
+            <div data-testid="longformRichTextComponent">
+              <div data-contents="true">${blocks}</div>
+            </div>
+          </div>
+        </article>
+      </body>
+    </html>
+  `;
+}
+
 describe('domToAst() article media blocks', () => {
   it('extracts captioned X article media links as images', () => {
     loadArticle(`
@@ -60,5 +82,63 @@ describe('domToAst() article media blocks', () => {
     const markdown = renderMarkdown(ast);
     expect(markdown).toContain('![Image](https://pbs.twimg.com/media/G_f76WFbAAAwrmo?format=jpg&name=large)');
     expect(markdown).not.toContain('/article/2015401219746128322/media/');
+  });
+  it('extracts a mounted article video player as a video node', () => {
+    loadArticle(articleHtml(`
+      <section>
+        <div data-testid="tweetPhoto">
+          <div data-testid="videoPlayer">
+            <div data-testid="videoComponent">
+              <video
+                preload="none"
+                aria-label="Embedded video"
+                poster="https://pbs.twimg.com/amplify_video_thumb/2076673758748639232/img/YpAYEsLVDS7JMxGE.jpg"
+              ></video>
+              <img alt="" src="https://pbs.twimg.com/amplify_video_thumb/2076673758748639232/img/YpAYEsLVDS7JMxGE.jpg">
+            </div>
+            <div>18:48</div>
+          </div>
+        </div>
+      </section>
+    `));
+
+    const ast = domToAst();
+    if (ast.body.type !== 'article') throw new Error('expected an article');
+    expect(ast.body.children[0]).toEqual({
+      type: 'video',
+      sourceUrl: 'https://pbs.twimg.com/amplify_video_thumb/2076673758748639232/img/YpAYEsLVDS7JMxGE.jpg',
+      posterUrl: 'https://pbs.twimg.com/amplify_video_thumb/2076673758748639232/img/YpAYEsLVDS7JMxGE.jpg',
+    });
+  });
+
+  it('extracts an unmounted article video player from its poster background', () => {
+    loadArticle(articleHtml(`
+      <section>
+        <div data-testid="tweetPhoto">
+          <div data-testid="videoPlayer">
+            <div style="background-image: url(&quot;https://pbs.twimg.com/amplify_video_thumb/2076673758748639232/img/YpAYEsLVDS7JMxGE.jpg&quot;);"></div>
+          </div>
+        </div>
+      </section>
+    `));
+
+    const ast = domToAst();
+    if (ast.body.type !== 'article') throw new Error('expected an article');
+    expect(ast.body.children[0]).toEqual({
+      type: 'video',
+      sourceUrl: 'https://pbs.twimg.com/amplify_video_thumb/2076673758748639232/img/YpAYEsLVDS7JMxGE.jpg',
+      posterUrl: 'https://pbs.twimg.com/amplify_video_thumb/2076673758748639232/img/YpAYEsLVDS7JMxGE.jpg',
+    });
+  });
+  it('throws rather than dropping a video player it cannot read a poster from', () => {
+    loadArticle(articleHtml(`
+      <section>
+        <div data-testid="tweetPhoto">
+          <div data-testid="videoPlayer"><div></div></div>
+        </div>
+      </section>
+    `));
+
+    expect(() => domToAst()).toThrow(/video player with no poster/);
   });
 });

--- a/tests/local-video.test.ts
+++ b/tests/local-video.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { Document } from '../src/ast/types';
+import { resolveLocalVideo } from '../src/shared/local-video';
+
+const POSTER = 'https://pbs.twimg.com/amplify_video_thumb/2076673758748639232/img/YpAYEsLVDS7JMxGE.jpg';
+const MP4 = 'https://video.twimg.com/amplify_video/2076673758748639232/vid/avc1/1280x720/x1MQ3cIsSkCfu1P1.mp4';
+
+// An X Article whose body holds one video — the shape the DOM extractor
+// produces, where sourceUrl is still the poster.
+function articleWithVideo(): Document {
+  return {
+    version: 1,
+    metadata: {
+      type: 'article',
+      sourceUrl: 'https://x.com/DeRonin_/status/2076690611399176506',
+      tweetId: '2076690611399176506',
+      author: { name: 'Ronin', handle: '@DeRonin_' },
+      date: '2026-06-28T18:03:20.000Z',
+    },
+    body: {
+      type: 'article',
+      children: [
+        { type: 'paragraph', children: [{ type: 'text', value: 'Before' }] },
+        { type: 'video', sourceUrl: POSTER, posterUrl: POSTER },
+      ],
+    },
+  };
+}
+
+describe('resolveLocalVideo()', () => {
+  it('fills an article-body video with its MP4 and reports it as an attachment', async () => {
+    const doc = articleWithVideo();
+
+    const result = await resolveLocalVideo(doc, '2076690611399176506', async () => [
+      ['/amplify_video_thumb/2076673758748639232/img/ypayeslvds7jmxge.jpg', MP4],
+    ]);
+
+    expect(result).toEqual({
+      status: 'resolved',
+      attachments: [{ renderedUrl: MP4, downloadUrl: MP4 }],
+    });
+    if (doc.body.type !== 'article') throw new Error('expected an article');
+    expect(doc.body.children[1]).toEqual({ type: 'video', sourceUrl: MP4, posterUrl: POSTER });
+  });
+
+  it('skips the round trip when nothing carries an unresolved video', async () => {
+    const fetchMp4Urls = vi.fn(async () => []);
+    const doc = articleWithVideo();
+    if (doc.body.type !== 'article') throw new Error('expected an article');
+    doc.body.children = [{ type: 'paragraph', children: [{ type: 'text', value: 'No media' }] }];
+
+    expect(await resolveLocalVideo(doc, '2076690611399176506', fetchMp4Urls)).toEqual({ status: 'none' });
+    expect(fetchMp4Urls).not.toHaveBeenCalled();
+  });
+
+  it('leaves the poster in place when the background resolves nothing', async () => {
+    const doc = articleWithVideo();
+
+    expect(await resolveLocalVideo(doc, '2076690611399176506', async () => [])).toEqual({
+      status: 'unresolved',
+    });
+    if (doc.body.type !== 'article') throw new Error('expected an article');
+    expect(doc.body.children[1]).toEqual({ type: 'video', sourceUrl: POSTER, posterUrl: POSTER });
+  });
+});


### PR DESCRIPTION
Fixes #118.

Two distinct failures kept a video out of a Manual export. Both are fixed here; each has its own commit and its own CHANGELOG entry, because they reach different users — the first changes the Markdown even with local saving **off**, the second only affects **Media**.

## 1. An article-body video only survived one player state

`f33231e` gave `article-body.ts` its first video producer, but the node was reached through the image-only gate (`findArticleBlockImage` + `blockHasOnlyImage`), which needs an `<img>` in the block *and* zero text. X's player has more states than that:

| Player state | Before |
|---|---|
| Mounted, no overlay text | video node ✓ (the one state the fixture captured) |
| Mounted, duration pill showing | paragraph reading `18:48` |
| Not yet mounted — poster is a CSS `background-image` | **dropped**, text runs paragraph to paragraph |

The player is now recognised *before* the image-only gate, and its poster read from wherever the render state keeps it: the mounted `<video>`, the thumbnail `<img>`, or the placeholder's `background-image`. `applyVideoUrls` then has a node to fill in, so the video also saves as an `.mp4` instead of a `.jpg`.

Per the extractor's contract, a player none of the three can supply a poster for now **throws** rather than vanishing — that was the second half of the issue ("is it throwing or skipping?" — it was skipping).

## 2. A Manual batch never resolved videos at all

Not an extractor problem. Video resolution only ever existed in `src/popup/actions.ts`; the batch worker called `postProcess` with no `videoAttachments`, so every post kept its poster while Auto and Super saved the file.

The worker tab can't fix this itself — `RESOLVE_VIDEO_URLS` replays the user's captured X session and rejects content-script senders on purpose. So resolution moves to the orchestrator, which is already the background, and the item is rebuilt from the filled-in AST through `docToExtracted(doc, { includeVideoLinks: true })` + `postProcess` — the same path Fast Batch renders through, which is what makes the two engines agree.

The steps around the fetch move to `src/shared/local-video.ts` with the resolver as a **parameter**: the popup keeps its message round trip, the background calls `resolveVideoUrls` directly, and that security boundary stays exactly where it was. Fast Batch's own copy of the attachment mapping goes with it.

Gated to per-item `md` writes; combined and zip modes never save media and stay on what the worker sent.

## Verification

- 314 passed, 8 skipped; `typecheck` and `build` clean.
- New: 3 extraction tests (mounted-with-overlay, unmounted-background, throws-without-poster) and 3 for `resolveLocalVideo` (resolves an article video, skips the round trip with nothing to resolve, keeps the poster when the background returns nothing).
- The `DeRonin_-2076690611399176506` article snapshot is byte-identical — the state that already worked produces the same node, so no existing user's Markdown changes.
- Confirmed working against a live Manual batch export.

## Known, not in this PR

Auto/Super drop an **embedded tweet** in an article body — `atomicBlock` in `src/graphql/json-to-ast.ts` handles `DIVIDER`/`MARKDOWN`/`MEDIA` and returns `undefined` for anything else. That's why an Auto export of the same article is missing the quoted post (and its poster). Needs a real `TweetDetail` capture to map; separate issue.

The inline button and context menu have the gap the batch just lost: they run in the content script, so Media saves images but leaves video as a link. Fixing it means carrying the AST on `DOWNLOAD_MD`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LYsossPceVgLacdDSuVnKD